### PR TITLE
[improve] Shutdown log when shutdown process

### DIFF
--- a/hugegraph-dist/src/main/java/com/baidu/hugegraph/dist/HugeGraphServer.java
+++ b/hugegraph-dist/src/main/java/com/baidu/hugegraph/dist/HugeGraphServer.java
@@ -21,6 +21,7 @@ package com.baidu.hugegraph.dist;
 
 import java.util.concurrent.CompletableFuture;
 
+import org.apache.logging.log4j.LogManager;
 import org.apache.tinkerpop.gremlin.server.GremlinServer;
 import org.slf4j.Logger;
 
@@ -139,6 +140,7 @@ public class HugeGraphServer {
             server.stop();
             LOG.info("HugeGraphServer stopped");
 
+            LogManager.shutdown();
             serverStopped.complete(null);
         }, "hugegraph-server-shutdown"));
         // Wait for server-shutdown and server-stopped

--- a/hugegraph-style.xml
+++ b/hugegraph-style.xml
@@ -16,9 +16,9 @@
   -->
 <code_scheme name="hugegraph-style" version="173">
   <option name="LINE_SEPARATOR" value="&#xA;" />
-  <option name="RIGHT_MARGIN" value="80" />
+  <option name="RIGHT_MARGIN" value="100" />
   <option name="WRAP_WHEN_TYPING_REACHES_RIGHT_MARGIN" value="true" />
-  <option name="SOFT_MARGINS" value="80" />
+  <option name="SOFT_MARGINS" value="100" />
   <JavaCodeStyleSettings>
     <option name="ANNOTATION_PARAMETER_WRAP" value="1" />
     <option name="ALIGN_MULTILINE_ANNOTATION_PARAMETERS" value="true" />


### PR DESCRIPTION
### Motivation 
If set `immediateFlush="false"` and log size < bufferSize log can't flush to file, we should call `LogManager.shutdown()` when shutdown process ensures log flush to file.
https://github.com/apache/incubator-hugegraph/blob/8abf3d5524de3d3d5a97bbdce460a75652792b0d/hugegraph-dist/src/main/resources/log4j2.xml#L56-L58

### Modifications

* Shutdown log when shutdown process
* Improve `RIGHT_MARGIN` and `SOFT_MARGINS`