### PR TITLE
fix: error when start gremlin-console with sample script

### DIFF
--- a/hugegraph-dist/src/assembly/static/bin/gremlin-console.sh
+++ b/hugegraph-dist/src/assembly/static/bin/gremlin-console.sh
@@ -113,7 +113,7 @@ if [ -z "${HADOOP_GREMLIN_LIBS:-}" ]; then
 fi
 
 if [ -z "${JAVA_OPTIONS:-}" ]; then
-    JAVA_OPTIONS="-Dtinkerpop.ext=$EXT -Dlog4j.configuration=conf/log4j-console.properties -Dgremlin.log4j.level=$GREMLIN_LOG_LEVEL -javaagent:$LIB/jamm-0.3.0.jar"
+    JAVA_OPTIONS="-Dtinkerpop.ext=$EXT -Dlog4j.configurationFile=conf/log4j2.xml -Dgremlin.log4j.level=$GREMLIN_LOG_LEVEL -javaagent:$LIB/jamm-0.3.0.jar"
 fi
 
 if [ "$PROFILING_ENABLED" = true ]; then
@@ -126,4 +126,4 @@ if [ -n "$SCRIPT_DEBUG" ]; then
 fi
 
 # Start the JVM, execute the application, and return its exit code
-exec $JAVA $JAVA_OPTIONS $MAIN_CLASS "$@"
+exec $JAVA $JAVA_OPTIONS $MAIN_CLASS -i "$@"

--- a/hugegraph-dist/src/assembly/static/bin/gremlin-console.sh
+++ b/hugegraph-dist/src/assembly/static/bin/gremlin-console.sh
@@ -126,4 +126,4 @@ if [ -n "$SCRIPT_DEBUG" ]; then
 fi
 
 # Start the JVM, execute the application, and return its exit code
-exec $JAVA $JAVA_OPTIONS $MAIN_CLASS -i "$@"
+exec $JAVA $JAVA_OPTIONS $MAIN_CLASS "$@"

--- a/hugegraph-dist/src/assembly/static/scripts/example.groovy
+++ b/hugegraph-dist/src/assembly/static/scripts/example.groovy
@@ -37,7 +37,6 @@ schema.propertyKey("price").asInt().ifNotExist().create()
 
 schema.vertexLabel("person").properties("name", "age", "city").primaryKeys("name").ifNotExist().create()
 schema.vertexLabel("software").properties("name", "lang", "price").primaryKeys("name").ifNotExist().create()
-// schema.indexLabel("personByName").onV("person").by("name").secondary().ifNotExist().create()
 schema.indexLabel("personByCity").onV("person").by("city").secondary().ifNotExist().create()
 schema.indexLabel("personByAgeAndCity").onV("person").by("age", "city").secondary().ifNotExist().create()
 schema.indexLabel("softwareByPrice").onV("software").by("price").range().ifNotExist().create()

--- a/hugegraph-dist/src/assembly/static/scripts/example.groovy
+++ b/hugegraph-dist/src/assembly/static/scripts/example.groovy
@@ -15,53 +15,55 @@
  * under the License.
  */
 import org.apache.hugegraph.HugeFactory
+import org.apache.hugegraph.backend.id.IdGenerator
 import org.apache.hugegraph.dist.RegisterUtil
+import org.apache.hugegraph.type.define.NodeRole
 import org.apache.tinkerpop.gremlin.structure.T
 
-RegisterUtil.registerCassandra();
-RegisterUtil.registerScyllaDB();
+RegisterUtil.registerRocksDB()
 
 conf = "conf/hugegraph.properties"
-graph = HugeFactory.open(conf);
-schema = graph.schema();
+graph = HugeFactory.open(conf)
+graph.serverStarted(IdGenerator.of("server-tinkerpop"), NodeRole.MASTER)
+schema = graph.schema()
 
-schema.propertyKey("name").asText().ifNotExist().create();
-schema.propertyKey("age").asInt().ifNotExist().create();
-schema.propertyKey("city").asText().ifNotExist().create();
-schema.propertyKey("weight").asDouble().ifNotExist().create();
-schema.propertyKey("lang").asText().ifNotExist().create();
-schema.propertyKey("date").asText().ifNotExist().create();
-schema.propertyKey("price").asInt().ifNotExist().create();
+schema.propertyKey("name").asText().ifNotExist().create()
+schema.propertyKey("age").asInt().ifNotExist().create()
+schema.propertyKey("city").asText().ifNotExist().create()
+schema.propertyKey("weight").asDouble().ifNotExist().create()
+schema.propertyKey("lang").asText().ifNotExist().create()
+schema.propertyKey("date").asText().ifNotExist().create()
+schema.propertyKey("price").asInt().ifNotExist().create()
 
-schema.vertexLabel("person").properties("name", "age", "city").primaryKeys("name").ifNotExist().create();
-schema.vertexLabel("software").properties("name", "lang", "price").primaryKeys("name").ifNotExist().create();
-schema.indexLabel("personByName").onV("person").by("name").secondary().ifNotExist().create();
-schema.indexLabel("personByCity").onV("person").by("city").secondary().ifNotExist().create();
-schema.indexLabel("personByAgeAndCity").onV("person").by("age", "city").secondary().ifNotExist().create();
-schema.indexLabel("softwareByPrice").onV("software").by("price").range().ifNotExist().create();
-schema.edgeLabel("knows").sourceLabel("person").targetLabel("person").properties("date", "weight").ifNotExist().create();
-schema.edgeLabel("created").sourceLabel("person").targetLabel("software").properties("date", "weight").ifNotExist().create();
-schema.indexLabel("createdByDate").onE("created").by("date").secondary().ifNotExist().create();
-schema.indexLabel("createdByWeight").onE("created").by("weight").range().ifNotExist().create();
-schema.indexLabel("knowsByWeight").onE("knows").by("weight").range().ifNotExist().create();
+schema.vertexLabel("person").properties("name", "age", "city").primaryKeys("name").ifNotExist().create()
+schema.vertexLabel("software").properties("name", "lang", "price").primaryKeys("name").ifNotExist().create()
+// schema.indexLabel("personByName").onV("person").by("name").secondary().ifNotExist().create()
+schema.indexLabel("personByCity").onV("person").by("city").secondary().ifNotExist().create()
+schema.indexLabel("personByAgeAndCity").onV("person").by("age", "city").secondary().ifNotExist().create()
+schema.indexLabel("softwareByPrice").onV("software").by("price").range().ifNotExist().create()
+schema.edgeLabel("knows").sourceLabel("person").targetLabel("person").properties("date", "weight").ifNotExist().create()
+schema.edgeLabel("created").sourceLabel("person").targetLabel("software").properties("date", "weight").ifNotExist().create()
+schema.indexLabel("createdByDate").onE("created").by("date").secondary().ifNotExist().create()
+schema.indexLabel("createdByWeight").onE("created").by("weight").range().ifNotExist().create()
+schema.indexLabel("knowsByWeight").onE("knows").by("weight").range().ifNotExist().create()
 
-marko = graph.addVertex(T.label, "person", "name", "marko", "age", 29, "city", "Beijing");
-vadas = graph.addVertex(T.label, "person", "name", "vadas", "age", 27, "city", "Hongkong");
-lop = graph.addVertex(T.label, "software", "name", "lop", "lang", "java", "price", 328);
-josh = graph.addVertex(T.label, "person", "name", "josh", "age", 32, "city", "Beijing");
-ripple = graph.addVertex(T.label, "software", "name", "ripple", "lang", "java", "price", 199);
-peter = graph.addVertex(T.label, "person", "name", "peter", "age", 35, "city", "Shanghai");
+marko = graph.addVertex(T.label, "person", "name", "marko", "age", 29, "city", "Beijing")
+vadas = graph.addVertex(T.label, "person", "name", "vadas", "age", 27, "city", "Hongkong")
+lop = graph.addVertex(T.label, "software", "name", "lop", "lang", "java", "price", 328)
+josh = graph.addVertex(T.label, "person", "name", "josh", "age", 32, "city", "Beijing")
+ripple = graph.addVertex(T.label, "software", "name", "ripple", "lang", "java", "price", 199)
+peter = graph.addVertex(T.label, "person", "name", "peter", "age", 35, "city", "Shanghai")
 
-marko.addEdge("knows", vadas, "date", "20160110", "weight", 0.5);
-marko.addEdge("knows", josh, "date", "20130220", "weight", 1.0);
-marko.addEdge("created", lop, "date", "20171210", "weight", 0.4);
-josh.addEdge("created", lop, "date", "20091111", "weight", 0.4);
-josh.addEdge("created", ripple, "date", "20171210", "weight", 1.0);
-peter.addEdge("created", lop, "date", "20170324", "weight", 0.2);
+marko.addEdge("knows", vadas, "date", "20160110", "weight", 0.5)
+marko.addEdge("knows", josh, "date", "20130220", "weight", 1.0)
+marko.addEdge("created", lop, "date", "20171210", "weight", 0.4)
+josh.addEdge("created", lop, "date", "20091111", "weight", 0.4)
+josh.addEdge("created", ripple, "date", "20171210", "weight", 1.0)
+peter.addEdge("created", lop, "date", "20170324", "weight", 0.2)
 
-graph.tx().commit();
+graph.tx().commit()
 
-g = graph.traversal();
+g = graph.traversal()
 
-System.out.println(">>>> query all vertices: size=" + g.V().toList().size());
-System.out.println(">>>> query all edges: size=" + g.E().toList().size());
+System.out.println(">>>> query all vertices: size=" + g.V().toList().size())
+System.out.println(">>>> query all edges: size=" + g.E().toList().size())

--- a/hugegraph-dist/src/assembly/static/scripts/example.groovy
+++ b/hugegraph-dist/src/assembly/static/scripts/example.groovy
@@ -22,7 +22,7 @@ import org.apache.tinkerpop.gremlin.structure.T
 
 RegisterUtil.registerRocksDB()
 
-conf = "conf/hugegraph.properties"
+conf = "conf/graphs/hugegraph.properties"
 graph = HugeFactory.open(conf)
 graph.serverStarted(IdGenerator.of("server-tinkerpop"), NodeRole.MASTER)
 schema = graph.schema()


### PR DESCRIPTION
<!-- 
  Thank you very much for contributing to Apache HugeGraph, we are happy that you want to help us improve it!

  Here are some tips for you:
    1. If this is your first time, please read the [contributing guidelines](https://github.com/apache/hugegraph/blob/master/CONTRIBUTING.md)

    2. If a PR will fix/close a issue, type the message "close xxx" (xxx is the link of related issue) in the content, github will auto link it (Required)
    
    3. Name the PR title in "Google Commit Format", start with "feat | fix | perf | refactor | doc | chore", 
      such like: "feat(core): support the PageRank algorithm" or "fix: wrong break in the compute loop" (module is optional)
      skip it if you are unsure about which is the best component.
    
    4. One PR address one issue, better not to mix up multiple issues.
    
    5. Put an `x` in the `[ ]` to mark the item as CHECKED. `[x]` (or click it directly after published)
-->

## Purpose of the PR

- fix: #2228  <!-- or use "fix: xxx", "xxx" is the link of related issue -->

<!--
Please explain more context in this section, clarify why the changes are needed. 
For example:
- If you propose a new API, clarify the use case for a new API.
- If you fix a bug, you can clarify why it is a bug, and should associated with an issue.
-->

## Main Changes

1. `hugegraph-dist/src/assembly/static/bin/gremlin-console.sh`
    1. update log4j configuration path
2. `hugegraph-dist/src/assembly/static/scripts/example.groovy`
    1. add `graph.serverStarted` to set the scheduler information
    2. remove unnecessary index on properties `[name]`
    3. remove all semicolons
    4. modify hugegraph conf path

**After modification, user should use the following command to start gremlin-console with sample script:**

```bash
> ./bin/gremlin-console.sh -- -i scripts/example.groovy

         \,,,/
         (o o)
-----oOOo-(3)-oOOo-----
plugin activated: HugeGraph
plugin activated: tinkerpop.server
plugin activated: tinkerpop.utilities
plugin activated: tinkerpop.tinkergraph
main dict load finished, time elapsed 644 ms
model load finished, time elapsed 35 ms.
>>>> query all vertices: size=6
>>>> query all edges: size=6
gremlin> 
```

Currently, `example.groovy` can serve multiple purposes. The modification to `example.groovy` mentioned above is to adapt to the scenario where Gremlin-Console is started. If HugeGraphServer is started using **scripts or IDEA**, the initialization part of `example.groovy` should be:

```groovy
conf = "conf/graphs/hugegraph.properties"
graph = HugeFactory.open(conf)
schema = graph.schema()
```

<!-- Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. These change logs are helpful for better ant faster reviews.)

For example:

- If you introduce a new feature, please show detailed design here or add the link of design documentation.
- If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
- If there is a discussion in the mailing list, please add the link. -->

## Verifying these changes

<!-- Please pick either of the following options -->

- This change is a trivial rework / code cleanup without any test coverage.

## Does this PR potentially affect the following parts?

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ]  Nope
- [ ]  Dependencies (add/update license info) <!-- Don't forget to add/update the info in "LICENSE" & "NOTICE" files (both in root & dist module) -->
- [x]  Modify configurations
- [ ]  The public API
- [ ]  Other affects (typed here)

## Documentation Status

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [x]  `Doc - TODO` <!-- Your PR changes impact docs and you will update later -->
- [ ]  `Doc - Done` <!-- Related docs have been already added or updated -->
- [ ]  `Doc - NO Need` <!-- Your PR changes don't impact/need docs -->

