### PR TITLE
Fix tx leak

### DIFF
--- a/hugegraph-test/src/main/java/org/apache/hugegraph/core/BaseCoreTest.java
+++ b/hugegraph-test/src/main/java/org/apache/hugegraph/core/BaseCoreTest.java
@@ -21,27 +21,72 @@ package org.apache.hugegraph.core;
 
 import java.util.Random;
 
+import org.apache.hugegraph.HugeGraph;
+import org.apache.hugegraph.HugeGraphParams;
+import org.apache.hugegraph.backend.id.IdGenerator;
+import org.apache.hugegraph.backend.store.BackendFeatures;
+import org.apache.hugegraph.dist.RegisterUtil;
+import org.apache.hugegraph.schema.SchemaManager;
+import org.apache.hugegraph.testutil.Utils;
+import org.apache.hugegraph.testutil.Whitebox;
+import org.apache.hugegraph.type.define.NodeRole;
+import org.apache.hugegraph.util.Log;
 import org.apache.tinkerpop.gremlin.structure.Edge;
 import org.apache.tinkerpop.gremlin.structure.Vertex;
 import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Assert;
 import org.junit.Before;
+import org.junit.BeforeClass;
 import org.slf4j.Logger;
-
-import org.apache.hugegraph.HugeGraph;
-import org.apache.hugegraph.HugeGraphParams;
-import org.apache.hugegraph.backend.store.BackendFeatures;
-import org.apache.hugegraph.schema.SchemaManager;
-import org.apache.hugegraph.testutil.Whitebox;
-import org.apache.hugegraph.util.Log;
 
 public class BaseCoreTest {
 
     protected static final Logger LOG = Log.logger(BaseCoreTest.class);
 
     protected static final int TX_BATCH = 100;
+    private static boolean registered = false;
+    private static HugeGraph graph = null;
 
-    public HugeGraph graph() {
-        return CoreTestSuite.graph();
+    public static HugeGraph graph() {
+        Assert.assertNotNull(graph);
+        //Assert.assertFalse(graph.closed());
+        return graph;
+    }
+
+    @BeforeClass
+    public static void initEnv() {
+        if (registered) {
+            return;
+        }
+        RegisterUtil.registerBackends();
+        registered = true;
+    }
+
+    @BeforeClass
+    public static void init() {
+        graph = Utils.open();
+        graph.clearBackend();
+        graph.initBackend();
+        graph.serverStarted(IdGenerator.of("server1"), NodeRole.MASTER);
+    }
+
+    @AfterClass
+    public static void clear() {
+        if (graph == null) {
+            return;
+        }
+
+        try {
+            graph.clearBackend();
+        } finally {
+            try {
+                graph.close();
+            } catch (Throwable e) {
+                LOG.error("Error when close()", e);
+            }
+            graph = null;
+        }
     }
 
     @Before

--- a/hugegraph-test/src/main/java/org/apache/hugegraph/core/CoreTestSuite.java
+++ b/hugegraph-test/src/main/java/org/apache/hugegraph/core/CoreTestSuite.java
@@ -19,21 +19,10 @@
 
 package org.apache.hugegraph.core;
 
-import org.apache.hugegraph.testutil.Utils;
-import org.junit.AfterClass;
-import org.junit.Assert;
-import org.junit.BeforeClass;
-import org.junit.runner.RunWith;
-import org.junit.runners.Suite;
-import org.slf4j.Logger;
-
-import org.apache.hugegraph.HugeGraph;
-import org.apache.hugegraph.backend.id.IdGenerator;
 import org.apache.hugegraph.core.PropertyCoreTest.EdgePropertyCoreTest;
 import org.apache.hugegraph.core.PropertyCoreTest.VertexPropertyCoreTest;
-import org.apache.hugegraph.dist.RegisterUtil;
-import org.apache.hugegraph.type.define.NodeRole;
-import org.apache.hugegraph.util.Log;
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
 
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
@@ -54,44 +43,4 @@ import org.apache.hugegraph.util.Log;
 })
 public class CoreTestSuite {
 
-    private static final Logger LOG = Log.logger(CoreTestSuite.class);
-
-    private static HugeGraph graph = null;
-
-    @BeforeClass
-    public static void initEnv() {
-        RegisterUtil.registerBackends();
-    }
-
-    @BeforeClass
-    public static void init() {
-        graph = Utils.open();
-        graph.clearBackend();
-        graph.initBackend();
-        graph.serverStarted(IdGenerator.of("server1"), NodeRole.MASTER);
-    }
-
-    @AfterClass
-    public static void clear() {
-        if (graph == null) {
-            return;
-        }
-
-        try {
-            graph.clearBackend();
-        } finally {
-            try {
-                graph.close();
-            } catch (Throwable e) {
-                LOG.error("Error when close()", e);
-            }
-            graph = null;
-        }
-    }
-
-    protected static HugeGraph graph() {
-        Assert.assertNotNull(graph);
-        //Assert.assertFalse(graph.closed());
-        return graph;
-    }
 }

--- a/hugegraph-test/src/main/java/org/apache/hugegraph/core/MultiGraphsTest.java
+++ b/hugegraph-test/src/main/java/org/apache/hugegraph/core/MultiGraphsTest.java
@@ -27,13 +27,6 @@ import java.util.List;
 import org.apache.commons.configuration2.BaseConfiguration;
 import org.apache.commons.configuration2.Configuration;
 import org.apache.commons.configuration2.PropertiesConfiguration;
-import org.apache.tinkerpop.gremlin.structure.T;
-import org.apache.tinkerpop.gremlin.structure.Vertex;
-import org.apache.tinkerpop.gremlin.structure.util.GraphFactory;
-import org.apache.hugegraph.testutil.Utils;
-import org.junit.Test;
-import org.rocksdb.RocksDBException;
-
 import org.apache.hugegraph.HugeException;
 import org.apache.hugegraph.HugeGraph;
 import org.apache.hugegraph.backend.id.IdGenerator;
@@ -48,10 +41,17 @@ import org.apache.hugegraph.schema.PropertyKey;
 import org.apache.hugegraph.schema.SchemaManager;
 import org.apache.hugegraph.schema.VertexLabel;
 import org.apache.hugegraph.testutil.Assert;
+import org.apache.hugegraph.testutil.Utils;
 import org.apache.hugegraph.type.define.NodeRole;
+import org.apache.tinkerpop.gremlin.structure.T;
+import org.apache.tinkerpop.gremlin.structure.Vertex;
+import org.apache.tinkerpop.gremlin.structure.util.GraphFactory;
+import org.junit.Test;
+import org.rocksdb.RocksDBException;
+
 import com.google.common.collect.ImmutableList;
 
-public class MultiGraphsTest {
+public class MultiGraphsTest extends BaseCoreTest {
 
     private static final String NAME48 =
             "g12345678901234567890123456789012345678901234567";


### PR DESCRIPTION
```java
2022-11-24 12:53:40 [gremlin-server-stop] [WARN] o.a.t.g.s.GremlinServer - Exception while closing Graph instance [hugegraph]
java.lang.IllegalStateException: Ensure tx closed in all threads when closing graph 'hugegraph'
	at com.google.common.base.Preconditions.checkState(Preconditions.java:531) ~[guava-25.1-jre.jar:?]
	at com.baidu.hugegraph.util.E.checkState(E.java:68) ~[hugegraph-common-2.1.2.jar:2.1.2.0]
	at com.baidu.hugegraph.StandardHugeGraph.close(StandardHugeGraph.java:948) ~[hugegraph-core-0.13.0.jar:0.13.0.0]
	at org.apache.tinkerpop.gremlin.server.GremlinServer.lambda$null$7(GremlinServer.java:307) ~[gremlin-server-3.5.1.jar:3.5.1]
	at java.util.concurrent.ConcurrentHashMap$KeySetView.forEach(ConcurrentHashMap.java:4649) ~[?:1.8.0_332]
	at org.apache.tinkerpop.gremlin.server.GremlinServer.lambda$stop$8(GremlinServer.java:304) ~[gremlin-server-3.5.1.jar:3.5.1]
	at java.lang.Thread.run(Thread.java:750) [?:1.8.0_332]
```