### PR TITLE
improve allow role for drop graph

### DIFF
--- a/hugegraph-api/src/main/java/com/baidu/hugegraph/api/profile/GraphsAPI.java
+++ b/hugegraph-api/src/main/java/com/baidu/hugegraph/api/profile/GraphsAPI.java
@@ -107,7 +107,7 @@ public class GraphsAPI extends API {
     @Timed
     @Path("{name}")
     @Produces(APPLICATION_JSON_WITH_CHARSET)
-    @RolesAllowed({"admin", "$owner=$name"})
+    @RolesAllowed({"admin"})
     public void drop(@Context GraphManager manager,
                      @PathParam("name") String name,
                      @QueryParam("confirm_message") String message) {


### PR DESCRIPTION
Since admin permission is required for create and clear graph, so drop should also be admin permission.

<img width="598" alt="image" src="https://user-images.githubusercontent.com/16890042/168237774-4ead5655-6250-4119-85c1-340ed1bd2aca.png">
