### PR TITLE
fix exception of vertex-drop with index

### DIFF
--- a/hugegraph-core/src/main/java/org/apache/hugegraph/backend/tx/GraphTransaction.java
+++ b/hugegraph-core/src/main/java/org/apache/hugegraph/backend/tx/GraphTransaction.java
@@ -691,6 +691,7 @@ public class GraphTransaction extends IndexableTransaction {
         this.addedVertices.remove(vertex.id());
 
         // Collect the removed vertex
+        vertex.forceLoad();
         this.removedVertices.put(vertex.id(), vertex);
 
         this.afterWrite();

--- a/hugegraph-core/src/main/java/org/apache/hugegraph/backend/tx/GraphTransaction.java
+++ b/hugegraph-core/src/main/java/org/apache/hugegraph/backend/tx/GraphTransaction.java
@@ -689,11 +689,12 @@ public class GraphTransaction extends IndexableTransaction {
 
         // Override vertices in local `addedVertices`
         this.addedVertices.remove(vertex.id());
-
+        // Force load vertex to ensure all properties are loaded (refer to #2181)
+        if (vertex.schemaLabel().indexLabels().size() > 0)  {
+            vertex.forceLoad();
+        }
         // Collect the removed vertex
-        vertex.forceLoad();
         this.removedVertices.put(vertex.id(), vertex);
-
         this.afterWrite();
     }
 


### PR DESCRIPTION
closed #2062

According to @javeme 's solution (https://github.com/apache/incubator-hugegraph/issues/2062#issuecomment-1375960811),  the id will be filtered during querying vertices and properties will still be null(refer to the screenshot below).

![image](https://user-images.githubusercontent.com/18065113/228119932-aaadbe4c-3b3c-4c79-a9bc-c614c19a85c5.png)

And it works if force loading properties (`forceLoad`)  before `vertex` being added to `removedVertices` in `GraphTransaction.removeVertex()`.

