### PR TITLE
chore: adopt license with apache action to check dependency license

### DIFF
--- a/.github/workflows/licence-checker.yml
+++ b/.github/workflows/licence-checker.yml
@@ -20,3 +20,29 @@ jobs:
         with:
           log: info
           config: .licenserc.yaml
+
+  dependency-license:
+    name: Dependency licenses
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          submodules: true
+      - uses: actions/setup-java@v3
+        with:
+          distribution: "temurin"
+          java-version: "11"
+          cache: "maven"
+      - name: Setup Go
+        uses: actions/setup-go@v3
+        with:
+          go-version: "1.16"
+      - name: Check Dependencies Licenses
+        run: |
+          go install github.com/apache/skywalking-eyes/cmd/license-eye@442d462
+          license-eye dependency resolve --summary ./hugegraph-dist/release-docs/LICENSE.tpl || exit 1
+          if [ ! -z "$(git diff -U0 ./hugegraph-dist/release-docs/LICENSE)" ]; then
+            echo "LICENSE file is not updated correctly"
+            git diff -U0 ./hugegraph-dist/release-docs/LICENSE
+            exit 1
+          fi

--- a/.licenserc.yaml
+++ b/.licenserc.yaml
@@ -99,3 +99,73 @@ header: # `header` section is configurations for source codes license header.
   # license-location-threshold specifies the index threshold where the license header can be located,
   # after all, a "header" cannot be TOO far from the file start.
   license-location-threshold: 80
+
+dependency:
+  files:
+    - pom.xml
+  excludes:
+    - name: org.apache.hugegraph:* # Exclude self dependencies
+  licenses: # Declare the licenses which cannot be identified by this tool.
+    - name: com.addthis.metrics:reporter-config-base
+      version: 3.0.3
+      license: Apache-2.0
+    - name: com.addthis.metrics:reporter-config3
+      version: 3.0.3
+      license: Apache-2.0
+    - name: com.alipay.sofa.lookout:lookout-api
+      version: 1.4.1
+      license: Apache-2.0
+    - name: com.alipay.sofa:jraft-core
+      version: 1.3.11
+      license: Apache-2.0
+    - name: com.carrotsearch:hppc
+      version: 0.7.1
+      license: Apache-2.0
+    - name: com.fasterxml.jackson.dataformat:jackson-dataformat-yaml
+      version: 2.9.3
+      license: Apache-2.0
+    - name: com.fasterxml.jackson.datatype:jackson-datatype-jsr310
+      version: 2.12.1
+      license: Apache-2.0
+    - name: com.fasterxml.jackson.jaxrs:jackson-jaxrs-json-provider
+      version: 2.12.1
+      license: Apache-2.0
+    - name: io.swagger.core.v3:swagger-models-jakarta
+      version: 2.1.9
+      license: Apache-2.0
+    - name: io.swagger.core.v3:swagger-annotations-jakarta
+      version: 2.1.9
+      license: Apache-2.0
+    - name: io.swagger:swagger-annotations
+      version: 2.1.9
+      license: Apache-2.0
+    - name: io.swagger:swagger-models
+      version: 1.5.18
+      license: Apache-2.0
+    - name: io.swagger:swagger-annotations
+      version: 1.5.18
+      license: Apache-2.0
+    - name: net.bytebuddy:byte-buddy
+      version: 1.10.5
+      license: Apache-2.0
+    - name: org.antlr:antlr-runtime
+      version: 3.5.2
+      license: BSD
+    - name: org.fusesource:sigar
+      version: 1.6.4
+      license: Apache-2.0
+    - name: org.lionsoul:jcseg-core
+      version: 2.6.2
+      license: Apache-2.0
+    - name: org.slf4j:jcl-over-slf4j
+      version: 1.7.25
+      license: Apache-2.0
+    - name: org.slf4j:slf4j-api
+      version: 1.7.25
+      license: MIT
+    - name: org.slf4j:slf4j-api
+      version: 1.7.7
+      license: MIT
+    - name: com.google.code.gson:gson
+      version: 2.8.6
+      license: Apache-2.0

--- a/hugegraph-dist/release-docs/LICENSE
+++ b/hugegraph-dist/release-docs/LICENSE
@@ -308,7 +308,6 @@ Apache-2.0 licenses
     net.minidev:json-smart 2.3 Apache-2.0
     net.objecthunter:exp4j 0.4.8 Apache-2.0
     org.ansj:ansj_seg 5.1.6 Apache-2.0
-    org.antlr:antlr-runtime 3.5.2 Apache-2.0
     org.apache.cassandra:cassandra-all 3.11.12 Apache-2.0
     org.apache.commons:commons-compress 1.21 Apache-2.0
     org.apache.commons:commons-configuration2 2.8.0 Apache-2.0
@@ -376,8 +375,6 @@ Apache-2.0 licenses
     org.parboiled:parboiled-core 1.2.0 Apache-2.0
     org.parboiled:parboiled-scala_2.12 1.2.0 Apache-2.0
     org.slf4j:jcl-over-slf4j 1.7.25 Apache-2.0
-    org.slf4j:slf4j-api 1.7.25 Apache-2.0
-    org.slf4j:slf4j-api 1.7.7 Apache-2.0
     org.xerial.snappy:snappy-java 1.1.1.7 Apache-2.0
     org.yaml:snakeyaml 1.27 Apache-2.0
     org.yaml:snakeyaml 1.26 Apache-2.0
@@ -416,6 +413,12 @@ Apache-2.0 and Zlib licenses
 ========================================================================
 
     org.apache.thrift:libthrift 0.9.2 Apache-2.0 and Zlib
+
+========================================================================
+BSD licenses
+========================================================================
+
+    org.antlr:antlr-runtime 3.5.2 BSD
 
 ========================================================================
 BSD-2-Clause licenses
@@ -516,6 +519,8 @@ MIT licenses
     org.checkerframework:checker-qual 3.5.0 MIT
     org.codehaus.mojo:animal-sniffer-annotations 1.14 MIT
     org.mockito:mockito-core 3.3.3 MIT
+    org.slf4j:slf4j-api 1.7.25 MIT
+    org.slf4j:slf4j-api 1.7.7 MIT
 
 ========================================================================
 MPL-1.1 and LGPL-2.1 licenses

--- a/hugegraph-dist/release-docs/LICENSE
+++ b/hugegraph-dist/release-docs/LICENSE
@@ -201,353 +201,429 @@
    limitations under the License.
 
 
-
-============================================================================
+=======================================================================
    APACHE HUGEGRAPH (Incubating) SUBCOMPONENTS:
 
    The Apache HugeGraph(Incubating) project contains subcomponents with separate copyright
    notices and license terms. Your use of the source code for the these
    subcomponents is subject to the terms and conditions of the following
    licenses.
-
 ========================================================================
-Apache 2.0 licenses
-========================================================================
-
-The following components are provided under the Apache License. See project link for details.
-The text of each license is the standard Apache 2.0 license.
-
-hugegraph-core/src/main/java/org/apache/hugegraph/type/Nameable.java from https://github.com/JanusGraph/janusgraph
-hugegraph-core/src/main/java/org/apache/hugegraph/type/define/Cardinality.java from https://github.com/JanusGraph/janusgraph
-hugegraph-core/src/main/java/org/apache/hugegraph/util/StringEncoding.java from https://github.com/JanusGraph/janusgraph
-hugegraph-core/src/main/java/org/apache/hugegraph/traversal/optimize/HugeScriptTraversal.java from https://github.com/apache/tinkerpop
-hugegraph-test/src/main/java/org/apache/hugegraph/tinkerpop/ProcessBasicSuite.java from https://github.com/apache/tinkerpop
-hugegraph-test/src/main/java/org/apache/hugegraph/tinkerpop/StructureBasicSuite.java from https://github.com/apache/tinkerpop
-hugegraph-core/src/main/java/org/apache/hugegraph/backend/id/SnowflakeIdGenerator.java from https://github.com/twitter-archive/snowflake
 
 
 ========================================================================
-Third party Apache 2.0 licenses
+Apache-2.0 licenses
 ========================================================================
 
-The following components are provided under the Apache 2.0 License.
-See licenses/ for text of these licenses.
-	(Apache License, Version 2.0) * Java Native Access (net.java.dev.jna:jna:5.5.0 - https://github.com/java-native-access/jna)
-	(Apache License, Version 2.0) * jersey-connectors-apache (org.glassfish.jersey.connectors:jersey-apache-connector:3.0.3 - https://projects.eclipse.org/projects/ee4j.jersey/project/jersey-apache-connector)
-	(Apache License, Version 2.0) * jersey-container-grizzly2-http (org.glassfish.jersey.containers:jersey-container-grizzly2-http:3.0.3 - https://projects.eclipse.org/projects/ee4j.jersey/project/jersey-container-grizzly2-http)
-	(Apache License, Version 2.0) * jersey-container-grizzly2-servlet (org.glassfish.jersey.containers:jersey-container-grizzly2-servlet:3.0.3 - https://projects.eclipse.org/projects/ee4j.jersey/project/jersey-container-grizzly2-servlet)
-	(Apache License, Version 2.0) * jersey-container-servlet (org.glassfish.jersey.containers:jersey-container-servlet:3.0.3 - https://projects.eclipse.org/projects/ee4j.jersey/project/jersey-container-servlet)
-	(Apache License, Version 2.0) * jersey-container-servlet-core (org.glassfish.jersey.containers:jersey-container-servlet-core:3.0.3 - https://projects.eclipse.org/projects/ee4j.jersey/project/jersey-container-servlet-core)
-	(Apache License, Version 2.0) * jersey-core-client (org.glassfish.jersey.core:jersey-client:3.0.3 - https://projects.eclipse.org/projects/ee4j.jersey/jersey-client)
-	(Apache License, Version 2.0) * jersey-ext-entity-filtering (org.glassfish.jersey.ext:jersey-entity-filtering:3.0.3 - https://projects.eclipse.org/projects/ee4j.jersey/project/jersey-entity-filtering)
-	(Apache License, Version 2.0) * jersey-inject-hk2 (org.glassfish.jersey.inject:jersey-hk2:3.0.3 - https://projects.eclipse.org/projects/ee4j.jersey/project/jersey-hk2)
-	(Apache License, Version 2.0) * jersey-media-jaxb (org.glassfish.jersey.media:jersey-media-jaxb:3.0.3 - https://projects.eclipse.org/projects/ee4j.jersey/project/jersey-media-jaxb)
-	(Apache License, Version 2.0) * jersey-test-framework-core (org.glassfish.jersey.test-framework:jersey-test-framework-core:3.0.3 - https://projects.eclipse.org/projects/ee4j.jersey/project/jersey-test-framework-core)
-	(Apache License, Version 2.0) * jersey-test-framework-provider-grizzly2 (org.glassfish.jersey.test-framework.providers:jersey-test-framework-provider-grizzly2:3.0.3 - https://projects.eclipse.org/projects/ee4j.jersey/project/project/jersey-test-framework-provider-grizzly2)
-	(Apache License, Version 2.0) * jersey-core-server (org.glassfish.jersey.core:jersey-server:3.0.3 - https://projects.eclipse.org/projects/ee4j.jersey/jersey-server)
-	(Apache License, Version 2.0) * jersey-core-common (org.glassfish.jersey.core:jersey-common:3.0.3 - https://projects.eclipse.org/projects/ee4j.jersey/jersey-common)
-	(Apache License, Version 2.0) * jersey-media-json-jackson (org.glassfish.jersey.media:jersey-media-json-jackson:3.0.3 - https://projects.eclipse.org/projects/ee4j.jersey/project/jersey-media-json-jackson)
-	(Apache License, Version 2.0) * ASM based accessors helper used by json-smart (net.minidev:accessors-smart:1.2 - http://www.minidev.net/)
-	(Apache License, Version 2.0) * Annotations for Metrics (io.dropwizard.metrics:metrics-annotation:4.2.4 - https://metrics.dropwizard.io/metrics-annotation)
-	(Apache License, Version 2.0) * Apache Cassandra (org.apache.cassandra:cassandra-all:3.11.12 - https://cassandra.apache.org)
-	(Apache License, Version 2.0) * Apache Commons BeanUtils (commons-beanutils:commons-beanutils:1.9.4 - https://commons.apache.org/proper/commons-beanutils/)
-	(Apache License, Version 2.0) * Apache Commons Codec (commons-codec:commons-codec:1.11 - http://commons.apache.org/proper/commons-codec/)
-	(Apache License, Version 2.0) * Apache Commons Codec (commons-codec:commons-codec:1.15 - https://commons.apache.org/proper/commons-codec/)
-	(Apache License, Version 2.0) * Apache Commons Codec (commons-codec:commons-codec:1.9 - http://commons.apache.org/proper/commons-codec/)
-	(Apache License, Version 2.0) * Apache Commons Collections (commons-collections:commons-collections:3.2.2 - http://commons.apache.org/collections/)
-	(Apache License, Version 2.0) * Apache Commons Compress (org.apache.commons:commons-compress:1.21 - https://commons.apache.org/proper/commons-compress/)
-	(Apache License, Version 2.0) * Apache Commons Configuration (commons-configuration:commons-configuration:1.10 - http://commons.apache.org/configuration/)
-	(Apache License, Version 2.0) * Apache Commons Configuration (org.apache.commons:commons-configuration2:2.3 - http://commons.apache.org/proper/commons-configuration/)
-	(Apache License, Version 2.0) * Apache Commons IO (commons-io:commons-io:2.7 - https://commons.apache.org/proper/commons-io/)
-	(Apache License, Version 2.0) * Apache Commons Lang (org.apache.commons:commons-lang3:3.11 - https://commons.apache.org/proper/commons-lang/)
-	(Apache License, Version 2.0) * Apache Commons Logging (commons-logging:commons-logging:1.2 - http://commons.apache.org/proper/commons-logging/)
-	(Apache License, Version 2.0) * Apache Commons Text (org.apache.commons:commons-text:1.9 - https://commons.apache.org/proper/commons-text)
-	(Apache License, Version 2.0) * Apache Groovy (org.codehaus.groovy:groovy-cli-picocli:2.5.14 - https://groovy-lang.org)
-	(Apache License, Version 2.0) * Apache Groovy (org.codehaus.groovy:groovy-console:2.5.14 - https://groovy-lang.org)
-	(Apache License, Version 2.0) * Apache Groovy (org.codehaus.groovy:groovy-groovysh:2.5.14 - https://groovy-lang.org)
-	(Apache License, Version 2.0) * Apache Groovy (org.codehaus.groovy:groovy-json:2.5.14 - https://groovy-lang.org)
-	(Apache License, Version 2.0) * Apache Groovy (org.codehaus.groovy:groovy-jsr223:2.5.14 - https://groovy-lang.org)
-	(Apache License, Version 2.0) * Apache Groovy (org.codehaus.groovy:groovy-swing:2.5.14 - https://groovy-lang.org)
-	(Apache License, Version 2.0) * Apache Groovy (org.codehaus.groovy:groovy-templates:2.5.14 - https://groovy-lang.org)
-	(Apache License, Version 2.0) * Apache Groovy (org.codehaus.groovy:groovy-xml:2.5.14 - https://groovy-lang.org)
-	(Apache License, Version 2.0) * Apache Groovy (org.codehaus.groovy:groovy:2.5.14 - https://groovy-lang.org)
-	(Apache License, Version 2.0) * Apache HttpClient (org.apache.httpcomponents:httpclient:4.5.13 - http://hc.apache.org/httpcomponents-client)
-	(Apache License, Version 2.0) * Apache HttpCore (org.apache.httpcomponents:httpcore:4.4.13 - http://hc.apache.org/httpcomponents-core-ga)
-	(Apache License, Version 2.0) * Apache Ivy (org.apache.ivy:ivy:2.4.0 - http://ant.apache.org/ivy/)
-	(Apache License, Version 2.0) * Apache Log4j API (org.apache.logging.log4j:log4j-api:2.17.1 - https://logging.apache.org/log4j/2.x/log4j-api/)
-	(Apache License, Version 2.0) * Apache Log4j Core (org.apache.logging.log4j:log4j-core:2.17.1 - https://logging.apache.org/log4j/2.x/log4j-core/)
-	(Apache License, Version 2.0) * Apache Log4j SLF4J Binding (org.apache.logging.log4j:log4j-slf4j-impl:2.17.1 - https://logging.apache.org/log4j/2.x/log4j-slf4j-impl/)
-	(Apache License, Version 2.0) * Apache Thrift (org.apache.thrift:libthrift:0.9.2 - http://thrift.apache.org)
-	(Apache License, Version 2.0) * Apache TinkerPop :: Gremlin Console (org.apache.tinkerpop:gremlin-console:3.5.1 - http://tinkerpop.apache.org/gremlin-console/)
-	(Apache License, Version 2.0) * Apache TinkerPop :: Gremlin Core (org.apache.tinkerpop:gremlin-core:3.5.1 - http://tinkerpop.apache.org/gremlin-core/)
-	(Apache License, Version 2.0) * Apache TinkerPop :: Gremlin Driver (org.apache.tinkerpop:gremlin-driver:3.5.1 - http://tinkerpop.apache.org/gremlin-driver/)
-	(Apache License, Version 2.0) * Apache TinkerPop :: Gremlin Groovy (org.apache.tinkerpop:gremlin-groovy:3.5.1 - http://tinkerpop.apache.org/gremlin-groovy/)
-	(Apache License, Version 2.0) * Apache TinkerPop :: Gremlin Groovy Test (org.apache.tinkerpop:gremlin-groovy-test:3.2.11 - http://tinkerpop.apache.org/gremlin-groovy-test/)
-	(Apache License, Version 2.0) * Apache TinkerPop :: Gremlin Server (org.apache.tinkerpop:gremlin-server:3.5.1 - http://tinkerpop.apache.org/gremlin-server/)
-	(Apache License, Version 2.0) * Apache TinkerPop :: Gremlin Shaded (org.apache.tinkerpop:gremlin-shaded:3.5.1 - http://tinkerpop.apache.org/gremlin-shaded/)
-	(Apache License, Version 2.0) * Apache TinkerPop :: Gremlin Test (org.apache.tinkerpop:gremlin-test:3.5.1 - http://tinkerpop.apache.org/gremlin-test/)
-	(Apache License, Version 2.0) * Apache TinkerPop :: TinkerGraph Gremlin (org.apache.tinkerpop:tinkergraph-gremlin:3.5.1 - http://tinkerpop.apache.org/tinkergraph-gremlin/)
-	(Apache License, Version 2.0) * Apache Yetus - Audience Annotations (org.apache.yetus:audience-annotations:0.5.0 - https://yetus.apache.org/audience-annotations)
-	(Apache License, Version 2.0) * Bean Validation API (javax.validation:validation-api:1.1.0.Final - http://beanvalidation.org)
-	(Apache License, Version 2.0) * Byte Buddy (without dependencies) (net.bytebuddy:byte-buddy:1.10.5 - https://bytebuddy.net/byte-buddy)
-	(Apache License, Version 2.0) * Byte Buddy agent (net.bytebuddy:byte-buddy-agent:1.10.5 - https://bytebuddy.net/byte-buddy-agent)
-	(Apache License, Version 2.0) * CLI (commons-cli:commons-cli:1.1 - http://jakarta.apache.org/commons/cli/)
-	(Apache License, Version 2.0) * Caffeine cache (com.github.ben-manes.caffeine:caffeine:2.2.6 - https://github.com/ben-manes/caffeine)
-	(Apache License, Version 2.0) * Caffeine cache (com.github.ben-manes.caffeine:caffeine:2.3.1 - https://github.com/ben-manes/caffeine)
-	(Apache License, Version 2.0) * Commons Lang (commons-lang:commons-lang:2.6 - http://commons.apache.org/lang/)
-	(Apache License, Version 2.0) * Commons Lang (org.apache.commons:commons-lang3:3.1 - http://commons.apache.org/lang/)
-	(Apache License, Version 2.0) * Commons Logging (commons-logging:commons-logging:1.1.1 - http://commons.apache.org/logging)
-	(Apache License, Version 2.0) * Commons Math (org.apache.commons:commons-math3:3.2 - http://commons.apache.org/proper/commons-math/)
-	(Apache License, Version 2.0) * Concurrent-Trees (com.googlecode.concurrent-trees:concurrent-trees:2.4.0 - http://code.google.com/p/concurrent-trees/)
-	(Apache License, Version 2.0) * ConcurrentLinkedHashMap (com.googlecode.concurrentlinkedhashmap:concurrentlinkedhashmap-lru:1.4 - http://code.google.com/p/concurrentlinkedhashmap)
-	(Apache License, Version 2.0) * Cypher for Gremlin: Gremlin language extensions (org.opencypher.gremlin:cypher-gremlin-extensions:1.0.4 - https://github.com/opencypher/cypher-for-gremlin)
-	(Apache License, Version 2.0) * Cypher for Gremlin: Translation (org.opencypher.gremlin:translation:1.0.4 - https://github.com/opencypher/cypher-for-gremlin)
-	(Apache License, Version 2.0) * DataStax Java Driver for Apache Cassandra - Core (com.datastax.cassandra:cassandra-driver-core:3.6.0 - https://github.com/datastax/java-driver/cassandra-driver-core)
-	(Apache License, Version 2.0) * Disruptor Framework (com.lmax:disruptor:3.3.7 - http://lmax-exchange.github.com/disruptor)
-	(Apache License, Version 2.0) * FindBugs-jsr305 (com.google.code.findbugs:jsr305:3.0.1 - http://findbugs.sourceforge.net/)
-	(Apache License, Version 2.0) * Findbugs Annotations under Apache License (com.github.stephenc.findbugs:findbugs-annotations:1.3.9-1 - http://stephenc.github.com/findbugs-annotations)
-	(Apache License, Version 2.0) * Google Android Annotations Library (com.google.android:annotations:4.1.1.4 - http://source.android.com/)
-	(Apache License, Version 2.0) * Gson (com.google.code.gson:gson:2.8.6 - https://github.com/google/gson/gson)
-	(Apache License, Version 2.0) * Guava: Google Core Libraries for Java (com.google.guava:guava:25.1-jre - https://github.com/google/guava/guava)
-	(Apache License, Version 2.0) * HPPC Collections (com.carrotsearch:hppc:0.7.1 - http://labs.carrotsearch.com/hppc.html/hppc)
-	(Apache License, Version 2.0) * HanLP (com.hankcs:hanlp:portable-1.8.3 - https://github.com/hankcs/HanLP)
-	(Apache License, Version 2.0) * J2ObjC Annotations (com.google.j2objc:j2objc-annotations:1.1 - https://github.com/google/j2objc/)
-	(Apache License, Version 2.0) * JCIP Annotations under Apache License (com.github.stephenc.jcip:jcip-annotations:1.0-1 - http://stephenc.github.com/jcip-annotations)
-	(Apache License, Version 2.0) * JJWT :: API (io.jsonwebtoken:jjwt-api:0.11.5 - https://github.com/jwtk/jjwt/jjwt-api)
-	(Apache License, Version 2.0) * JJWT :: Extensions :: Jackson (io.jsonwebtoken:jjwt-jackson:0.11.5 - https://github.com/jwtk/jjwt/jjwt-jackson)
-	(Apache License, Version 2.0) * JJWT :: Impl (io.jsonwebtoken:jjwt-impl:0.11.5 - https://github.com/jwtk/jjwt/jjwt-impl)
-	(Apache License, Version 2.0) * JSON Small and Fast Parser (net.minidev:json-smart:2.3 - http://www.minidev.net/)
-	(Apache License, Version 2.0) * JSON.simple (com.googlecode.json-simple:json-simple:1.1 - http://code.google.com/p/json-simple/)
-	(Apache License, Version 2.0) * JVM Integration for Metrics (io.dropwizard.metrics:metrics-jvm:3.1.5 - http://metrics.codahale.com/metrics-jvm/)
-	(Apache License, Version 2.0) * Jackson datatype: JSR310 (com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.12.1 - https://github.com/FasterXML/jackson-modules-java8/jackson-datatype-jsr310)
-	(Apache License, Version 2.0) * Jackson module: JAXB Annotations (com.fasterxml.jackson.module:jackson-module-jaxb-annotations:2.12.1 - https://github.com/FasterXML/jackson-modules-base)
-	(Apache License, Version 2.0) * Jackson-JAXRS-JSON (com.fasterxml.jackson.jaxrs:jackson-jaxrs-json-provider:2.12.1 - http://github.com/FasterXML/jackson-jaxrs-providers/jackson-jaxrs-json-provider)
-	(Apache License, Version 2.0) * Jackson-JAXRS-base (com.fasterxml.jackson.jaxrs:jackson-jaxrs-base:2.12.1 - http://github.com/FasterXML/jackson-jaxrs-providers/jackson-jaxrs-base)
-	(Apache License, Version 2.0) * Jackson-annotations (com.fasterxml.jackson.core:jackson-annotations:2.12.1 - http://github.com/FasterXML/jackson)
-	(Apache License, Version 2.0) * Jackson-annotations (com.fasterxml.jackson.core:jackson-annotations:2.12.5 - http://github.com/FasterXML/jackson)
-	(Apache License, Version 2.0) * Jackson-core (com.fasterxml.jackson.core:jackson-core:2.12.1 - https://github.com/FasterXML/jackson-core)
-	(Apache License, Version 2.0) * Jackson-core (com.fasterxml.jackson.core:jackson-core:2.12.5 - https://github.com/FasterXML/jackson-core)
-	(Apache License, Version 2.0) * Jackson-dataformat-YAML (com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.9.3 - https://github.com/FasterXML/jackson-dataformats-text)
-	(Apache License, Version 2.0) * Jakarta Bean Validation API (jakarta.validation:jakarta.validation-api:3.0.0 - https://beanvalidation.org)
-	(Apache License, Version 2.0) * Jakarta Dependency Injection (jakarta.inject:jakarta.inject-api:2.0.0 - https://github.com/eclipse-ee4j/injection-api)
-	(Apache License, Version 2.0) * Java Agent for Memory Measurements (com.github.jbellis:jamm:0.3.0 - https://github.com/jbellis/jamm/)
-	(Apache License, Version 2.0) * Java Concurrency Tools Core Library (org.jctools:jctools-core:1.2.1 - https://github.com/JCTools)
-	(Apache License, Version 2.0) * Java Concurrency Tools Core Library (org.jctools:jctools-core:2.1.1 - https://github.com/JCTools)
-	(Apache License, Version 2.0) * JavaPoet (com.squareup:javapoet:1.8.0 - http://github.com/square/javapoet/)
-	(Apache License, Version 2.0) * Joda-Time (joda-time:joda-time:2.10.8 - https://www.joda.org/joda-time/)
-	(Apache License, Version 2.0) * Joda-Time (joda-time:joda-time:2.4 - http://www.joda.org/joda-time/)
-	(Apache License, Version 2.0) * Kerb Simple Kdc (org.apache.kerby:kerb-simplekdc:2.0.0 - http://directory.apache.org/kerby/kerby-kerb/kerb-simplekdc)
-	(Apache License, Version 2.0) * Kerby ASN1 Project (org.apache.kerby:kerby-asn1:2.0.0 - http://directory.apache.org/kerby/kerby-common/kerby-asn1)
-	(Apache License, Version 2.0) * Kerby Config (org.apache.kerby:kerby-config:2.0.0 - http://directory.apache.org/kerby/kerby-common/kerby-config)
-	(Apache License, Version 2.0) * Kerby PKIX Project (org.apache.kerby:kerby-pkix:2.0.0 - http://directory.apache.org/kerby/kerby-pkix)
-	(Apache License, Version 2.0) * Kerby Util (org.apache.kerby:kerby-util:2.0.0 - http://directory.apache.org/kerby/kerby-common/kerby-util)
-	(Apache License, Version 2.0) * Kerby XDR Project (org.apache.kerby:kerby-xdr:2.0.0 - http://directory.apache.org/kerby/kerby-common/kerby-xdr)
-	(Apache License, Version 2.0) * Kerby-kerb Admin (org.apache.kerby:kerb-admin:2.0.0 - http://directory.apache.org/kerby/kerby-kerb/kerb-admin)
-	(Apache License, Version 2.0) * Kerby-kerb Client (org.apache.kerby:kerb-client:2.0.0 - http://directory.apache.org/kerby/kerby-kerb/kerb-client)
-	(Apache License, Version 2.0) * Kerby-kerb Common (org.apache.kerby:kerb-common:2.0.0 - http://directory.apache.org/kerby/kerby-kerb/kerb-common)
-	(Apache License, Version 2.0) * Kerby-kerb Crypto (org.apache.kerby:kerb-crypto:2.0.0 - http://directory.apache.org/kerby/kerby-kerb/kerb-crypto)
-	(Apache License, Version 2.0) * Kerby-kerb Identity (org.apache.kerby:kerb-identity:2.0.0 - http://directory.apache.org/kerby/kerby-kerb/kerb-identity)
-	(Apache License, Version 2.0) * Kerby-kerb Server (org.apache.kerby:kerb-server:2.0.0 - http://directory.apache.org/kerby/kerby-kerb/kerb-server)
-	(Apache License, Version 2.0) * Kerby-kerb Util (org.apache.kerby:kerb-util:2.0.0 - http://directory.apache.org/kerby/kerby-kerb/kerb-util)
-	(Apache License, Version 2.0) * Kerby-kerb core (org.apache.kerby:kerb-core:2.0.0 - http://directory.apache.org/kerby/kerby-kerb/kerb-core)
-	(Apache License, Version 2.0) * LZ4 and xxHash (net.jpountz.lz4:lz4:1.3.0 - https://github.com/jpountz/lz4-java)
-	(Apache License, Version 2.0) * LZ4 and xxHash (org.lz4:lz4-java:1.8.0 - https://github.com/lz4/lz4-java)
-	(Apache License, Version 2.0) * Lucene Common Analyzers (org.apache.lucene:lucene-analyzers-common:8.11.2 - https://lucene.apache.org/lucene-parent/lucene-analyzers-common)
-	(Apache License, Version 2.0) * Lucene Core (org.apache.lucene:lucene-core:8.11.2 - https://lucene.apache.org/lucene-parent/lucene-core)
-	(Apache License, Version 2.0) * Lucene Smart Chinese Analyzer (org.apache.lucene:lucene-analyzers-smartcn:8.11.2 - https://lucene.apache.org/lucene-parent/lucene-analyzers-smartcn)
-	(Apache License, Version 2.0) * Metrics Core (com.codahale.metrics:metrics-core:3.0.2 - http://metrics.codahale.com/metrics-core/)
-	(Apache License, Version 2.0) * Metrics Core (io.dropwizard.metrics:metrics-core:3.1.5 - http://metrics.codahale.com/metrics-core/)
-	(Apache License, Version 2.0) * Metrics Core (io.dropwizard.metrics:metrics-core:4.0.2 - http://metrics.dropwizard.io/metrics-core)
-	(Apache License, Version 2.0) * Metrics Core (io.dropwizard.metrics:metrics-core:4.2.4 - https://metrics.dropwizard.io/metrics-core)
-	(Apache License, Version 2.0) * Metrics Integration for Jersey 3.x (io.dropwizard.metrics:metrics-jersey3:4.2.4 - https://metrics.dropwizard.io/metrics-jersey3)
-	(Apache License, Version 2.0) * Metrics Integration for Logback (io.dropwizard.metrics:metrics-logback:3.1.5 - http://metrics.codahale.com/metrics-logback/)
-	(Apache License, Version 2.0) * Netty/All-in-One (io.netty:netty-all:4.1.44.Final - https://netty.io/netty-all/)
-	(Apache License, Version 2.0) * Netty/All-in-One (io.netty:netty-all:4.1.61.Final - https://netty.io/netty-all/)
-	(Apache License, Version 2.0) * Nimbus JOSE+JWT (com.nimbusds:nimbus-jose-jwt:4.41.2 - https://bitbucket.org/connect2id/nimbus-jose-jwt)
-	(Apache License, Version 2.0) * Ning-compress-LZF (com.ning:compress-lzf:0.8.4 - http://github.com/ning/compress)
-	(Apache License, Version 2.0) * OHC core (org.caffinitas.ohc:ohc-core:0.7.4 - http://caffinitas.org/)
-	(Apache License, Version 2.0) * OHC core - Java8 optimization (org.caffinitas.ohc:ohc-core-j8:0.4.4 - http://caffinitas.org/)
-	(Apache License, Version 2.0) * Objenesis (org.objenesis:objenesis:2.6 - http://objenesis.org)
-	(Apache License, Version 2.0) * OpenTracing API (io.opentracing:opentracing-api:0.22.0 - https://github.com/opentracing/opentracing-java/opentracing-api)
-	(Apache License, Version 2.0) * OpenTracing-mock (io.opentracing:opentracing-mock:0.22.0 - https://github.com/opentracing/opentracing-java/opentracing-mock)
-	(Apache License, Version 2.0) * OpenTracing-noop (io.opentracing:opentracing-noop:0.22.0 - https://github.com/opentracing/opentracing-java/opentracing-noop)
-	(Apache License, Version 2.0) * OpenTracing-util (io.opentracing:opentracing-util:0.22.0 - https://github.com/opentracing/opentracing-java/opentracing-util)
-	(Apache License, Version 2.0) * SnakeYAML (org.yaml:snakeyaml:1.26 - http://www.snakeyaml.org)
-	(Apache License, Version 2.0) * SnakeYAML (org.yaml:snakeyaml:1.27 - http://www.snakeyaml.org)
-	(Apache License, Version 2.0) * Thrift Server implementation backed by LMAX Disruptor (com.thinkaurelius.thrift:thrift-server:0.3.7 - http://github.com/xedin/disruptor_thrift_server)
-	(Apache License, Version 2.0) * Token provider (org.apache.kerby:token-provider:2.0.0 - http://directory.apache.org/kerby/kerby-provider/token-provider)
-	(Apache License, Version 2.0) * ansj_seg (org.ansj:ansj_seg:5.1.6 - https://github.com/NLPchina/ansj_seg)
-	(Apache License, Version 2.0) * cli (io.airlift:airline:0.6 - https://github.com/airlift/airline)
-	(Apache License, Version 2.0) * com.alipay.sofa.common:sofa-common-tools (com.alipay.sofa.common:sofa-common-tools:1.0.12 - https://github.com/sofastack/sofa-common-tools)
-	(Apache License, Version 2.0) * com.alipay.sofa:bolt (com.alipay.sofa:bolt:1.6.4 - https://github.com/alipay/sofa-bolt)
-	(Apache License, Version 2.0) * com.alipay.sofa:hessian (com.alipay.sofa:hessian:3.3.6 - http://github.com/alipay/sofa-hessian)
-	(Apache License, Version 2.0) * com.alipay.sofa:sofa-rpc-all (com.alipay.sofa:sofa-rpc-all:5.7.6 - http://github.com/sofastack/sofa-rpc)
-	(Apache License, Version 2.0) * error-prone annotations (com.google.errorprone:error_prone_annotations:2.1.3 - http://nexus.sonatype.org/oss-repository-hosting.html/error_prone_parent/error_prone_annotations)
-	(Apache License, Version 2.0) * exp4j (net.objecthunter:exp4j:0.4.8 - http://www.objecthunter.net/exp4j)
-	(Apache License, Version 2.0) * fastutil (it.unimi.dsi:fastutil:8.5.9 - http://fastutil.di.unimi.it/)
-	(Apache License, Version 2.0) * htrace-core4 (org.apache.htrace:htrace-core4:4.2.0-incubating - http://incubator.apache.org/projects/htrace.html)
-	(Apache License, Version 2.0) * hugegraph-api (com.baidu.hugegraph:hugegraph-api:0.13.0 - https://github.com/hugegraph/hugegraph/hugegraph-api)
-	(Apache License, Version 2.0) * hugegraph-cassandra (com.baidu.hugegraph:hugegraph-cassandra:0.13.0 - https://github.com/hugegraph/hugegraph/hugegraph-cassandra)
-	(Apache License, Version 2.0) * hugegraph-common (com.baidu.hugegraph:hugegraph-common:2.1.2 - https://github.com/hugegraph/hugegraph-common)
-	(Apache License, Version 2.0) * hugegraph-core (com.baidu.hugegraph:hugegraph-core:0.13.0 - https://github.com/hugegraph/hugegraph/hugegraph-core)
-	(Apache License, Version 2.0) * hugegraph-dist (com.baidu.hugegraph:hugegraph-dist:0.13.0 - https://github.com/hugegraph/hugegraph/hugegraph-dist)
-	(Apache License, Version 2.0) * hugegraph-hbase (com.baidu.hugegraph:hugegraph-hbase:0.13.0 - https://github.com/hugegraph/hugegraph/hugegraph-hbase)
-	(Apache License, Version 2.0) * hugegraph-hbase-shaded-endpoint (com.baidu.hugegraph:hbase-shaded-endpoint:2.0.6 - https://github.com/hugegraph/hbase/tree/HBASE-26097/hbase-shaded/hbase-shaded-endpoint)
-	(Apache License, Version 2.0) * hugegraph-mysql (com.baidu.hugegraph:hugegraph-mysql:0.13.0 - https://github.com/hugegraph/hugegraph/hugegraph-mysql)
-	(Apache License, Version 2.0) * hugegraph-palo (com.baidu.hugegraph:hugegraph-palo:0.13.0 - https://github.com/hugegraph/hugegraph/hugegraph-palo)
-	(Apache License, Version 2.0) * hugegraph-postgresql (com.baidu.hugegraph:hugegraph-postgresql:0.13.0 - https://github.com/hugegraph/hugegraph/hugegraph-postgresql)
-	(Apache License, Version 2.0) * hugegraph-rocksdb (com.baidu.hugegraph:hugegraph-rocksdb:0.13.0 - https://github.com/hugegraph/hugegraph/hugegraph-rocksdb)
-	(Apache License, Version 2.0) * hugegraph-rpc (com.baidu.hugegraph:hugegraph-rpc:2.0.1 - https://github.com/hugegraph/hugegraph-commons/hugegraph-rpc)
-	(Apache License, Version 2.0) * hugegraph-scylladb (com.baidu.hugegraph:hugegraph-scylladb:0.13.0 - https://github.com/hugegraph/hugegraph/hugegraph-scylladb)
-	(Apache License, Version 2.0) * io.grpc:grpc-api (io.grpc:grpc-api:1.28.0 - https://github.com/grpc/grpc-java)
-	(Apache License, Version 2.0) * io.grpc:grpc-context (io.grpc:grpc-context:1.28.0 - https://github.com/grpc/grpc-java)
-	(Apache License, Version 2.0) * io.grpc:grpc-core (io.grpc:grpc-core:1.28.0 - https://github.com/grpc/grpc-java)
-	(Apache License, Version 2.0) * io.grpc:grpc-netty-shaded (io.grpc:grpc-netty-shaded:1.28.0 - https://github.com/grpc/grpc-java)
-	(Apache License, Version 2.0) * io.grpc:grpc-protobuf (io.grpc:grpc-protobuf:1.47.0 - https://github.com/grpc/grpc-java)
-	(Apache License, Version 2.0) * io.grpc:grpc-protobuf-lite (io.grpc:grpc-protobuf-lite:1.47.0 - https://github.com/grpc/grpc-java)
-	(Apache License, Version 2.0) * io.grpc:grpc-stub (io.grpc:grpc-stub:1.47.0 - https://github.com/grpc/grpc-java)
-	(Apache License, Version 2.0) * jackson-databind (com.fasterxml.jackson.core:jackson-databind:2.12.1 - http://github.com/FasterXML/jackson)
-	(Apache License, Version 2.0) * jackson-databind (com.fasterxml.jackson.core:jackson-databind:2.12.5 - http://github.com/FasterXML/jackson)
-	(Apache License, Version 2.0) * javatuples (org.javatuples:javatuples:1.2 - http://www.javatuples.org)
-	(Apache License, Version 2.0) * javax.inject (javax.inject:javax.inject:1 - http://code.google.com/p/atinject/)
-	(Apache License, Version 2.0) * jcseg-core (org.lionsoul:jcseg-core:2.6.2 - http://github.com/lionsoul2014/jcseg)
-	(Apache License, Version 2.0) * jffi (com.github.jnr:jffi:1.2.16 - http://github.com/jnr/jffi)
-	(Apache License, Version 2.0) * jnr-ffi (com.github.jnr:jnr-ffi:2.1.7 - http://github.com/jnr/jnr-ffi)
-	(Apache License, Version 2.0) * jraft-core 1.3.11 (com.alipay.sofa:jraft-core:1.3.11 - https://github.com/alipay/sofa-jraft/jraft-core)
-	(Apache License, Version 2.0) * lookout-api (com.alipay.sofa.lookout:lookout-api:1.4.1 - https://github.com/sofastack/sofa-lookout/lookout-api)
-	(Apache License, Version 2.0) * metrics reporter config 3.x (com.addthis.metrics:reporter-config3:3.0.3 - https://github.com/addthis/metrics-reporter-config/reporter-config3)
-	(Apache License, Version 2.0) * metrics reporter config base (com.addthis.metrics:reporter-config-base:3.0.3 - https://github.com/addthis/metrics-reporter-config/reporter-config-base)
-	(Apache License, Version 2.0) * mmseg4j-core (com.chenlb.mmseg4j:mmseg4j-core:1.10.0 - https://github.com/chenlb/mmseg4j-core)
-	(Apache License, Version 2.0) * nlp-lang (org.nlpcn:nlp-lang:1.7.7 - https://github.com/NLPchina/nlp-lang)
-	(Apache License, Version 2.0) * openCypher AST for the Cypher Query Language (org.opencypher:ast-9.0:9.0.20190305 - https://www.opencypher.org/ast-9.0)
-	(Apache License, Version 2.0) * openCypher Expressions (org.opencypher:expressions-9.0:9.0.20190305 - https://www.opencypher.org/expressions-9.0)
-	(Apache License, Version 2.0) * openCypher Front End (org.opencypher:front-end-9.0:9.0.20190305 - http://components.neo4j.org/front-end-9.0/9.0.20190305)
-	(Apache License, Version 2.0) * openCypher Parser (org.opencypher:parser-9.0:9.0.20190305 - https://www.opencypher.org/parser-9.0)
-	(Apache License, Version 2.0) * openCypher Rewriting (org.opencypher:rewriting-9.0:9.0.20190305 - https://www.opencypher.org/rewriting-9.0)
-	(Apache License, Version 2.0) * openCypher Utils (org.opencypher:util-9.0:9.0.20190305 - http://components.neo4j.org/util-9.0/9.0.20190305)
-	(Apache License, Version 2.0) * parboiled-core (org.parboiled:parboiled-core:1.2.0 - http://parboiled.org)
-	(Apache License, Version 2.0) * parboiled-scala (org.parboiled:parboiled-scala_2.12:1.2.0 - http://parboiled.org)
-	(Apache License, Version 2.0) * perfmark:perfmark-api (io.perfmark:perfmark-api:0.19.0 - https://github.com/perfmark/perfmark)
-	(Apache License, Version 2.0) * picocli - a mighty tiny Command Line Interface (info.picocli:picocli:4.3.2 - http://picocli.info)
-	(Apache License, Version 2.0) * proto-google-common-protos (com.google.api.grpc:proto-google-common-protos:2.0.1 - https://github.com/googleapis/java-iam/proto-google-common-protos)
-	(Apache License, Version 2.0) * sigar (org.fusesource:sigar:1.6.4 - http://fusesource.com/sigar/)
-	(Apache License, Version 2.0) * snappy-java (org.xerial.snappy:snappy-java:1.1.1.7 - https://github.comm/xerial/snappy-java)
-	(Apache License, Version 2.0) * stream-lib (com.clearspring.analytics:stream:2.5.2 - https://github.com/clearspring/stream-lib)
-	(Apache License, Version 2.0) * swagger-annotations (io.swagger:swagger-annotations:1.5.18 - https://github.com/swagger-api/swagger-core/modules/swagger-annotations)
-	(Apache License, Version 2.0) * swagger-annotations-jakarta (io.swagger.core.v3:swagger-annotations-jakarta:2.1.9 - https://github.com/swagger-api/swagger-core/modules/swagger-annotations-jakarta)
-	(Apache License, Version 2.0) * swagger-core (io.swagger:swagger-core:1.5.18 - https://github.com/swagger-api/swagger-core/modules/swagger-core)
-	(Apache License, Version 2.0) * swagger-core-jakarta (io.swagger.core.v3:swagger-core-jakarta:2.1.9 - https://github.com/swagger-api/swagger-core/modules/swagger-core-jakarta)
-	(Apache License, Version 2.0) * swagger-integration-jakarta (io.swagger.core.v3:swagger-integration-jakarta:2.1.9 - https://github.com/swagger-api/swagger-core/modules/swagger-integration-jakarta)
-	(Apache License, Version 2.0) * swagger-jaxrs2-jakarta (io.swagger.core.v3:swagger-jaxrs2-jakarta:2.1.9 - https://github.com/swagger-api/swagger-core/modules/swagger-jaxrs2-jakarta)
-	(Apache License, Version 2.0) * swagger-models (io.swagger:swagger-models:1.5.18 - https://github.com/swagger-api/swagger-core/modules/swagger-models)
-	(Apache License, Version 2.0) * swagger-models-jakarta (io.swagger.core.v3:swagger-models-jakarta:2.1.9 - https://github.com/swagger-api/swagger-core/modules/swagger-models-jakarta)
-	(Apache License, Version 2.0) * tracer-core (com.alipay.sofa:tracer-core:3.0.8 - https://projects.spring.io/spring-boot/#/spring-boot-starter-parent/sofaboot-dependencies/tracer-all-parent/tracer-core)
-	(Apache License, Version 2.0) * 结巴分词工具(jieba for java) (com.huaban:jieba-analysis:1.0.2 - http://maven.apache.org)
-	(Apache License, Version 2.0) * RocksDB JNI (org.rocksdb:rocksdbjni:7.2.2 - https://rocksdb.org)
-	(Apache License, Version 2.0) * Javassist (org.javassist:javassist:3.21.0-GA - http://www.javassist.org/)
+    com.addthis.metrics:reporter-config-base 3.0.3 Apache-2.0
+    com.addthis.metrics:reporter-config3 3.0.3 Apache-2.0
+    com.alipay.sofa.common:sofa-common-tools 1.0.12 Apache-2.0
+    com.alipay.sofa.lookout:lookout-api 1.4.1 Apache-2.0
+    com.alipay.sofa:bolt 1.6.4 Apache-2.0
+    com.alipay.sofa:hessian 3.3.6 Apache-2.0
+    com.alipay.sofa:jraft-core 1.3.11 Apache-2.0
+    com.alipay.sofa:sofa-rpc-all 5.7.6 Apache-2.0
+    com.alipay.sofa:tracer-core 3.0.8 Apache-2.0
+    com.carrotsearch:hppc 0.7.1 Apache-2.0
+    com.chenlb.mmseg4j:mmseg4j-core 1.10.0 Apache-2.0
+    com.clearspring.analytics:stream 2.5.2 Apache-2.0
+    com.datastax.cassandra:cassandra-driver-core 3.6.0 Apache-2.0
+    com.fasterxml.jackson.core:jackson-annotations 2.14.0-rc1 Apache-2.0
+    com.fasterxml.jackson.core:jackson-annotations 2.12.5 Apache-2.0
+    com.fasterxml.jackson.core:jackson-core 2.14.0-rc1 Apache-2.0
+    com.fasterxml.jackson.core:jackson-core 2.12.5 Apache-2.0
+    com.fasterxml.jackson.core:jackson-databind 2.14.0-rc1 Apache-2.0
+    com.fasterxml.jackson.core:jackson-databind 2.12.1 Apache-2.0
+    com.fasterxml.jackson.core:jackson-databind 2.12.5 Apache-2.0
+    com.fasterxml.jackson.dataformat:jackson-dataformat-yaml 2.9.3 Apache-2.0
+    com.fasterxml.jackson.datatype:jackson-datatype-jsr310 2.12.1 Apache-2.0
+    com.fasterxml.jackson.jaxrs:jackson-jaxrs-base 2.14.0-rc1 Apache-2.0
+    com.fasterxml.jackson.jaxrs:jackson-jaxrs-json-provider 2.14.0-rc1 Apache-2.0
+    com.fasterxml.jackson.jaxrs:jackson-jaxrs-json-provider 2.12.1 Apache-2.0
+    com.fasterxml.jackson.module:jackson-module-jaxb-annotations 2.14.0-rc1 Apache-2.0
+    com.github.ben-manes.caffeine:caffeine 2.3.1 Apache-2.0
+    com.github.ben-manes.caffeine:caffeine 2.2.6 Apache-2.0
+    com.github.jbellis:jamm 0.3.0 Apache-2.0
+    com.github.jnr:jffi 1.2.16 Apache-2.0
+    com.github.jnr:jnr-ffi 2.1.7 Apache-2.0
+    com.github.stephenc.findbugs:findbugs-annotations 1.3.9-1 Apache-2.0
+    com.github.stephenc.jcip:jcip-annotations 1.0-1 Apache-2.0
+    com.google.android:annotations 4.1.1.4 Apache-2.0
+    com.google.code.findbugs:jsr305 3.0.1 Apache-2.0
+    com.google.code.gson:gson 2.8.6 Apache-2.0
+    com.google.errorprone:error_prone_annotations 2.1.3 Apache-2.0
+    com.google.guava:guava 25.1-jre Apache-2.0
+    com.google.j2objc:j2objc-annotations 1.1 Apache-2.0
+    com.googlecode.concurrent-trees:concurrent-trees 2.4.0 Apache-2.0
+    com.googlecode.concurrentlinkedhashmap:concurrentlinkedhashmap-lru 1.4 Apache-2.0
+    com.googlecode.json-simple:json-simple 1.1 Apache-2.0
+    com.huaban:jieba-analysis 1.0.2 Apache-2.0
+    com.janeluo:ikanalyzer 2012_u6 Apache-2.0
+    com.lmax:disruptor 3.3.7 Apache-2.0
+    com.nimbusds:nimbus-jose-jwt 4.41.2 Apache-2.0
+    com.squareup:javapoet 1.8.0 Apache-2.0
+    com.thinkaurelius.thrift:thrift-server 0.3.7 Apache-2.0
+    commons-beanutils:commons-beanutils 1.9.4 Apache-2.0
+    commons-cli:commons-cli 1.1 Apache-2.0
+    commons-codec:commons-codec 1.13 Apache-2.0
+    commons-codec:commons-codec 1.9 Apache-2.0
+    commons-codec:commons-codec 1.11 Apache-2.0
+    commons-codec:commons-codec 1.15 Apache-2.0
+    commons-collections:commons-collections 3.2.2 Apache-2.0
+    commons-configuration:commons-configuration 1.10 Apache-2.0
+    commons-io:commons-io 2.7 Apache-2.0
+    commons-lang:commons-lang 2.6 Apache-2.0
+    commons-logging:commons-logging 1.1.1 Apache-2.0
+    commons-logging:commons-logging 1.2 Apache-2.0
+    info.picocli:picocli 4.3.2 Apache-2.0
+    io.airlift:airline 0.6 Apache-2.0
+    io.grpc:grpc-api 1.28.0 Apache-2.0
+    io.grpc:grpc-context 1.28.0 Apache-2.0
+    io.grpc:grpc-core 1.28.0 Apache-2.0
+    io.grpc:grpc-netty-shaded 1.28.0 Apache-2.0
+    io.jsonwebtoken:jjwt-api 0.11.5 Apache-2.0
+    io.jsonwebtoken:jjwt-impl 0.11.5 Apache-2.0
+    io.jsonwebtoken:jjwt-jackson 0.11.5 Apache-2.0
+    io.netty:netty-all 4.1.61.Final Apache-2.0
+    io.netty:netty-all 4.1.44.Final Apache-2.0
+    io.opentracing:opentracing-api 0.22.0 Apache-2.0
+    io.opentracing:opentracing-mock 0.22.0 Apache-2.0
+    io.opentracing:opentracing-noop 0.22.0 Apache-2.0
+    io.opentracing:opentracing-util 0.22.0 Apache-2.0
+    io.perfmark:perfmark-api 0.19.0 Apache-2.0
+    io.swagger.core.v3:swagger-annotations-jakarta 2.1.9 Apache-2.0
+    io.swagger.core.v3:swagger-models-jakarta 2.1.9 Apache-2.0
+    io.swagger:swagger-annotations 1.5.18 Apache-2.0
+    io.swagger:swagger-models 1.5.18 Apache-2.0
+    jakarta.inject:jakarta.inject-api 2.0.0 Apache-2.0
+    jakarta.validation:jakarta.validation-api 3.0.0 Apache-2.0
+    javax.inject:javax.inject 1 Apache-2.0
+    javax.validation:validation-api 1.1.0.Final Apache-2.0
+    joda-time:joda-time 2.10.8 Apache-2.0
+    joda-time:joda-time 2.4 Apache-2.0
+    net.bytebuddy:byte-buddy 1.10.5 Apache-2.0
+    net.bytebuddy:byte-buddy-agent 1.10.5 Apache-2.0
+    net.jpountz.lz4:lz4 1.3.0 Apache-2.0
+    net.minidev:accessors-smart 1.2 Apache-2.0
+    net.minidev:json-smart 2.3 Apache-2.0
+    net.objecthunter:exp4j 0.4.8 Apache-2.0
+    org.ansj:ansj_seg 5.1.6 Apache-2.0
+    org.antlr:antlr-runtime 3.5.2 Apache-2.0
+    org.apache.cassandra:cassandra-all 3.11.12 Apache-2.0
+    org.apache.commons:commons-compress 1.21 Apache-2.0
+    org.apache.commons:commons-configuration2 2.8.0 Apache-2.0
+    org.apache.commons:commons-lang3 3.11 Apache-2.0
+    org.apache.commons:commons-lang3 3.1 Apache-2.0
+    org.apache.commons:commons-text 1.10.0 Apache-2.0
+    org.apache.htrace:htrace-core4 4.2.0-incubating Apache-2.0
+    org.apache.httpcomponents:httpclient 4.5.13 Apache-2.0
+    org.apache.httpcomponents:httpcore 4.4.13 Apache-2.0
+    org.apache.kerby:kerb-admin 2.0.0 Apache-2.0
+    org.apache.kerby:kerb-client 2.0.0 Apache-2.0
+    org.apache.kerby:kerb-common 2.0.0 Apache-2.0
+    org.apache.kerby:kerb-core 2.0.0 Apache-2.0
+    org.apache.kerby:kerb-crypto 2.0.0 Apache-2.0
+    org.apache.kerby:kerb-identity 2.0.0 Apache-2.0
+    org.apache.kerby:kerb-server 2.0.0 Apache-2.0
+    org.apache.kerby:kerb-simplekdc 2.0.0 Apache-2.0
+    org.apache.kerby:kerb-util 2.0.0 Apache-2.0
+    org.apache.kerby:kerby-asn1 2.0.0 Apache-2.0
+    org.apache.kerby:kerby-config 2.0.0 Apache-2.0
+    org.apache.kerby:kerby-pkix 2.0.0 Apache-2.0
+    org.apache.kerby:kerby-util 2.0.0 Apache-2.0
+    org.apache.kerby:kerby-xdr 2.0.0 Apache-2.0
+    org.apache.kerby:token-provider 2.0.0 Apache-2.0
+    org.apache.logging.log4j:log4j-api 2.17.1 Apache-2.0
+    org.apache.logging.log4j:log4j-core 2.17.1 Apache-2.0
+    org.apache.logging.log4j:log4j-slf4j-impl 2.17.1 Apache-2.0
+    org.apache.tinkerpop:gremlin-console 3.5.1 Apache-2.0
+    org.apache.tinkerpop:gremlin-core 3.5.1 Apache-2.0
+    org.apache.tinkerpop:gremlin-driver 3.5.1 Apache-2.0
+    org.apache.tinkerpop:gremlin-groovy 3.5.1 Apache-2.0
+    org.apache.tinkerpop:gremlin-groovy-test 3.2.11 Apache-2.0
+    org.apache.tinkerpop:gremlin-server 3.5.1 Apache-2.0
+    org.apache.tinkerpop:gremlin-shaded 3.5.1 Apache-2.0
+    org.apache.tinkerpop:gremlin-test 3.5.1 Apache-2.0
+    org.apache.tinkerpop:tinkergraph-gremlin 3.5.1 Apache-2.0
+    org.apache.yetus:audience-annotations 0.5.0 Apache-2.0
+    org.caffinitas.ohc:ohc-core 0.7.4 Apache-2.0
+    org.caffinitas.ohc:ohc-core-j8 0.4.4 Apache-2.0
+    org.codehaus.groovy:groovy 2.5.14 Apache-2.0
+    org.codehaus.groovy:groovy-cli-picocli 2.5.14 Apache-2.0
+    org.codehaus.groovy:groovy-console 2.5.14 Apache-2.0
+    org.codehaus.groovy:groovy-groovysh 2.5.14 Apache-2.0
+    org.codehaus.groovy:groovy-json 2.5.14 Apache-2.0
+    org.codehaus.groovy:groovy-jsr223 2.5.14 Apache-2.0
+    org.codehaus.groovy:groovy-swing 2.5.14 Apache-2.0
+    org.codehaus.groovy:groovy-templates 2.5.14 Apache-2.0
+    org.codehaus.groovy:groovy-xml 2.5.14 Apache-2.0
+    org.fusesource:sigar 1.6.4 Apache-2.0
+    org.javatuples:javatuples 1.2 Apache-2.0
+    org.jctools:jctools-core 2.1.1 Apache-2.0
+    org.jctools:jctools-core 1.2.1 Apache-2.0
+    org.lionsoul:jcseg-core 2.6.2 Apache-2.0
+    org.lz4:lz4-java 1.8.0 Apache-2.0
+    org.nlpcn:nlp-lang 1.7.7 Apache-2.0
+    org.objenesis:objenesis 2.6 Apache-2.0
+    org.opencypher.gremlin:cypher-gremlin-extensions 1.0.4 Apache-2.0
+    org.opencypher.gremlin:translation 1.0.4 Apache-2.0
+    org.opencypher:ast-9.0 9.0.20190305 Apache-2.0
+    org.opencypher:expressions-9.0 9.0.20190305 Apache-2.0
+    org.opencypher:front-end-9.0 9.0.20190305 Apache-2.0
+    org.opencypher:parser-9.0 9.0.20190305 Apache-2.0
+    org.opencypher:rewriting-9.0 9.0.20190305 Apache-2.0
+    org.opencypher:util-9.0 9.0.20190305 Apache-2.0
+    org.parboiled:parboiled-core 1.2.0 Apache-2.0
+    org.parboiled:parboiled-scala_2.12 1.2.0 Apache-2.0
+    org.slf4j:jcl-over-slf4j 1.7.25 Apache-2.0
+    org.slf4j:slf4j-api 1.7.25 Apache-2.0
+    org.slf4j:slf4j-api 1.7.7 Apache-2.0
+    org.xerial.snappy:snappy-java 1.1.1.7 Apache-2.0
+    org.yaml:snakeyaml 1.27 Apache-2.0
+    org.yaml:snakeyaml 1.26 Apache-2.0
 
 ========================================================================
-Third party CDDL licenses
+Apache-2.0 and BSD-2-Clause and BSD-3-Clause licenses
 ========================================================================
 
-The following components are provided under the CDDL License.
-See licenses/ for text of these licenses.
-	(CDDL) * JavaBeans Activation Framework API jar (javax.activation:javax.activation-api:1.2.0 - http://java.net/all/javax.activation-api/)
-	(CDDL 1.1) * jaxb-api (javax.xml.bind:jaxb-api:2.3.1 - https://github.com/javaee/jaxb-spec/jaxb-api)
-	(Dual license consisting of the CDDL v1.1) * JSR 353 (JSON Processing) Default Provider (org.glassfish:javax.json:1.0 - http://jsonp.java.net)
+    org.apache.commons:commons-math3 3.2 Apache-2.0 and BSD-2-Clause and BSD-3-Clause
 
 ========================================================================
-Third party EPL licenses
+Apache-2.0 and BSD-3-Clause and BSD-2-Clause and MIT and EPL-1.0 licenses
 ========================================================================
 
-The following components are provided under the EPL License.
-See licenses/ for text of these licenses.
-	(Eclipse Public License - v1.0) * JUnit (junit:junit:4.12 - http://junit.org)
-	(Eclipse Public License - v2.0) * HK2 API module (org.glassfish.hk2:hk2-api:3.0.1 - https://github.com/eclipse-ee4j/glassfish-hk2/hk2-api)
-	(Eclipse Public License - v2.0) * HK2 Implementation Utilities (org.glassfish.hk2:hk2-utils:3.0.1 - https://github.com/eclipse-ee4j/glassfish-hk2/hk2-utils)
-	(Eclipse Public License - v2.0) * Jakarta Annotations API (jakarta.annotation:jakarta.annotation-api:2.0.0 - https://projects.eclipse.org/projects/ee4j.ca)
-	(Eclipse Public License - v2.0) * Jakarta Servlet (jakarta.servlet:jakarta.servlet-api:5.0.0 - https://projects.eclipse.org/projects/ee4j.servlet)
-	(Eclipse Public License - v2.0) * OSGi resource locator (org.glassfish.hk2:osgi-resource-locator:1.0.3 - https://projects.eclipse.org/projects/ee4j/osgi-resource-locator)
-	(Eclipse Public License - v2.0) * ServiceLocator Default Implementation (org.glassfish.hk2:hk2-locator:3.0.1 - https://github.com/eclipse-ee4j/glassfish-hk2/hk2-locator)
-	(Eclipse Public License - v2.0) * aopalliance version 1.0 repackaged as a module (org.glassfish.hk2.external:aopalliance-repackaged:3.0.1 - https://github.com/eclipse-ee4j/glassfish-hk2/external/aopalliance-repackaged)
-	(Eclipse Public License - v2.0) * grizzly-framework (org.glassfish.grizzly:grizzly-framework:3.0.1 - https://projects.eclipse.org/projects/ee4j.grizzly/grizzly-framework)
-	(Eclipse Public License - v2.0) * grizzly-http (org.glassfish.grizzly:grizzly-http:3.0.1 - https://projects.eclipse.org/projects/ee4j.grizzly/grizzly-http)
-	(Eclipse Public License - v2.0) * grizzly-http-server (org.glassfish.grizzly:grizzly-http-server:3.0.1 - https://projects.eclipse.org/projects/ee4j.grizzly/grizzly-http-server)
-	(Eclipse Public License - v2.0) * grizzly-http-servlet (org.glassfish.grizzly:grizzly-http-servlet:3.0.1 - https://projects.eclipse.org/projects/ee4j.grizzly/grizzly-http-servlet)
-	(Eclipse Public License - v2.0) * jakarta.ws.rs-api (jakarta.ws.rs:jakarta.ws.rs-api:3.0.0 - https://github.com/eclipse-ee4j/jaxrs-api)
+    com.baidu.hugegraph:hbase-shaded-endpoint 2.0.6 Apache-2.0 and BSD-3-Clause and BSD-2-Clause and MIT and EPL-1.0
 
 ========================================================================
-Third party EDL licenses
+Apache-2.0 and BSD-3-Clause and MIT licenses
 ========================================================================
 
-The following components are provided under the EDL License.
-See licenses/ for text of these licenses.
-	(Eclipse Distribution License - v1.0) * Eclipse Collections API (org.eclipse.collections:eclipse-collections-api:11.1.0 - https://github.com/eclipse/eclipse-collections/eclipse-collections-api)
-	(Eclipse Distribution License - v1.0) * Eclipse Collections Main Library (org.eclipse.collections:eclipse-collections:11.1.0 - https://github.com/eclipse/eclipse-collections/eclipse-collections)
-	(Eclipse Distribution License - v1.0) * Jakarta Activation (com.sun.activation:jakarta.activation:2.0.1 - https://github.com/eclipse-ee4j/jaf/jakarta.activation)
-	(Eclipse Distribution License - v1.0) * Jakarta XML Binding API (jakarta.xml.bind:jakarta.xml.bind-api:4.0.0-RC2 - https://github.com/eclipse-ee4j/jaxb-api/jakarta.xml.bind-api)
-	(Eclipse Distribution License - v1.0) * JavaBeans Activation Framework API jar (jakarta.activation:jakarta.activation-api:1.2.1 - https://github.com/eclipse-ee4j/jaf/jakarta.activation-api)
-	(Eclipse Distribution License - v1.0) * Old JAXB Core (com.sun.xml.bind:jaxb-core:3.0.2 - https://eclipse-ee4j.github.io/jaxb-ri/)
-	(Eclipse Distribution License - v1.0) * Old JAXB Runtime (com.sun.xml.bind:jaxb-impl:3.0.2 - https://eclipse-ee4j.github.io/jaxb-ri/)
-
+    org.apache.ivy:ivy 2.4.0 Apache-2.0 and BSD-3-Clause and MIT
 
 ========================================================================
-Third party BSD licenses
+Apache-2.0 and BSD-3-Clause and MIT and ICU and BSD-2-Clause licenses
 ========================================================================
 
-The following components are provided under the BSD License.
-See licenses/ for text of these licenses.
-	(The 2-Clause BSD License) * ANTLR 3 Runtime (org.antlr:antlr-runtime:3.5.2 - http://www.antlr.org)
-	(The 2-Clause BSD License) * ASM Analysis (org.ow2.asm:asm-analysis:5.0.3 - http://asm.objectweb.org/asm-analysis/)
-	(The 2-Clause BSD License) * ASM Commons (org.ow2.asm:asm-commons:5.0.3 - http://asm.objectweb.org/asm-commons/)
-	(The 2-Clause BSD License) * ASM Core (org.ow2.asm:asm:5.0.4 - http://asm.objectweb.org/asm/)
-	(The 2-Clause BSD License) * ASM Core (org.ow2.asm:asm:6.0 - http://asm.objectweb.org/asm/)
-	(The 2-Clause BSD License) * ASM Tree (org.ow2.asm:asm-tree:5.0.3 - http://asm.objectweb.org/asm-tree/)
-	(The 2-Clause BSD License) * ASM Util (org.ow2.asm:asm-util:5.0.3 - http://asm.objectweb.org/asm-util/)
-	(The 2-Clause BSD License) * JFlex (de.jflex:jflex:1.6.0 - http://jflex.de/)
-	(The 2-Clause BSD License) * JLine (jline:jline:2.14.6 - http://nexus.sonatype.org/oss-repository-hosting.html/jline)
-	(The 2-Clause BSD License) * PostgreSQL JDBC Driver (org.postgresql:postgresql:42.4.1 - https://jdbc.postgresql.org)
-	(The 2-Clause BSD License) * StringTemplate 4 (org.antlr:ST4:4.0.8 - http://www.stringtemplate.org)
-	(The 2-Clause BSD License) * jcabi-log (com.jcabi:jcabi-log:0.14 - http://www.jcabi.com/jcabi-log)
-	(The 2-Clause BSD License) * jcabi-manifests (com.jcabi:jcabi-manifests:1.1 - http://www.jcabi.com/jcabi-manifests)
-	(The 2-Clause BSD License) * snowball-stemmer (com.github.rholder:snowball-stemmer:1.3.0.581.1 - http://snowball.tartarus.org/)
-	(The 3-Clause BSD License) * Hamcrest (org.hamcrest:hamcrest:2.2 - http://hamcrest.org/JavaHamcrest/)
-	(The 3-Clause BSD License) * Hamcrest Core (org.hamcrest:hamcrest-core:1.3 - https://github.com/hamcrest/JavaHamcrest/hamcrest-core)
-	(The 3-Clause BSD License) * Protocol Buffers [Core] (com.google.protobuf:protobuf-java:3.21.7 - https://developers.google.com/protocol-buffers/protobuf-java/)
-	(The 3-Clause BSD License) * Scala Compiler (org.scala-lang:scala-reflect:2.12.7 - http://www.scala-lang.org/)
-	(The 3-Clause BSD License) * Scala Library (org.scala-lang:scala-library:2.12.7 - http://www.scala-lang.org/)
-	(The 3-Clause BSD License) * scala-java8-compat (org.scala-lang.modules:scala-java8-compat_2.12:0.8.0 - http://www.scala-lang.org/)
+    org.apache.lucene:lucene-analyzers-common 8.11.2 Apache-2.0 and BSD-3-Clause and MIT and ICU and BSD-2-Clause
+    org.apache.lucene:lucene-analyzers-smartcn 8.11.2 Apache-2.0 and BSD-3-Clause and MIT and ICU and BSD-2-Clause
+    org.apache.lucene:lucene-core 8.11.2 Apache-2.0 and BSD-3-Clause and MIT and ICU and BSD-2-Clause
+    org.apache.lucene:lucene-queries 4.7.2 Apache-2.0 and BSD-3-Clause and MIT and ICU and BSD-2-Clause
+    org.apache.lucene:lucene-queryparser 4.7.2 Apache-2.0 and BSD-3-Clause and MIT and ICU and BSD-2-Clause
+    org.apache.lucene:lucene-sandbox 4.7.2 Apache-2.0 and BSD-3-Clause and MIT and ICU and BSD-2-Clause
 
 ========================================================================
-Third party MIT licenses
+Apache-2.0 and Zlib licenses
 ========================================================================
 
-The following components are provided under the MIT License.
-See licenses/ for text of these licenses.
-	(The MIT License) * Animal Sniffer Annotations (org.codehaus.mojo:animal-sniffer-annotations:1.14 - http://mojo.codehaus.org/animal-sniffer/animal-sniffer-annotations)
-	(The MIT License) * Checker Qual (org.checkerframework:checker-qual:3.5.0 - https://checkerframework.org)
-	(The MIT License) * ClassGraph (io.github.classgraph:classgraph:4.8.95 - https://github.com/classgraph/classgraph)
-	(The MIT License) * JCL 1.2 implemented over SLF4J (org.slf4j:jcl-over-slf4j:1.7.25 - http://www.slf4j.org)
-	(The MIT License) * SLF4J API Module (org.slf4j:slf4j-api:1.7.25 - http://www.slf4j.org)
-	(The MIT License) * SLF4J API Module (org.slf4j:slf4j-api:1.7.7 - http://www.slf4j.org)
-	(The MIT License) * fastparse_2.12 (com.lihaoyi:fastparse_2.12:2.0.4 - https://github.com/lihaoyi/fastparse)
-	(The MIT License) * high-scale-lib (com.boundary:high-scale-lib:1.0.6 - https://github.com/boundary/high-scale-lib)
-	(The MIT License) * jnr-x86asm (com.github.jnr:jnr-x86asm:1.0.2 - http://github.com/jnr/jnr-x86asm)
-	(The MIT License) * mockito-core (org.mockito:mockito-core:3.3.3 - https://github.com/mockito/mockito)
-	(The MIT License) * sourcecode (com.lihaoyi:sourcecode_2.12:0.1.4 - https://github.com/lihaoyi/sourcecode)
-	(The MIT License) * Checker Qual (org.checkerframework:checker-qual:2.0.0 - http://checkerframework.org)
+    org.apache.thrift:libthrift 0.9.2 Apache-2.0 and Zlib
 
 ========================================================================
-Third party Public Domain licenses
+BSD-2-Clause licenses
 ========================================================================
 
-The following components are provided under the Public Domain License.
-	(Public Domain, per Creative Commons CC0) * HdrHistogram (org.hdrhistogram:HdrHistogram:2.1.9 - http://hdrhistogram.github.io/HdrHistogram/)
-
+    org.postgresql:postgresql 42.4.1 BSD-2-Clause
 
 ========================================================================
-Third party ISC licenses
+BSD-3-Clause licenses
 ========================================================================
 
-The following components are provided under the ISC License.
-	(ISC) * jBCrypt (org.mindrot:jbcrypt:0.4 - https://github.com/djmdjm/jBCrypt)
+    com.google.protobuf:protobuf-java 3.21.7 BSD-3-Clause
+    com.jcabi:jcabi-log 0.14 BSD-3-Clause
+    com.jcabi:jcabi-manifests 1.1 BSD-3-Clause
+    com.sun.activation:jakarta.activation 2.0.1 BSD-3-Clause
+    com.sun.xml.bind:jaxb-core 3.0.2 BSD-3-Clause
+    com.sun.xml.bind:jaxb-impl 3.0.2 BSD-3-Clause
+    de.jflex:jflex 1.6.0 BSD-3-Clause
+    jakarta.activation:jakarta.activation-api 1.2.2 BSD-3-Clause
+    jakarta.xml.bind:jakarta.xml.bind-api 4.0.0-RC2 BSD-3-Clause
+    org.eclipse.collections:eclipse-collections 11.1.0 BSD-3-Clause
+    org.eclipse.collections:eclipse-collections-api 11.1.0 BSD-3-Clause
+    org.hamcrest:hamcrest 2.2 BSD-3-Clause
+    org.hamcrest:hamcrest-core 1.3 BSD-3-Clause
+    org.ow2.asm:asm 6.0 BSD-3-Clause
+    org.ow2.asm:asm 5.0.4 BSD-3-Clause
+    org.ow2.asm:asm-analysis 5.0.3 BSD-3-Clause
+    org.ow2.asm:asm-commons 5.0.3 BSD-3-Clause
+    org.ow2.asm:asm-tree 5.0.3 BSD-3-Clause
+    org.ow2.asm:asm-util 5.0.3 BSD-3-Clause
+    org.scala-lang.modules:scala-java8-compat_2.12 0.8.0 BSD-3-Clause
+
+========================================================================
+CC0-1.0 licenses
+========================================================================
+
+    org.hdrhistogram:HdrHistogram 2.1.9 CC0-1.0
+
+========================================================================
+CDDL-1.1 and GPL-2.0 licenses
+========================================================================
+
+    javax.xml.bind:jaxb-api 2.3.1 CDDL-1.1 and GPL-2.0
+
+========================================================================
+CDDL-1.1 and GPL-2.0 and Apache-2.0 licenses
+========================================================================
+
+    javax.activation:javax.activation-api 1.2.0 CDDL-1.1 and GPL-2.0 and Apache-2.0
+
+========================================================================
+EPL-1.0 licenses
+========================================================================
+
+    junit:junit 4.12 EPL-1.0
+
+========================================================================
+EPL-2.0 and GPL-2.0 licenses
+========================================================================
+
+    jakarta.annotation:jakarta.annotation-api 2.0.0 EPL-2.0 and GPL-2.0
+    jakarta.ws.rs:jakarta.ws.rs-api 3.0.0 EPL-2.0 and GPL-2.0
+    org.glassfish.grizzly:grizzly-framework 3.0.1 EPL-2.0 and GPL-2.0
+    org.glassfish.grizzly:grizzly-http 3.0.1 EPL-2.0 and GPL-2.0
+    org.glassfish.grizzly:grizzly-http-server 3.0.1 EPL-2.0 and GPL-2.0
+    org.glassfish.hk2.external:aopalliance-repackaged 3.0.1 EPL-2.0 and GPL-2.0
+    org.glassfish.hk2:hk2-api 3.0.1 EPL-2.0 and GPL-2.0
+    org.glassfish.hk2:hk2-locator 3.0.1 EPL-2.0 and GPL-2.0
+    org.glassfish.hk2:hk2-utils 3.0.1 EPL-2.0 and GPL-2.0
+    org.glassfish.jersey.connectors:jersey-apache-connector 3.0.3 EPL-2.0 and GPL-2.0
+    org.glassfish.jersey.containers:jersey-container-grizzly2-http 3.0.3 EPL-2.0 and GPL-2.0
+    org.glassfish.jersey.containers:jersey-container-grizzly2-servlet 3.0.3 EPL-2.0 and GPL-2.0
+    org.glassfish.jersey.containers:jersey-container-servlet 3.0.3 EPL-2.0 and GPL-2.0
+    org.glassfish.jersey.containers:jersey-container-servlet-core 3.0.3 EPL-2.0 and GPL-2.0
+    org.glassfish.jersey.core:jersey-client 3.0.3 EPL-2.0 and GPL-2.0
+    org.glassfish.jersey.core:jersey-common 3.0.3 EPL-2.0 and GPL-2.0
+    org.glassfish.jersey.core:jersey-server 3.0.3 EPL-2.0 and GPL-2.0
+    org.glassfish.jersey.ext:jersey-entity-filtering 3.0.3 EPL-2.0 and GPL-2.0
+    org.glassfish.jersey.inject:jersey-hk2 3.0.3 EPL-2.0 and GPL-2.0
+    org.glassfish.jersey.media:jersey-media-jaxb 3.0.3 EPL-2.0 and GPL-2.0
+    org.glassfish.jersey.media:jersey-media-json-jackson 3.0.3 EPL-2.0 and GPL-2.0
+    org.glassfish.jersey.test-framework.providers:jersey-test-framework-provider-grizzly2 3.0.3 EPL-2.0 and GPL-2.0
+    org.glassfish.jersey.test-framework:jersey-test-framework-core 3.0.3 EPL-2.0 and GPL-2.0
+
+========================================================================
+GPL-2.0-with-classpath-exception and MIT licenses
+========================================================================
+
+    org.checkerframework:checker-qual 2.0.0 GPL-2.0-with-classpath-exception and MIT
+
+========================================================================
+MIT licenses
+========================================================================
+
+    com.boundary:high-scale-lib 1.0.6 MIT
+    com.github.jnr:jnr-x86asm 1.0.2 MIT
+    io.github.classgraph:classgraph 4.8.95 MIT
+    org.checkerframework:checker-qual 3.5.0 MIT
+    org.codehaus.mojo:animal-sniffer-annotations 1.14 MIT
+    org.mockito:mockito-core 3.3.3 MIT
+
+========================================================================
+MPL-1.1 and LGPL-2.1 licenses
+========================================================================
+
+    org.javassist:javassist 3.21.0-GA MPL-1.1 and LGPL-2.1
+
+========================================================================
+http://antlr.org/license.html licenses
+========================================================================
+
+    org.antlr:ST4 4.0.8 http://antlr.org/license.html
+
+========================================================================
+http://www.apache.org/licenses/LICENSE-2.0.html licenses
+========================================================================
+
+    com.codahale.metrics:metrics-core 3.0.2 http://www.apache.org/licenses/LICENSE-2.0.html
+    com.ning:compress-lzf 0.8.4 http://www.apache.org/licenses/LICENSE-2.0.html
+    io.dropwizard.metrics:metrics-core 4.0.2 http://www.apache.org/licenses/LICENSE-2.0.html
+    io.dropwizard.metrics:metrics-core 3.1.5 http://www.apache.org/licenses/LICENSE-2.0.html
+    io.dropwizard.metrics:metrics-jvm 3.1.5 http://www.apache.org/licenses/LICENSE-2.0.html
+    io.dropwizard.metrics:metrics-logback 3.1.5 http://www.apache.org/licenses/LICENSE-2.0.html
+    io.swagger:swagger-core 1.5.18 http://www.apache.org/licenses/LICENSE-2.0.html
+    it.unimi.dsi:fastutil 8.5.9 http://www.apache.org/licenses/LICENSE-2.0.html
+
+========================================================================
+http://www.apache.org/licenses/LICENSE-2.0.html and http://www.gnu.org/licenses/gpl-2.0.html licenses
+========================================================================
+
+    org.rocksdb:rocksdbjni 7.2.2 http://www.apache.org/licenses/LICENSE-2.0.html and http://www.gnu.org/licenses/gpl-2.0.html
+
+========================================================================
+http://www.apache.org/licenses/LICENSE-2.0.html" licenses
+========================================================================
+
+    io.swagger.core.v3:swagger-core-jakarta 2.1.9 http://www.apache.org/licenses/LICENSE-2.0.html"
+    io.swagger.core.v3:swagger-integration-jakarta 2.1.9 http://www.apache.org/licenses/LICENSE-2.0.html"
+    io.swagger.core.v3:swagger-jaxrs2-jakarta 2.1.9 http://www.apache.org/licenses/LICENSE-2.0.html"
+
+========================================================================
+http://www.eclipse.org/legal/epl-2.0 licenses
+========================================================================
+
+    org.glassfish.grizzly:grizzly-http-servlet 3.0.1 http://www.eclipse.org/legal/epl-2.0
+
+========================================================================
+http://www.eclipse.org/legal/epl-2.0, https://www.gnu.org/software/classpath/license.html licenses
+========================================================================
+
+    jakarta.servlet:jakarta.servlet-api 5.0.0 http://www.eclipse.org/legal/epl-2.0, https://www.gnu.org/software/classpath/license.html
+    org.glassfish.hk2:osgi-resource-locator 1.0.3 http://www.eclipse.org/legal/epl-2.0, https://www.gnu.org/software/classpath/license.html
+
+========================================================================
+http://www.opensource.org/licenses/bsd-license.html  licenses
+========================================================================
+
+    com.github.rholder:snowball-stemmer 1.3.0.581.1 http://www.opensource.org/licenses/bsd-license.html
+
+========================================================================
+http://www.opensource.org/licenses/bsd-license.php licenses
+========================================================================
+
+    jline:jline 2.14.6 http://www.opensource.org/licenses/bsd-license.php
+
+========================================================================
+http://www.opensource.org/licenses/mit-license.html;description=MIT licenses
+========================================================================
+
+    com.lihaoyi:sourcecode_2.12 0.1.4 http://www.opensource.org/licenses/mit-license.html;description=MIT
+
+========================================================================
+http://www.scala-lang.org/license.html licenses
+========================================================================
+
+    org.scala-lang:scala-library 2.12.7 http://www.scala-lang.org/license.html
+    org.scala-lang:scala-reflect 2.12.7 http://www.scala-lang.org/license.html
+
+========================================================================
+https://glassfish.java.net/public/CDDL+GPL_1_1.html licenses
+========================================================================
+
+    org.glassfish:javax.json 1.0 https://glassfish.java.net/public/CDDL+GPL_1_1.html
+
+========================================================================
+https://opensource.org/licenses/isc-license licenses
+========================================================================
+
+    org.mindrot:jbcrypt 0.4 https://opensource.org/licenses/isc-license
+
+========================================================================
+https://spdx.org/licenses/MIT.html licenses
+========================================================================
+
+    com.lihaoyi:fastparse_2.12 2.0.4 https://spdx.org/licenses/MIT.html
+
+========================================================================
+https://www.apache.org/licenses/LICENSE-2.0.html licenses
+========================================================================
+
+    com.hankcs:hanlp portable-1.8.3 https://www.apache.org/licenses/LICENSE-2.0.html
+    io.dropwizard.metrics:metrics-annotation 4.2.4 https://www.apache.org/licenses/LICENSE-2.0.html
+    io.dropwizard.metrics:metrics-core 4.2.4 https://www.apache.org/licenses/LICENSE-2.0.html
+    io.dropwizard.metrics:metrics-jersey3 4.2.4 https://www.apache.org/licenses/LICENSE-2.0.html
+
+========================================================================
+https://www.gnu.org/licenses/old-licenses/lgpl-2.1 and Apache-2.0 licenses
+========================================================================
+
+    net.java.dev.jna:jna 5.12.1 https://www.gnu.org/licenses/old-licenses/lgpl-2.1 and Apache-2.0
+

--- a/hugegraph-dist/release-docs/LICENSE.tpl
+++ b/hugegraph-dist/release-docs/LICENSE.tpl
@@ -1,0 +1,19 @@
+{{ .LicenseContent }}
+
+=======================================================================
+   APACHE HUGEGRAPH (Incubating) SUBCOMPONENTS:
+
+   The Apache HugeGraph(Incubating) project contains subcomponents with separate copyright
+   notices and license terms. Your use of the source code for the these
+   subcomponents is subject to the terms and conditions of the following
+   licenses.
+========================================================================
+
+{{ range .Groups }}
+========================================================================
+{{.LicenseID}} licenses
+========================================================================
+{{range .Deps}}
+    {{.Name}} {{.Version}} {{.LicenseID}}
+{{- end }}
+{{ end }}


### PR DESCRIPTION
Refer to the usage by skywalking's configs, here are the steps to use it:
1. Install license-eye according to [the doc](https://github.com/apache/skywalking-eyes#usage).
2. Run license-eye dependency resolve --summary  ./hugegraph-dist/release-docs/LICENSE.tpl in the root directory of this project.
3. Check the modified lines in  ./hugegraph-dist/release-docs/LICENSE (via command git diff -U0  ./hugegraph-dist/release-docs/LICENSE) and check whether the new dependencies' licenses are compatible with Apache 2.0.
4. Add the new dependencies' notice files (if any) to  ./hugegraph-dist/release-docs/NOTICE if they are Apache 2.0 license. 
5. Copy their license files to ./hugegraph-dist/release-docs/LICENSE if they are not standard Apache 2.0 license.
6. Copy the new dependencies' license file to  ./hugegraph-dist/release-docs/LICENSE if they are not standard Apache 2.0 license.