### PR TITLE
refact: use a slim way to build docker image on latest code & support zgc

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,7 +35,6 @@ ENV JAVA_OPTS="-XX:+UnlockExperimentalVMOptions -XX:+UseContainerSupport -XX:Max
 WORKDIR /hugegraph/
 
 # 1. Install environment
-# && sed -i s@/deb.debian.org/@/mirrors.tencentyun.com/@g /etc/apt/sources.list && apt-get clean \
 RUN set -x \
     && apt-get -q update \
     && apt-get -q install -y --no-install-recommends --no-install-suggests \
@@ -50,7 +49,7 @@ RUN set -x \
 RUN set -e \
     && pwd && cd /hugegraph/ \
     && sed -i "s/^restserver.url.*$/restserver.url=http:\/\/0.0.0.0:8080/g" ./conf/rest-server.properties \
-    && ./bin/init-store.sh
+    && ./bin/init-store.sh && ./bin/start-hugegraph.sh -d false -j $JAVA_OPTS -g g1
     #     && sed -n '81p' ./bin/start-hugegraph.sh | grep "&" > /dev/null && sed -i 81{s/\&$/#/g} ./bin/start-hugegraph.sh \
     #     && sed -n '91p' ./bin/start-hugegraph.sh | grep "exit" > /dev/null && sed -i 91{s/^/#/g} ./bin/start-hugegraph.sh \
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+
+# Dockerfile for HugeGraph Server
 # 1st stage: build source code
 FROM maven:3.9.0-eclipse-temurin-11 AS build
 
@@ -50,9 +52,6 @@ RUN set -e \
     && pwd && cd /hugegraph/ \
     && sed -i "s/^restserver.url.*$/restserver.url=http:\/\/0.0.0.0:8080/g" ./conf/rest-server.properties \
     && ./bin/init-store.sh
-    #&& sed -n '89p' ./bin/start-hugegraph.sh | grep "&" > /dev/null && sed -i 89{s/\&$/#/g} ./bin/start-hugegraph.sh \
-    #&& sed -n '104p' ./bin/start-hugegraph.sh | grep "exit" > /dev/null && sed -i 104{s/^/#/g} ./bin/start-hugegraph.sh
-    #&& ./bin/start-hugegraph.sh -d false -j $JAVA_OPTS -g g1
 
 EXPOSE 8080
 VOLUME /hugegraph

--- a/Dockerfile
+++ b/Dockerfile
@@ -49,12 +49,13 @@ RUN set -x \
 RUN set -e \
     && pwd && cd /hugegraph/ \
     && sed -i "s/^restserver.url.*$/restserver.url=http:\/\/0.0.0.0:8080/g" ./conf/rest-server.properties \
-    && ./bin/init-store.sh && ./bin/start-hugegraph.sh -d false -j $JAVA_OPTS -g g1
-    #     && sed -n '81p' ./bin/start-hugegraph.sh | grep "&" > /dev/null && sed -i 81{s/\&$/#/g} ./bin/start-hugegraph.sh \
-    #     && sed -n '91p' ./bin/start-hugegraph.sh | grep "exit" > /dev/null && sed -i 91{s/^/#/g} ./bin/start-hugegraph.sh \
+    && ./bin/init-store.sh
+    #&& sed -n '89p' ./bin/start-hugegraph.sh | grep "&" > /dev/null && sed -i 89{s/\&$/#/g} ./bin/start-hugegraph.sh \
+    #&& sed -n '104p' ./bin/start-hugegraph.sh | grep "exit" > /dev/null && sed -i 104{s/^/#/g} ./bin/start-hugegraph.sh
+    #&& ./bin/start-hugegraph.sh -d false -j $JAVA_OPTS -g g1
 
 EXPOSE 8080
 VOLUME /hugegraph
 
 ENTRYPOINT ["/usr/bin/dumb-init", "--"]
-CMD ["./bin/start-hugegraph.sh", "-d false -j $JAVA_OPTS -g g1"]
+CMD ["./bin/start-hugegraph.sh", "-d false -j $JAVA_OPTS -g zgc"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,55 +14,48 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+# 1st stage: build source code
+FROM maven:3.9.0-eclipse-temurin-11 AS build
 
-FROM ubuntu:xenial
+COPY . /pkg
+WORKDIR /pkg
+RUN mvn package -e -B -ntp -DskipTests -Dmaven.javadoc.skip=true && pwd && ls -l
 
-LABEL maintainer="HugeGraph Docker Maintainers <hugegraph@googlegroups.com>"
+# 2nd stage: runtime env
+FROM openjdk:11-slim
+# TODO: get the version from the pom.xml
+ENV version=1.0.0
+COPY --from=build /pkg/apache-hugegraph-incubating-$version/ /hugegraph
+LABEL maintainer="HugeGraph Docker Maintainers <dev@hugegraph.apache.org>"
 
-ENV PKG_URL https://github.com/hugegraph
+# TODO: use g1gc or zgc as default
+ENV JAVA_OPTS="-XX:+UnlockExperimentalVMOptions -XX:+UseContainerSupport -XX:MaxRAMPercentage=50 -XshowSettings:vm"
 
-# 1. Install needed dependencies of GraphServer & RocksDB
+#COPY . /hugegraph/hugegraph-server
+WORKDIR /hugegraph/
+
+# 1. Install environment
+# && sed -i s@/deb.debian.org/@/mirrors.tencentyun.com/@g /etc/apt/sources.list && apt-get clean \
 RUN set -x \
     && apt-get -q update \
     && apt-get -q install -y --no-install-recommends --no-install-suggests \
+       dumb-init \
+       procps \
        curl \
        lsof \
-       g++ \
-       gcc \
-       openjdk-8-jdk \
-    && apt-get clean
-    # && rm -rf /var/lib/apt/lists/*
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
 
 # 2. Init HugeGraph Sever
-# (Optional) You can set the ip of github to speed up the local build
-# && echo "192.30.253.112 github.com\n151.101.44.249 github.global.ssl.fastly.net" >> /etc/hosts \
-ENV SERVER_VERSION 0.12.0
 RUN set -e \
-    && mkdir -p /root/hugegraph-server \
-    && curl -L -S ${PKG_URL}/hugegraph/releases/download/v${SERVER_VERSION}/hugegraph-${SERVER_VERSION}.tar.gz -o /root/server.tar.gz \
-    && tar xzf /root/server.tar.gz --strip-components 1 -C /root/hugegraph-server \
-    && rm /root/server.tar.gz \
-    && cd /root/hugegraph-server/ \
+    && pwd && cd /hugegraph/ \
     && sed -i "s/^restserver.url.*$/restserver.url=http:\/\/0.0.0.0:8080/g" ./conf/rest-server.properties \
-    && sed -n '65p' ./bin/start-hugegraph.sh | grep "&" > /dev/null && sed -i 65{s/\&$/#/g} ./bin/start-hugegraph.sh \
-    && sed -n '75p' ./bin/start-hugegraph.sh | grep "exit" > /dev/null && sed -i 75{s/^/#/g} ./bin/start-hugegraph.sh \
     && ./bin/init-store.sh
+    #     && sed -n '81p' ./bin/start-hugegraph.sh | grep "&" > /dev/null && sed -i 81{s/\&$/#/g} ./bin/start-hugegraph.sh \
+    #     && sed -n '91p' ./bin/start-hugegraph.sh | grep "exit" > /dev/null && sed -i 91{s/^/#/g} ./bin/start-hugegraph.sh \
 
-# 3. Prepare for HugeGraph Studio
-ENV STUDIO_VERSION 0.10.0
-# (Optional) You can set the ip of github to speed up the local build
-# && echo "192.30.253.112 github.com\n151.101.44.249 github.global.ssl.fastly.net" >> /etc/hosts \
-RUN set -e \
-    && mkdir -p /root/hugegraph-studio \
-    && curl -L -S ${PKG_URL}/hugegraph-studio/releases/download/v${STUDIO_VERSION}/hugegraph-studio-${STUDIO_VERSION}.tar.gz -o /root/studio.tar.gz \
-    && tar xzf /root/studio.tar.gz --strip-components 1 -C /root/hugegraph-studio \
-    && rm /root/studio.tar.gz \
-    && cd /root/hugegraph-studio/ \
-    && sed -i "s/^studio.server.host.*$/studio.server.host=0.0.0.0/g" ./conf/hugegraph-studio.properties \
-    && sed -i "s/^graph.server.host.*$/graph.server.host=0.0.0.0/g" ./conf/hugegraph-studio.properties
+EXPOSE 8080
+VOLUME /hugegraph
 
-EXPOSE 8080 8088
-WORKDIR /root
-VOLUME /root
-
-ENTRYPOINT ["./hugegraph-server/bin/start-hugegraph.sh"]
+ENTRYPOINT ["/usr/bin/dumb-init", "--"]
+CMD ["./bin/start-hugegraph.sh", "-d false -j $JAVA_OPTS -g g1"]

--- a/README.md
+++ b/README.md
@@ -16,26 +16,44 @@
 [![Codecov](https://codecov.io/gh/apache/hugegraph/branch/master/graph/badge.svg)](https://codecov.io/gh/apache/hugegraph)
 [![GitHub Releases Downloads](https://img.shields.io/github/downloads/apache/hugegraph/total.svg)](https://github.com/apache/hugegraph/releases)
 
-[HugeGraph](https://hugegraph.apache.org/) is a fast-speed and highly-scalable [graph database](https://en.wikipedia.org/wiki/Graph_database). Billions of vertices and edges can be easily stored into and queried from HugeGraph due to its excellent OLTP ability. As compliance to [Apache TinkerPop 3](https://tinkerpop.apache.org/) framework, various complicated graph queries can be accomplished through [Gremlin](https://tinkerpop.apache.org/gremlin.html)(a powerful graph traversal language).
+[HugeGraph](https://hugegraph.apache.org/) is a fast-speed and highly-scalable [graph database](https://en.wikipedia.org/wiki/Graph_database). 
+Billions of vertices and edges can be easily stored into and queried from HugeGraph due to its excellent OLTP ability. As compliance to [Apache TinkerPop 3](https://tinkerpop.apache.org/) framework, various complicated graph queries can be accomplished through [Gremlin](https://tinkerpop.apache.org/gremlin.html)(a powerful graph traversal language).
 
 ## Features
 
-- Compliance to [Apache TinkerPop 3](https://tinkerpop.apache.org/), supporting [Gremlin](https://tinkerpop.apache.org/gremlin.html)
+- Compliance to [Apache TinkerPop 3](https://tinkerpop.apache.org/), support [Gremlin](https://tinkerpop.apache.org/gremlin.html) & [Cypher](https://en.wikipedia.org/wiki/Cypher) language
 - Schema Metadata Management, including VertexLabel, EdgeLabel, PropertyKey and IndexLabel
 - Multi-type Indexes, supporting exact query, range query and complex conditions combination query
-- Plug-in Backend Store Driver Framework, supporting RocksDB, Cassandra, ScyllaDB, HBase and MySQL now and easy to add other backend store driver if needed
-- Integration with Hadoop/Spark
+- Plug-in Backend Store Driver Framework, support `RocksDB`, `Cassandra`, `HBase`, `ScyllaDB`, and `MySQL/Postgre` now and easy to add other backend store driver if needed
+- Integration with `Flink/Spark/HDFS`, and friendly to connect other big data platforms
 
-## Getting Started
+## Quick Start
 
-The project [homepage](https://hugegraph.apache.org/docs/) contains more information on HugeGraph
-and provides links to **documentation**, getting-started guides and [Release Download Page](https://hugegraph.apache.org/docs/download/download/)
+### 1. Docker Way
 
-And here are links of other repositories:
-1. [hugegraph-toolchain](https://github.com/apache/incubator-hugegraph-toolchain) (include loader/dashboard/tool/client)
-2. [hugegraph-computer](https://github.com/apache/incubator-hugegraph-computer) (graph computing system)
-3. [hugegraph-commons](https://github.com/apache/incubator-hugegraph-commons) (include common & rpc module)
-4. [hugegraph-website](https://github.com/apache/incubator-hugegraph-doc) (include doc & website code)
+We can use `docker run -itd --name=graph -p 8080:8080 hugegraph/hugegraph` to quickly start an inner 
+HugeGraph server with `RocksDB` in background.
+
+Optional: use `docker exec -it graph bash` to enter the container to do some operations.
+
+### 2. Download Way
+
+Visit [Download Page](https://hugegraph.apache.org/docs/download/download/) and refer the [doc](https://hugegraph.apache.org/docs/quickstart/hugegraph-server/#33-source-code-compilation) 
+to download the latest release package and start the server.
+
+### 3. Source Building Way
+
+Visit [Source Building Page](https://hugegraph.apache.org/docs/quickstart/hugegraph-server/#33-source-code-compilation) and follow the 
+steps to build the source code and start the server.
+
+The project [doc page](https://hugegraph.apache.org/docs/) contains more information on HugeGraph
+and provides detailed documentation for users. (Structure / Usage / API / Configs...)
+
+And here are links of other **HugeGraph** component/repositories:
+1. [hugegraph-toolchain](https://github.com/apache/incubator-hugegraph-toolchain) (graph **loader/dashboard/tool/client**)
+2. [hugegraph-computer](https://github.com/apache/incubator-hugegraph-computer) (matched **graph computing** system)
+3. [hugegraph-commons](https://github.com/apache/incubator-hugegraph-commons) (**common & rpc** module)
+4. [hugegraph-website](https://github.com/apache/incubator-hugegraph-doc) (**doc & website** code)
 
 ## Contributing
 

--- a/hugegraph-dist/src/assembly/static/bin/hugegraph-server.sh
+++ b/hugegraph-dist/src/assembly/static/bin/hugegraph-server.sh
@@ -17,8 +17,8 @@
 #
 function abs_path() {
     SOURCE="${BASH_SOURCE[0]}"
-    while [ -h "$SOURCE" ]; do
-        DIR="$(cd -P "$(dirname "$SOURCE")" && pwd )"
+    while [[ -h "$SOURCE" ]]; do
+        DIR="$(cd -P "$(dirname "$SOURCE")" && pwd)"
         SOURCE="$(readlink "$SOURCE")"
         [[ $SOURCE != /* ]] && SOURCE="$DIR/$SOURCE"
     done
@@ -28,7 +28,7 @@ function abs_path() {
 if [[ $# -lt 3 ]]; then
     echo "USAGE: $0 GREMLIN_SERVER_CONF REST_SERVER_CONF OPEN_SECURITY_CHECK"
     echo " e.g.: $0 conf/gremlin-server.yaml conf/rest-server.properties true"
-    exit 1;
+    exit 1
 fi
 
 BIN=$(abs_path)
@@ -67,8 +67,8 @@ MIN_MEM=$((1 * 512))
 MIN_JAVA_VERSION=8
 
 # download binary file
-if [[ ! -e "${CONF}/hugegraph-server.keystore"  ]]; then
-  download "${CONF}" "https://github.com/apache/hugegraph-doc/raw/binary-1.0/dist/server/hugegraph-server.keystore"
+if [[ ! -e "${CONF}/hugegraph-server.keystore" ]]; then
+    download "${CONF}" "https://github.com/apache/hugegraph-doc/raw/binary-1.0/dist/server/hugegraph-server.keystore"
 fi
 
 # Add the slf4j-log4j12 binding
@@ -77,8 +77,8 @@ CP=$(find -L $LIB -name 'log4j-slf4j-impl*.jar' | sort | tr '\n' ':')
 CP="$CP":$(find -L $LIB -name 'hugegraph*.jar' | sort | tr '\n' ':')
 # Add the remaining jars in lib.
 CP="$CP":$(find -L $LIB -name '*.jar' \
-                \! -name 'hugegraph*' \
-                \! -name 'log4j-slf4j-impl*.jar' | sort | tr '\n' ':')
+    \! -name 'hugegraph*' \
+    \! -name 'log4j-slf4j-impl*.jar' | sort | tr '\n' ':')
 # Add the jars in ext (at any subdirectory depth)
 CP="$CP":$(find -L $EXT -name '*.jar' | sort | tr '\n' ':')
 # Add the jars in plugins (at any subdirectory depth)
@@ -90,7 +90,7 @@ CP="$CP":$(find -L $PLUGINS -name '*.jar' | sort | tr '\n' ':')
 export CLASSPATH="${CLASSPATH:-}:$CP"
 
 # Change to $BIN's parent
-cd "${TOP}" || exit 1;
+cd "${TOP}" || exit 1
 
 # Find java & enable server option
 if [ "$JAVA_HOME" = "" ]; then
@@ -102,7 +102,7 @@ fi
 JAVA_VERSION=$($JAVA -version 2>&1 | head -1 | cut -d'"' -f2 | sed 's/^1\.//' | cut -d'.' -f1)
 if [[ $? -ne 0 || $JAVA_VERSION -lt $MIN_JAVA_VERSION ]]; then
     echo "Make sure the JDK is installed and the version >= $MIN_JAVA_VERSION, current is $JAVA_VERSION" \
-         >> ${OUTPUT}
+         >> "${OUTPUT}"
     exit 1
 fi
 
@@ -110,7 +110,7 @@ fi
 if [ "$JAVA_OPTIONS" = "" ]; then
     XMX=$(calc_xmx $MIN_MEM $MAX_MEM)
     if [ $? -ne 0 ]; then
-        echo "Failed to start HugeGraphServer, requires at least ${MIN_MEM}MB free memory" >> ${OUTPUT}
+        echo "Failed to start HugeGraphServer, requires at least ${MIN_MEM}MB free memory" >> "${OUTPUT}"
         exit 1
     fi
     JAVA_OPTIONS="-Xms${MIN_MEM}m -Xmx${XMX}m -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=${LOGS} ${USER_OPTION}"
@@ -153,6 +153,6 @@ if [[ ${OPEN_SECURITY_CHECK} == "true" ]]; then
 fi
 
 # Turn on security check
-exec ${JAVA} -Dname="HugeGraphServer" ${JVM_OPTIONS} ${JAVA_OPTIONS} \
-     -cp ${CLASSPATH}: org.apache.hugegraph.dist.HugeGraphServer ${GREMLIN_SERVER_CONF} ${REST_SERVER_CONF} \
-     >> ${OUTPUT} 2>&1
+exec ${JAVA} -Dname="HugeGraphServer" ${JVM_OPTIONS} ${JAVA_OPTIONS} -cp ${CLASSPATH}: \
+    org.apache.hugegraph.dist.HugeGraphServer ${GREMLIN_SERVER_CONF} ${REST_SERVER_CONF} \
+    >> ${OUTPUT} 2>&1

--- a/hugegraph-dist/src/assembly/static/bin/init-store.sh
+++ b/hugegraph-dist/src/assembly/static/bin/init-store.sh
@@ -15,25 +15,25 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 #
-abs_path() {
+function abs_path() {
     SOURCE="${BASH_SOURCE[0]}"
     while [[ -h "$SOURCE" ]]; do
-        DIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
+        DIR="$(cd -P "$(dirname "$SOURCE")" && pwd)"
         SOURCE="$(readlink "$SOURCE")"
-        [[ ${SOURCE} != /* ]] && SOURCE="$DIR/$SOURCE"
+        [[ $SOURCE != /* ]] && SOURCE="$DIR/$SOURCE"
     done
-    echo "$( cd -P "$( dirname "$SOURCE" )" && pwd )"
+    cd -P "$(dirname "$SOURCE")" && pwd
 }
 
-BIN=`abs_path`
-TOP="$(cd ${BIN}/../ && pwd)"
+BIN=$(abs_path)
+TOP="$(cd "${BIN}"/../ && pwd)"
 CONF="$TOP/conf"
 LIB="$TOP/lib"
 PLUGINS="$TOP/plugins"
 
-. ${BIN}/util.sh
+. "${BIN}"/util.sh
 
-ensure_path_writable ${PLUGINS}
+ensure_path_writable "${PLUGINS}"
 
 if [[ -n "$JAVA_HOME" ]]; then
     JAVA="$JAVA_HOME"/bin/java
@@ -43,11 +43,11 @@ else
     EXT="$LIB:$PLUGINS"
 fi
 
-cd ${TOP}
+cd "${TOP}" || exit
 
 DEFAULT_JAVA_OPTIONS=""
-JAVA_VERSION=$($JAVA -version 2>&1 | awk 'NR==1{gsub(/"/,""); print $3}' \
-              | awk -F'_' '{print $1}')
+JAVA_VERSION=$($JAVA -version 2>&1 | awk 'NR==1{gsub(/"/,""); print $3}' | awk -F'_' '{print $1}')
+# TODO: better not string number compare, use `bc` like github.com/koalaman/shellcheck/wiki/SC2072
 if [[ $? -eq 0 && $JAVA_VERSION >  "1.9" ]]; then
       DEFAULT_JAVA_OPTIONS="--add-exports=java.base/jdk.internal.reflect=ALL-UNNAMED"
 fi

--- a/hugegraph-dist/src/assembly/static/bin/start-hugegraph.sh
+++ b/hugegraph-dist/src/assembly/static/bin/start-hugegraph.sh
@@ -94,8 +94,10 @@ echo "$PID" > "$PID_FILE"
 
 trap 'kill $PID; exit' SIGHUP SIGINT SIGQUIT SIGTERM
 
-wait_for_startup ${PID} 'HugeGraphServer' "$REST_SERVER_URL/graphs" "${SERVER_STARTUP_TIMEOUT_S}" || {
+wait_for_startup ${PID} 'HugeGraphServer' "$REST_SERVER_URL/graphs" ${SERVER_STARTUP_TIMEOUT_S} || {
     echo "See $LOGS/hugegraph-server.log for HugeGraphServer log output." >&2
+    # TODO: test now
+    cat "$LOGS"/hugegraph-server.log
     if [[ $DAEMON == "true" ]]; then
         exit 1
     fi

--- a/hugegraph-dist/src/assembly/static/bin/start-hugegraph.sh
+++ b/hugegraph-dist/src/assembly/static/bin/start-hugegraph.sh
@@ -23,7 +23,7 @@ GC_OPTION=""
 USER_OPTION=""
 SERVER_STARTUP_TIMEOUT_S=30
 
-while getopts "d:g:m:s:j:t" arg; do
+while getopts "d:g:m:s:j:t:v" arg; do
     case ${arg} in
         d) DAEMON="$OPTARG" ;;
         g) GC_OPTION="$OPTARG" ;;
@@ -31,7 +31,8 @@ while getopts "d:g:m:s:j:t" arg; do
         s) OPEN_SECURITY_CHECK="$OPTARG" ;;
         j) USER_OPTION="$OPTARG" ;;
         t) SERVER_STARTUP_TIMEOUT_S="$OPTARG" ;;
-        #v) VERBOSE="verbose" ;;
+        # TODO: should remove it in future (check the usage carefully)
+        v) VERBOSE="verbose" ;;
         ?) echo "USAGE: $0 [-d true|false] [-g g1] [-m true|false] [-s true|false] [-j java_options]
                 [-t timeout]" && exit 1 ;;
     esac
@@ -79,14 +80,14 @@ if [ ! -d "$LOGS" ]; then
 fi
 
 #TODO: test
-if [[ $DAEMON == "false" ]]; then
-    echo "Starting HugeGraphServer in foreground mode..."
-    "${BIN}"/hugegraph-server.sh "${CONF}"/gremlin-server.yaml "${CONF}"/rest-server.properties \
-    "${OPEN_SECURITY_CHECK}" "${USER_OPTION}" "${GC_OPTION}" >>"${LOGS}"/hugegraph-server.log 2>&1
-else
+if [[ $DAEMON == "true" ]]; then
     echo "Starting HugeGraphServer in daemon mode..."
     "${BIN}"/hugegraph-server.sh "${CONF}"/gremlin-server.yaml "${CONF}"/rest-server.properties \
     "${OPEN_SECURITY_CHECK}" "${USER_OPTION}" "${GC_OPTION}" >>"${LOGS}"/hugegraph-server.log 2>&1 &
+else
+    echo "Starting HugeGraphServer in foreground mode..."
+    "${BIN}"/hugegraph-server.sh "${CONF}"/gremlin-server.yaml "${CONF}"/rest-server.properties \
+    "${OPEN_SECURITY_CHECK}" "${USER_OPTION}" "${GC_OPTION}" >>"${LOGS}"/hugegraph-server.log 2>&1
 fi
 
 PID="$!"

--- a/hugegraph-dist/src/assembly/static/bin/start-hugegraph.sh
+++ b/hugegraph-dist/src/assembly/static/bin/start-hugegraph.sh
@@ -78,6 +78,7 @@ if [ ! -d "$LOGS" ]; then
     mkdir -p "$LOGS"
 fi
 
+#TODO: test
 if [[ $DAEMON == "false" ]]; then
     echo "Starting HugeGraphServer in foreground mode..."
     "${BIN}"/hugegraph-server.sh "${CONF}"/gremlin-server.yaml "${CONF}"/rest-server.properties \
@@ -89,6 +90,7 @@ else
 fi
 
 PID="$!"
+echo "$DAEMON, pid=$PID"
 # Write pid to file
 echo "$PID" > "$PID_FILE"
 
@@ -97,8 +99,8 @@ trap 'kill $PID; exit' SIGHUP SIGINT SIGQUIT SIGTERM
 wait_for_startup ${PID} 'HugeGraphServer' "$REST_SERVER_URL/graphs" ${SERVER_STARTUP_TIMEOUT_S} || {
     echo "See $LOGS/hugegraph-server.log for HugeGraphServer log output." >&2
     # TODO: test now
-    cat "$LOGS"/hugegraph-server.log
     if [[ $DAEMON == "true" ]]; then
+        echo "exit here" && cat "$LOGS"/hugegraph-server.log
         exit 1
     fi
 }

--- a/hugegraph-dist/src/assembly/static/bin/start-hugegraph.sh
+++ b/hugegraph-dist/src/assembly/static/bin/start-hugegraph.sh
@@ -32,8 +32,8 @@ while getopts "d:g:m:s:j:t" arg; do
         j) USER_OPTION="$OPTARG" ;;
         t) SERVER_STARTUP_TIMEOUT_S="$OPTARG" ;;
         #v) VERBOSE="verbose" ;;
-        ?) echo "USAGE: $0 [-d true|false] [-g g1] [-m true|false] [-s true|false] [-j java_options] \
-             [-t timeout]" && exit 1 ;;
+        ?) echo "USAGE: $0 [-d true|false] [-g g1] [-m true|false] [-s true|false] [-j java_options]
+                [-t timeout]" && exit 1 ;;
     esac
 done
 
@@ -49,8 +49,8 @@ fi
 
 function abs_path() {
     SOURCE="${BASH_SOURCE[0]}"
-    while [ -h "$SOURCE" ]; do
-        DIR="$(cd -P "$(dirname "$SOURCE")" && pwd )"
+    while [[ -h "$SOURCE" ]]; do
+        DIR="$(cd -P "$(dirname "$SOURCE")" && pwd)"
         SOURCE="$(readlink "$SOURCE")"
         [[ $SOURCE != /* ]] && SOURCE="$DIR/$SOURCE"
     done
@@ -78,12 +78,12 @@ if [ ! -d "$LOGS" ]; then
     mkdir -p "$LOGS"
 fi
 
-echo "Starting HugeGraphServer..."
-
 if [[ $DAEMON == "false" ]]; then
+    echo "Starting HugeGraphServer in foreground mode..."
     "${BIN}"/hugegraph-server.sh "${CONF}"/gremlin-server.yaml "${CONF}"/rest-server.properties \
     "${OPEN_SECURITY_CHECK}" "${USER_OPTION}" "${GC_OPTION}" >>"${LOGS}"/hugegraph-server.log 2>&1
 else
+    echo "Starting HugeGraphServer in daemon mode..."
     "${BIN}"/hugegraph-server.sh "${CONF}"/gremlin-server.yaml "${CONF}"/rest-server.properties \
     "${OPEN_SECURITY_CHECK}" "${USER_OPTION}" "${GC_OPTION}" >>"${LOGS}"/hugegraph-server.log 2>&1 &
 fi

--- a/hugegraph-dist/src/assembly/static/bin/start-hugegraph.sh
+++ b/hugegraph-dist/src/assembly/static/bin/start-hugegraph.sh
@@ -79,7 +79,6 @@ if [ ! -d "$LOGS" ]; then
     mkdir -p "$LOGS"
 fi
 
-#TODO: test
 if [[ $DAEMON == "true" ]]; then
     echo "Starting HugeGraphServer in daemon mode..."
     "${BIN}"/hugegraph-server.sh "${CONF}"/gremlin-server.yaml "${CONF}"/rest-server.properties \
@@ -91,17 +90,14 @@ else
 fi
 
 PID="$!"
-echo "$DAEMON, pid=$PID"
 # Write pid to file
 echo "$PID" > "$PID_FILE"
 
 trap 'kill $PID; exit' SIGHUP SIGINT SIGQUIT SIGTERM
 
-wait_for_startup ${PID} 'HugeGraphServer' "$REST_SERVER_URL/graphs" ${SERVER_STARTUP_TIMEOUT_S} || {
+wait_for_startup ${PID} 'HugeGraphServer' "$REST_SERVER_URL/graphs" "${SERVER_STARTUP_TIMEOUT_S}" || {
     echo "See $LOGS/hugegraph-server.log for HugeGraphServer log output." >&2
-    # TODO: test now
     if [[ $DAEMON == "true" ]]; then
-        echo "exit here" && cat "$LOGS"/hugegraph-server.log
         exit 1
     fi
 }

--- a/hugegraph-dist/src/assembly/travis/run-api-test.sh
+++ b/hugegraph-dist/src/assembly/travis/run-api-test.sh
@@ -21,15 +21,15 @@ BACKEND=$1
 REPORT_DIR=$2
 REPORT_FILE=$REPORT_DIR/jacoco-api-test-for-raft.xml
 
-TRAVIS_DIR=`dirname $0`
-VERSION=`mvn help:evaluate -Dexpression=project.version -q -DforceStdout`
+TRAVIS_DIR=$(dirname $0)
+VERSION=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)
 SERVER_DIR=apache-hugegraph-incubating-$VERSION
 CONF=$SERVER_DIR/conf/graphs/hugegraph.properties
 REST_SERVER_CONF=$SERVER_DIR/conf/rest-server.properties
 GREMLIN_SERVER_CONF=$SERVER_DIR/conf/gremlin-server.yaml
 JACOCO_PORT=36320
 
-mvn package -DskipTests
+mvn package -DskipTests -ntp
 
 
 # add mysql dependency


### PR DESCRIPTION
replace & close #2046, finish some of #840

also support `ARM` env by using `buildx`

**TODO:**
- [x]  consider use zgc as default gc in `java11`
- [ ] we need update/enhance our `README` in each repo (add more Doc/Usage)