### PR TITLE
fix: jdbc ssl mode parameter redundant

### DIFF
--- a/hugegraph-dist/src/assembly/static/conf/graphs/hugegraph.properties
+++ b/hugegraph-dist/src/assembly/static/conf/graphs/hugegraph.properties
@@ -82,7 +82,7 @@ cassandra.password=
 #jdbc.password=
 #jdbc.reconnect_max_times=3
 #jdbc.reconnect_interval=3
-#jdbc.sslmode=false
+#jdbc.ssl_mode=false
 
 # postgresql & cockroachdb backend config
 #jdbc.driver=org.postgresql.Driver


### PR DESCRIPTION
`jdbc.sslmode` is not registered, we should use `jdbc.ssl_mode` instead.

i see #2175 #2196 outputs have the same problem

```
2023-06-06 02:04:22 [main] [WARN] o.a.h.c.HugeConfig - The config option 'jdbc.sslmode' is redundant, please ensure it has been registered
2023-06-06 02:04:22 [main] [INFO] o.a.h.u.ConfigUtil - Scanning option 'graphs' directory './conf/graphs'
2023-06-06 02:04:22 [main] [INFO] o.a.h.c.InitStore - Init graph with config file: .\conf\graphs\hugegraph.properties
2023-06-06 02:04:22 [main] [WARN] o.a.h.c.HugeConfig - The config option 'jdbc.sslmode' is redundant, please ensure it has been registered
```

https://github.com/apache/incubator-hugegraph/blob/bcf2a395cf8949c39a127facb404f75cf3842475/hugegraph-mysql/src/main/java/org/apache/hugegraph/backend/store/mysql/MysqlOptions.java#L101-L107