### PR TITLE
fix: specify the code generation directory for raft.proto

### DIFF
--- a/hugegraph-core/pom.xml
+++ b/hugegraph-core/pom.xml
@@ -280,6 +280,7 @@
                     <protocArtifact>com.google.protobuf:protoc:${protobuf.version}:exe:${os.detected.classifier}</protocArtifact>
                     <pluginId>protoc-java</pluginId>
                     <protoSourceRoot>${project.basedir}/src/main/resources/proto</protoSourceRoot>
+                    <outputDirectory>${basedir}/target/generated-sources/protobuf/java</outputDirectory>
                 </configuration>
                 <executions>
                     <execution>


### PR DESCRIPTION
followup #2045 , without specifying the code generation directory for raft.proto
![image](https://user-images.githubusercontent.com/18065113/208386459-d062165e-77fa-4d95-ad33-cd1253ab350f.png)
