### PR TITLE
chore: fix GraphOfTheMoviesExample exception

### DIFF
--- a/hugegraph-example/src/main/java/com/baidu/hugegraph/example/GraphOfTheMoviesExample.java
+++ b/hugegraph-example/src/main/java/com/baidu/hugegraph/example/GraphOfTheMoviesExample.java
@@ -105,12 +105,8 @@ public class GraphOfTheMoviesExample {
               .sourceLabel("person").targetLabel("movie")
               .create();
 
-        schema.indexLabel("personByName").onV("person").by("name")
-              .secondary().create();
         schema.indexLabel("personByBorn").onV("person").by("born")
               .range().create();
-
-        graph.tx().open();
 
         Vertex theMatrix = graph.addVertex(T.label, "movie", "title",
             "The Matrix", "released", 1999);


### PR DESCRIPTION
This pr will fix these exception:
```
Exception in thread "main" java.lang.IllegalArgumentException: No need to build index on properties [name], because they contains all primary keys [name] for vertex label 'person'
```

```
Exception in thread "main" java.lang.IllegalStateException: Stop the current transaction before opening another
```