### PR TITLE
fix(api): fix remoting rpc server not started

### DIFF
--- a/hugegraph-api/src/main/java/com/baidu/hugegraph/core/GraphManager.java
+++ b/hugegraph-api/src/main/java/com/baidu/hugegraph/core/GraphManager.java
@@ -308,6 +308,12 @@ public final class GraphManager {
         ServerConfig serverConfig = Whitebox.getInternalState(this.rpcServer,
                                                               "serverConfig");
         serverConfig.buildIfAbsent();
+
+        // Start remote rpc server if none rpc services registered
+        // Note it goes here only when raft mode enabled
+        if (!serverConfig.getServer().isStarted()) {
+            serverConfig.getServer().start();
+        }
         return Whitebox.getInternalState(serverConfig.getServer(),
                                          "remotingServer");
     }


### PR DESCRIPTION
使用rocksdb作为后端存储+开启raft，不能成功启动，`registerRpcServices`时未导出service，rpcserver未启动

增加判断，如果server未启动，手动启动

```
   /*
         * Skip register cache-rpc service if it's non-shared storage,
         * because we assume cache of non-shared storage is updated by raft.
         */
        if (!this.backendStoreFeatures().supportsSharedStorage()) {
            return;
        }
```