### PR TITLE
fix(sec): upgrade netty-all to 4.1.44.Final

### DIFF
--- a/hugegraph-cassandra/pom.xml
+++ b/hugegraph-cassandra/pom.xml
@@ -75,7 +75,7 @@
             <!-- netty-all contain netty-transport-native-epoll, https://github.com/netty/netty/issues/8714 -->
             <groupId>io.netty</groupId>
             <artifactId>netty-all</artifactId>
-            <version>4.1.42.Final</version>
+            <version>4.1.44.Final</version>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
Upgrade netty-all 4.1.42.Final to 4.1.44.Final for vulnerability fix:
         - [CVE-2020-7238](https://www.oscs1024.com/hd/MPS-2020-1320)
         - [CVE-2019-20444](https://www.oscs1024.com/hd/MPS-2020-1526)
         - [CVE-2019-20445](https://www.oscs1024.com/hd/MPS-2020-1527)