### PR TITLE
chore: replace `APPLICATION_JSON` with `TEXT_PLAIN` in dynamic create graph api

### DIFF
--- a/hugegraph-api/src/main/java/com/baidu/hugegraph/api/API.java
+++ b/hugegraph-api/src/main/java/com/baidu/hugegraph/api/API.java
@@ -49,6 +49,7 @@ public class API {
 
     public static final String CHARSET = "UTF-8";
 
+    public static final String TEXT_PLAIN = MediaType.TEXT_PLAIN;
     public static final String APPLICATION_JSON = MediaType.APPLICATION_JSON;
     public static final String APPLICATION_JSON_WITH_CHARSET =
                                APPLICATION_JSON + ";charset=" + CHARSET;

--- a/hugegraph-api/src/main/java/com/baidu/hugegraph/api/profile/GraphsAPI.java
+++ b/hugegraph-api/src/main/java/com/baidu/hugegraph/api/profile/GraphsAPI.java
@@ -24,7 +24,6 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
-import io.swagger.annotations.Api;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.annotation.security.RolesAllowed;
 import jakarta.inject.Singleton;
@@ -124,7 +123,7 @@ public class GraphsAPI extends API {
     @POST
     @Timed
     @Path("{name}")
-    @Consumes(APPLICATION_JSON_WITH_CHARSET)
+    @Consumes(TEXT_PLAIN)
     @Produces(APPLICATION_JSON_WITH_CHARSET)
     @RolesAllowed({"admin"})
     public Object create(@Context GraphManager manager,


### PR DESCRIPTION
The format of the graph instance config is `text` instead of `json`
<img width="589" alt="image" src="https://user-images.githubusercontent.com/18065113/168750115-96d3dec6-3b78-4b8e-b3ef-7cee1861af4b.png">
