### PR TITLE
chore: disable PR up-to-date in branch

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -35,7 +35,7 @@ github:
     master:
       required_status_checks:
         # strict means "Require branches to be up-to-date before merging".
-        strict: true
+        strict: false
         # contexts are the names of checks that must pass (now only enable the basic check)
         contexts:
           - Analyze (java)


### PR DESCRIPTION
In order to avoid updating the branch of the PR every time the master code is updated, we cancel the strict mode.