### PR TITLE
refact(core): early stop unnecessary loops in edge cache

### DIFF
--- a/hugegraph-core/src/main/java/org/apache/hugegraph/backend/cache/CachedGraphTransaction.java
+++ b/hugegraph-core/src/main/java/org/apache/hugegraph/backend/cache/CachedGraphTransaction.java
@@ -326,6 +326,7 @@ public final class CachedGraphTransaction extends GraphTransaction {
                 if (edge.expired()) {
                     this.edgesCache.invalidate(cacheKey);
                     value = null;
+                    break;
                 }
             }
         }


### PR DESCRIPTION
The loop in this method can jump out directly when the condition is met, avoiding useless loops.