### PR TITLE
fix TraversalStrategyProxy() compile error on java 11

### DIFF
--- a/hugegraph-api/src/main/java/com/baidu/hugegraph/auth/HugeGraphAuthProxy.java
+++ b/hugegraph-api/src/main/java/com/baidu/hugegraph/auth/HugeGraphAuthProxy.java
@@ -1659,16 +1659,14 @@ public final class HugeGraphAuthProxy implements HugeGraph {
                 return Collections.emptyIterator();
 
             }
-            return new MapperIterator<TraversalStrategy<?>,
-                                      TraversalStrategy<?>>(
+            return new MapperIterator<TraversalStrategy<?>, TraversalStrategy<?>>(
                        this.strategies.iterator(), (strategy) -> {
                            return new TraversalStrategyProxy<>(strategy);
                        });
         }
 
         @Override
-        public TraversalStrategies addStrategies(TraversalStrategy<?>...
-                                                 strategies) {
+        public TraversalStrategies addStrategies(TraversalStrategy<?>... strategies) {
             return this.strategies.addStrategies(strategies);
         }
 
@@ -1709,8 +1707,10 @@ public final class HugeGraphAuthProxy implements HugeGraph {
 
         private final TraversalStrategy<T> origin;
 
-        public TraversalStrategyProxy(TraversalStrategy<T> origin) {
-            this.origin = origin;
+        public TraversalStrategyProxy(TraversalStrategy<?> origin) {
+            @SuppressWarnings({ "rawtypes", "unchecked" })
+            TraversalStrategy<T> strategy = (TraversalStrategy) origin;
+            this.origin = strategy;
         }
 
         @Override
@@ -1768,8 +1768,8 @@ public final class HugeGraphAuthProxy implements HugeGraph {
 
         @Override
         public int compareTo(@SuppressWarnings("rawtypes")
-                             Class<? extends TraversalStrategy> otherCategory) {
-            return this.origin.compareTo(otherCategory);
+                             Class<? extends TraversalStrategy> other) {
+            return this.origin.compareTo(other);
         }
 
         @Override
@@ -1788,8 +1788,7 @@ public final class HugeGraphAuthProxy implements HugeGraph {
         }
     }
 
-    private static final ThreadLocal<Context> CONTEXTS =
-                                              new InheritableThreadLocal<>();
+    private static final ThreadLocal<Context> CONTEXTS = new InheritableThreadLocal<>();
 
     protected static final Context setContext(Context context) {
         Context old = CONTEXTS.get();


### PR DESCRIPTION
compile error on java 11:
`  Cannot infer type arguments for new TraversalStrategyProxy<>(strategy)`

Change-Id: I6a31cb24d4f37cc6af9ae9769a986593301ea1ff