### PR TITLE
fix bug: get profile api cannot be accessed #1882

### DIFF
--- a/hugegraph-api/src/main/java/com/baidu/hugegraph/api/profile/ProfileAPI.java
+++ b/hugegraph-api/src/main/java/com/baidu/hugegraph/api/profile/ProfileAPI.java
@@ -59,6 +59,7 @@ public class ProfileAPI {
     private static String API_PROFILES = null;
 
     @GET
+    @Path("profiles")
     @Timed
     @Produces(MediaType.APPLICATION_JSON)
     public String getProfile(@Context Application application) {


### PR DESCRIPTION
To solve this problem [#1882](https://github.com/apache/incubator-hugegraph/issues/1882),  I modified the route of getprofile API as `/profiles`

![image](https://user-images.githubusercontent.com/16890042/168511823-7029cf45-151b-44a7-a886-c82c644b11bc.png)
