### PR TITLE
chore: use .asf.yaml for apache workflow rule

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -24,10 +24,9 @@ github:
     # Enable projects for project management boards
     projects: true
   description: A graph database that supports more than 100+ billion data, high performance and scalability (Include OLTP Engine & REST-API & Backends)
-  homepage: https://apache.github.io/incubator-hugegraph-doc/
+  homepage: https://hugegraph.apache.org
   del_branch_on_merge: true
   #labels:
-
   enabled_merge_buttons:
     merge:  true
     squash: true

--- a/.asf.yaml
+++ b/.asf.yaml
@@ -25,6 +25,7 @@ github:
     projects: true
   description: A graph database that supports more than 100+ billion data, high performance and scalability (Include OLTP Engine & REST-API & Backends)
   homepage: https://apache.github.io/incubator-hugegraph-doc/
+  del_branch_on_merge: true
   #labels:
 
   enabled_merge_buttons:
@@ -42,7 +43,9 @@ github:
           - hugegraph-ci/build
       required_pull_request_reviews:
         dismiss_stale_reviews: true
+        require_code_owner_reviews: false
         required_approving_review_count: 2
+
 notifications:
   issues: dev@hugegraph.apache.org
   pullrequests: commits@hugegraph.apache.org

--- a/.asf.yaml
+++ b/.asf.yaml
@@ -38,9 +38,9 @@ github:
         # strict means "Require branches to be up to date before merging".
         strict: true
         # contexts are the names of checks that must pass
-        contexts:
-          - hugegraph ci/build
-          - hugegraph-ci/build
+        #contexts:
+        #  - hugegraph ci/build
+        #  - hugegraph-ci/build
       required_pull_request_reviews:
         dismiss_stale_reviews: true
         require_code_owner_reviews: false

--- a/.asf.yaml
+++ b/.asf.yaml
@@ -1,0 +1,43 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+github:
+  features:
+    # Enable issue management
+    issues: true
+    # Enable wiki for documentation
+    wiki: true
+    # Enable projects for project management boards
+    projects: true
+  description: A graph database that supports more than 100+ billion data, high performance and scalability (Include OLTP Engine & REST-API & Backends)
+  homepage: https://apache.github.io/incubator-hugegraph-doc/
+  #labels:
+
+  enabled_merge_buttons:
+    merge:  true
+    squash: true
+    rebase: true
+  protected_branches:
+    master:
+      required_status_checks:
+        strict: false
+      required_pull_request_reviews:
+        dismiss_stale_reviews: true
+        required_approving_review_count: 2
+notifications:
+  issues: dev@hugegraph.apache.org
+  pullrequests: commits@hugegraph.apache.org

--- a/.asf.yaml
+++ b/.asf.yaml
@@ -34,7 +34,12 @@ github:
   protected_branches:
     master:
       required_status_checks:
-        strict: false
+        # strict means "Require branches to be up to date before merging".
+        strict: true
+        # contexts are the names of checks that must pass
+        contexts:
+          - hugegraph ci/build
+          - hugegraph-ci/build
       required_pull_request_reviews:
         dismiss_stale_reviews: true
         required_approving_review_count: 2


### PR DESCRIPTION
Apache provides a config way to control the settings, detail in [asf.yaml
](https://cwiki.apache.org/confluence/display/INFRA/Git+-+.asf.yaml+features#Git.asf.yamlfeatures-GitHubsettings)

And due to we lack permission to push the file into master, we need INFRA ticket now.

<img width="1436" alt="image" src="https://user-images.githubusercontent.com/17706099/164244667-868ca496-2d14-4d56-b6a2-4a93181fc199.png">

Consider cherry-pick the #1834 to avoid stuck on build CI... 
