### PR TITLE
add github token for license check comment

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,12 +48,6 @@ jobs:
         with:
           fetch-depth: 2
 
-      - name: License check(RAT)
-        run: |
-          mvn apache-rat:check -ntp
-          find ./ -name rat.txt -print0 | xargs -0 -I file cat file > merged-rat.txt
-          grep "Binaries" merged-rat.txt -C 3 && cat merged-rat.txt
-
       - name: Compile
         run: |
           mvn clean compile -U -Dmaven.javadoc.skip=true -ntp

--- a/.github/workflows/licence-checker.yml
+++ b/.github/workflows/licence-checker.yml
@@ -19,4 +19,16 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           log: info
+          token: ${{ github.token }}
           config: .licenserc.yaml
+
+      - uses: actions/setup-java@v3
+        with:
+          java-version: '11'
+          distribution: 'adopt'
+
+      - name: License check(RAT)
+        run: |
+          mvn apache-rat:check -ntp
+          find ./ -name rat.txt -print0 | xargs -0 -I file cat file > merged-rat.txt
+          grep "Binaries" merged-rat.txt -C 3 && cat merged-rat.txt


### PR DESCRIPTION
the token that license eye uses when it needs to comment on the pull request. Set to empty ("") to disable commenting on pull request. The default value is ${{ github.token }}