### PR TITLE
refact(dist): avoid script exit while restarting & clean script

### DIFF
--- a/hugegraph-api/src/main/java/org/apache/hugegraph/version/ApiVersion.java
+++ b/hugegraph-api/src/main/java/org/apache/hugegraph/version/ApiVersion.java
@@ -120,13 +120,11 @@ public final class ApiVersion {
 
     /**
      * The second parameter of Version.of() is for IDE running without JAR
-     * TODO: what shall we set for this version? (consider the basic compatibility)
      */
     public static final Version VERSION = Version.of(ApiVersion.class, "0.69");
 
     public static void check() {
         // Check version of hugegraph-core. Firstly do check from version 0.3
-        // TODO: what shall we set for this version? (consider the basic compatibility)
         VersionUtil.check(CoreVersion.VERSION, "1.0", "1.1", CoreVersion.NAME);
     }
 }

--- a/hugegraph-core/src/main/java/org/apache/hugegraph/version/CoreVersion.java
+++ b/hugegraph-core/src/main/java/org/apache/hugegraph/version/CoreVersion.java
@@ -40,7 +40,6 @@ public class CoreVersion {
 
     public static void check() {
         // Check version of hugegraph-common
-        // TODO: why shall we check it? Update it if need
         VersionUtil.check(CommonVersion.VERSION, "1.0", "1.1", CommonVersion.NAME);
     }
 }

--- a/hugegraph-dist/src/assembly/static/bin/hugegraph
+++ b/hugegraph-dist/src/assembly/static/bin/hugegraph
@@ -16,45 +16,26 @@
 # limitations under the License.
 #
 
-#
-# hugegraph     This shell script takes care of starting and stopping
-#               HugeGraphServer.
-#
-# chkconfig: - 58 74
-# description: HugeGraphServer is graph database server. It provides graph \
-# service by RESTful API consisted with graph, schema, gremlin and other APIs.
+# This script is used for starting and stopping HugeGraphServer easily.
+# We could copy this file under '/usr/bin' to use it globally
 
-### BEGIN INIT INFO
-# Provides: HugeGraphServer
-# Required-Start: $java
-# Required-Stop: $java
-# Should-Start: -
-# Should-Stop: -
-# Short-Description: start and stop HugeGraphServer
-# Description: HugeGraphServer is graph database server. It provides graph
-#              service by RESTful API consisted with graph, schema, gremlin
-#              and other APIs.
-### END INIT INFO
-
-# Variables
-# it requires user to set a fixed abs path manually
+# Note: user must set a absolute path below
 INSTALL_DIR=
 SERVER_PORT=
 
-${INSTALL_DIR:?"Please set variables 'INSTALL_DIR'"}
-${SERVER_PORT:?"Please set variables 'SERVER_PORT'"}
+${INSTALL_DIR:?"Please open the script then set variable 'INSTALL_DIR' manually"}
+${SERVER_PORT:?"Please open the script then set variable 'SERVER_PORT' manually"}
 
 BIN_DIR=$INSTALL_DIR/bin
 SERVER_URL="http://localhost:${SERVER_PORT}"
 DETECT_URL="$SERVER_URL/versions"
+EXIT=1
 
 # Start the HugeGraphServer
 start() {
-    echo "Starting HugeGraphServer..."
     # Verify if the service is running
-    get_status
-    if [ $? -eq 0 ]; then
-        echo "The service is already running"
+    if get_status; then
+        echo "The graph server is already running"
         exit 0
     else
         # Run the service
@@ -64,12 +45,11 @@ start() {
         #sleep 10
 
         # Verify if the service is running
-        get_status
-        if [ $? -eq 0 ]; then
-            echo "Service was successfully started"
+        if get_status; then
+            echo "Graph server was successfully started"
             exit 0
         else
-            echo "Failed to start service"
+            echo "Failed to start graph server"
             exit 1
         fi
     fi
@@ -77,37 +57,29 @@ start() {
 
 # Stop the MATH
 stop() {
-    echo "Stopping HugeGraphServer..."
     # Verify if the service is running
-    get_status
-    if [ $? -eq 0 ]; then
+    if get_status; then
         # Stop the service
         $BIN_DIR/stop-hugegraph.sh
 
-        # Sleep time before the service verification
-        #sleep 10
-
         # Verify if the service is running
-        get_status
-        if [ $? -eq 0 ]; then
+        if get_status; then
             echo "Failed to stop service"
-            exit 1
         else
             echo "Service was successfully stopped"
-            exit 0
         fi
     else
         echo "The service is already stopped"
+    fi
+
+    if [[ $EXIT -eq 1 ]]; then
         exit 0
     fi
 }
 
 # Verify the status of HugeGraphServer
 status() {
-    echo "Checking status of HugeGraphServer..."
-    # Verify if the HugeGraphServer is running
-    get_status
-    if [ $? -eq 0 ]; then
+    if get_status; then
         echo "Service is running"
         exit 0
     else
@@ -119,7 +91,7 @@ status() {
 # Get status of HugeGraphServer to ensure it is alive
 get_status() {
     HTTP_CODE=$(curl -I -s -w "%{http_code}" -o /dev/null $DETECT_URL)
-    if [ $HTTP_CODE = 200 ]; then
+    if [ "$HTTP_CODE" = 200 ]; then
         return 0
     else
         return 1
@@ -137,12 +109,13 @@ case "$1" in
     status)
         status
         ;;
-    restart|reload)
+    restart|reload|rs)
+        EXIT=0
         stop
         start
         ;;
     *)
-        echo $"Usage: $0 {start|stop|status|restart|reload}"
+        echo $"Usage: $0 {start, stop, status, restart|reload|rs}"
         exit 1
 esac
 exit 0

--- a/hugegraph-dist/src/assembly/static/bin/stop-hugegraph.sh
+++ b/hugegraph-dist/src/assembly/static/bin/stop-hugegraph.sh
@@ -39,17 +39,16 @@ abs_path() {
     echo "$( cd -P "$( dirname "$SOURCE" )" && pwd )"
 }
 
-BIN=`abs_path`
+BIN=$(abs_path)
 TOP="$(cd $BIN/../ && pwd)"
 
-. $BIN/util.sh
+. "$BIN"/util.sh
 
 PID_FILE=$BIN/pid
 SERVER_SHUTDOWN_TIMEOUT_S=10
 
 if [ "$CLOSE_MONITOR" == "true" ]; then
-    $BIN/stop-monitor.sh
-    if [ $? -ne 0 ]; then
+    if ! "$BIN"/stop-monitor.sh; then
         # TODO: If remove monitor failed, should continue kill process?
         echo "Failed to close monitor, please stop it manually via crontab -e"
     else
@@ -57,14 +56,13 @@ if [ "$CLOSE_MONITOR" == "true" ]; then
     fi
 fi
 
-if [ ! -f ${PID_FILE} ]; then
+if [ ! -f "${PID_FILE}" ]; then
     echo "The pid file $PID_FILE doesn't exist"
     exit 1
 fi
 
-PID=`cat $PID_FILE`
-kill_process_and_wait "HugeGraphServer" "$PID" "$SERVER_SHUTDOWN_TIMEOUT_S"
+PID=$(cat $PID_FILE)
 
-if [ $? -eq 0 ]; then
+if kill_process_and_wait "HugeGraphServer" "$PID" "$SERVER_SHUTDOWN_TIMEOUT_S"; then
     rm "$PID_FILE"
 fi

--- a/hugegraph-dist/src/assembly/static/bin/util.sh
+++ b/hugegraph-dist/src/assembly/static/bin/util.sh
@@ -17,7 +17,7 @@
 #
 function command_available() {
     local cmd=$1
-    if [ `command -v $cmd >/dev/null 2>&1` ]; then
+    if [ "$(command -v "$cmd" >/dev/null 2>&1)" ]; then
         return 1
     else
         return 0
@@ -29,8 +29,8 @@ function read_property() {
     # file path
     file_name=$1
     # replace "." to "\."
-    property_name=`echo $2 | sed 's/\./\\\./g'`
-    cat $file_name | sed -n -e "s/^[ ]*//g;/^#/d;s/^$property_name=//p" | tail -1
+    property_name=$(echo "$2" | sed 's/\./\\\./g')
+    cat "$file_name" | sed -n -e "s/^[ ]*//g;/^#/d;s/^$property_name=//p" | tail -1
 }
 
 function write_property() {
@@ -38,7 +38,7 @@ function write_property() {
     local key=$2
     local value=$3
 
-    local os=`uname`
+    local os=$(uname)
     case $os in
         # Note: in mac os should use sed -i '' "xxx" to replace string,
         # otherwise prompt 'command c expects \ followed by text'.
@@ -53,7 +53,7 @@ function parse_yaml() {
     local version=$2
     local module=$3
 
-    cat $file | tr -d '\n {}'| awk -F',+|:' '''{
+    cat "$file" | tr -d '\n {}'| awk -F',+|:' '''{
         pre="";
         for(i=1; i<=NF; ) {
             if(match($i, /version/)) {
@@ -69,23 +69,23 @@ function parse_yaml() {
 }
 
 function process_num() {
-    num=`ps -ef | grep $1 | grep -v grep | wc -l`
-    return $num
+    num=$(ps -ef | grep "$1" | grep -v grep | wc -l)
+    return "$num"
 }
 
 function process_id() {
-    pid=`ps -ef | grep $1 | grep -v grep | awk '{print $2}'`
-    return $pid
+    pid=$(ps -ef | grep "$1" | grep -v grep | awk '{print $2}')
+    return "$pid"
 }
 
 # check the port of rest server is occupied
 function check_port() {
-    local port=`echo $1 | awk -F':' '{print $3}'`
+    local port=$(echo "$1" | awk -F':' '{print $3}')
     if ! command_available "lsof"; then
         echo "Required lsof but it is unavailable"
         exit 1
     fi
-    lsof -i :$port >/dev/null
+    lsof -i :"$port" >/dev/null
     if [ $? -eq 0 ]; then
         echo "The port $port has already been used"
         exit 1
@@ -127,13 +127,13 @@ function wait_for_startup() {
     local server_url="$3"
     local timeout_s="$4"
 
-    local now_s=`date '+%s'`
-    local stop_s=$(( $now_s + $timeout_s ))
+    local now_s=$(date '+%s')
+    local stop_s=$((now_s + timeout_s))
 
     local status
 
     echo -n "Connecting to $server_name ($server_url)"
-    while [ $now_s -le $stop_s ]; do
+    while [ "$now_s" -le $stop_s ]; do
         echo -n .
         process_status "$server_name" "$pid" >/dev/null
         if [ $? -eq 1 ]; then
@@ -141,14 +141,14 @@ function wait_for_startup() {
             return 1
         fi
 
-        status=`curl -o /dev/null -s -k -w %{http_code} $server_url`
+        status=$(curl -I -s -w "%{http_code}" -o /dev/null "$server_url")
         if [[ $status -eq 200 || $status -eq 401 ]]; then
             echo "OK"
             echo "Started [pid $pid]"
             return 0
         fi
         sleep 2
-        now_s=`date '+%s'`
+        now_s=$(date '+%s')
     done
 
     echo "The operation timed out(${timeout_s}s) when attempting to connect to $server_url" >&2
@@ -157,35 +157,35 @@ function wait_for_startup() {
 
 function free_memory() {
     local free=""
-    local os=`uname`
+    local os=$(uname)
     if [ "$os" == "Linux" ]; then
-        local mem_free=`cat /proc/meminfo | grep -w "MemFree" | awk '{print $2}'`
-        local mem_buffer=`cat /proc/meminfo | grep -w "Buffers" | awk '{print $2}'`
-        local mem_cached=`cat /proc/meminfo | grep -w "Cached" | awk '{print $2}'`
+        local mem_free=$(cat /proc/meminfo | grep -w "MemFree" | awk '{print $2}')
+        local mem_buffer=$(cat /proc/meminfo | grep -w "Buffers" | awk '{print $2}')
+        local mem_cached=$(cat /proc/meminfo | grep -w "Cached" | awk '{print $2}')
         if [[ "$mem_free" == "" || "$mem_buffer" == "" || "$mem_cached" == "" ]]; then
             echo "Failed to get free memory"
             exit 1
         fi
-        free=`expr $mem_free + $mem_buffer + $mem_cached`
-        free=`expr $free / 1024`
+        free=$(expr "$mem_free" + "$mem_buffer" + "$mem_cached")
+        free=$(expr "$free" / 1024)
     elif [ "$os" == "Darwin" ]; then
-        local pages_free=`vm_stat | awk '/Pages free/{print $0}' | awk -F'[:.]+' '{print $2}' | tr -d " "`
-        local pages_inactive=`vm_stat | awk '/Pages inactive/{print $0}' | awk -F'[:.]+' '{print $2}' | tr -d " "`
-        local pages_available=`expr $pages_free + $pages_inactive`
-        free=`expr $pages_available \* 4096 / 1024 / 1024`
+        local pages_free=$(vm_stat | awk '/Pages free/{print $0}' | awk -F'[:.]+' '{print $2}' | tr -d " ")
+        local pages_inactive=$(vm_stat | awk '/Pages inactive/{print $0}' | awk -F'[:.]+' '{print $2}' | tr -d " ")
+        local pages_available=$(expr "$pages_free" + "$pages_inactive")
+        free=$(expr "$pages_available" \* 4096 / 1024 / 1024)
     else
         echo "Unsupported operating system $os"
         exit 1
     fi
-    echo $free
+    echo "$free"
 }
 
 function calc_xmx() {
     local min_mem=$1
     local max_mem=$2
     # Get machine available memory
-    local free=`free_memory`
-    local half_free=$[free/2]
+    local free=$(free_memory)
+    local half_free=$((free/2))
 
     local xmx=$min_mem
     if [[ "$free" -lt "$min_mem" ]]; then
@@ -223,7 +223,7 @@ function ensure_path_writable() {
     local path=$1
     # Ensure input path exist
     if [ ! -d "${path}" ]; then
-        mkdir -p ${path}
+        mkdir -p "${path}"
     fi
     # Check for write permission
     if [ ! -w "${path}" ]; then
@@ -233,29 +233,29 @@ function ensure_path_writable() {
 }
 
 function get_ip() {
-    local os=`uname`
+    local os=$(uname)
     local loopback="127.0.0.1"
     local ip=""
     case $os in
         Linux)
             if command_available "ifconfig"; then
-                ip=`ifconfig | grep 'inet addr:' | grep -v "$loopback" | cut -d: -f2 | awk '{ print $1}'`
+                ip=$(ifconfig | grep 'inet addr:' | grep -v "$loopback" | cut -d: -f2 | awk '{ print $1}')
             elif command_available "ip"; then
-                ip=`ip addr | grep 'state UP' -A2 | tail -n1 | awk '{print $2}' | awk -F"/" '{print $1}'`
+                ip=$(ip addr | grep 'state UP' -A2 | tail -n1 | awk '{print $2}' | awk -F"/" '{print $1}')
             else
                 ip=$loopback
             fi
             ;;
         FreeBSD|OpenBSD|Darwin)
             if command_available "ifconfig"; then
-                ip=`ifconfig | grep -E 'inet.[0-9]' | grep -v "$loopback" | awk '{ print $2}'`
+                ip=$(ifconfig | grep -E 'inet.[0-9]' | grep -v "$loopback" | awk '{ print $2}')
             else
                 ip=$loopback
             fi
             ;;
         SunOS)
             if command_available "ifconfig"; then
-                ip=`ifconfig -a | grep inet | grep -v "$loopback" | awk '{ print $2} '`
+                ip=$(ifconfig -a | grep inet | grep -v "$loopback" | awk '{ print $2} ')
             else
                 ip=$loopback
             fi
@@ -271,9 +271,9 @@ function download() {
 
     if command_available "wget"; then
         wget --help | grep -q '\--show-progress' && progress_opt="-q --show-progress" || progress_opt=""
-        wget ${link_url} -P ${path} $progress_opt
+        wget "${link_url}" -P "${path}" "$progress_opt"
     elif command_available "curl"; then
-        curl ${link_url} -o ${path}/${link_url}
+        curl "${link_url}" -o "${path}"/"${link_url}"
     else
         echo "Required wget or curl but they are unavailable"
         exit 1
@@ -286,10 +286,10 @@ function ensure_package_exist() {
     local tar=$3
     local link=$4
 
-    if [ ! -d ${path}/${dir} ]; then
-        if [ ! -f ${path}/${tar} ]; then
+    if [ ! -d "${path}"/"${dir}" ]; then
+        if [ ! -f "${path}"/"${tar}" ]; then
             echo "Downloading the compressed package '${tar}'"
-            download ${path} ${link}
+            download "${path}" "${link}"
             if [ $? -ne 0 ]; then
                 echo "Failed to download, please ensure the network is available and link is valid"
                 exit 1
@@ -297,7 +297,7 @@ function ensure_package_exist() {
             echo "[OK] Finished download"
         fi
         echo "Unzip the compressed package '$tar'"
-        tar -zxvf ${path}/${tar} -C ${path} >/dev/null 2>&1
+        tar zxvf "${path}"/"${tar}" -C "${path}" >/dev/null 2>&1
         if [ $? -ne 0 ]; then
             echo "Failed to unzip, please check the compressed package"
             exit 1
@@ -313,11 +313,11 @@ function wait_for_shutdown() {
     local pid="$2"
     local timeout_s="$3"
 
-    local now_s=`date '+%s'`
-    local stop_s=$(( $now_s + $timeout_s ))
+    local now_s=$(date '+%s')
+    local stop_s=$((now_s + timeout_s))
 
     echo -n "Killing $process_name(pid $pid)" >&2
-    while [ $now_s -le $stop_s ]; do
+    while [ "$now_s" -le $stop_s ]; do
         echo -n .
         process_status "$process_name" "$pid" >/dev/null
         if [ $? -eq 1 ]; then
@@ -325,7 +325,7 @@ function wait_for_shutdown() {
             return 0
         fi
         sleep 2
-        now_s=`date '+%s'`
+        now_s=$(date '+%s')
     done
     echo "$process_name shutdown timeout(exceeded $timeout_s seconds)" >&2
     return 1
@@ -354,7 +354,7 @@ function kill_process() {
         return 0
     fi
 
-    case "`uname`" in
+    case "$(uname)" in
         CYGWIN*) taskkill /F /PID "$pid" ;;
         *)       kill "$pid" ;;
     esac


### PR DESCRIPTION
- fix "restart" not work in `hugegraph` script
- clean shell script to avoid error in high-version bash/sh


refer:
- https://github.com/koalaman/shellcheck/wiki/SC2181
- https://github.com/koalaman/shellcheck/wiki/SC2004

and we have a lot of writing way may break the shell rules, and it will lead some unexpected error in high `bash/shell` version (like the problem when start with java11)