### PR TITLE
fix: optimizing ClassNotFoundException error message for MYSQL

### DIFF
--- a/hugegraph-core/src/main/java/org/apache/hugegraph/StandardHugeGraph.java
+++ b/hugegraph-core/src/main/java/org/apache/hugegraph/StandardHugeGraph.java
@@ -460,7 +460,7 @@ public class StandardHugeGraph implements HugeGraph {
         } catch (BackendException e) {
             String message = "Failed to open schema transaction";
             LOG.error("{}", message, e);
-            throw new HugeException(message);
+            throw new HugeException(message, e);
         }
     }
 

--- a/hugegraph-mysql/src/main/java/org/apache/hugegraph/backend/store/mysql/MysqlSessions.java
+++ b/hugegraph-mysql/src/main/java/org/apache/hugegraph/backend/store/mysql/MysqlSessions.java
@@ -283,7 +283,7 @@ public class MysqlSessions extends BackendSessionPool {
             // Register JDBC driver
             Class.forName(driverName);
         } catch (ClassNotFoundException e) {
-            throw new BackendException("Invalid driver class '%s'",
+            throw new BackendException("Failed to register JDBC driver. Class '%s' not found. Please check if the MySQL driver package is available.",
                                        driverName);
         }
         return DriverManager.getConnection(url, username, password);


### PR DESCRIPTION
## Purpose of the PR

According to the documentation at https://hugegraph.apache.org/cn/docs/contribution-guidelines/hugegraph-server-idea-setup/, when setting up the development environment for the Server and using MySQL as the database, if the MySQL driver package is missing, the startup will fail. However, the error message displayed is not clear. This submission optimizes the error message.
![image](https://github.com/apache/incubator-hugegraph/assets/55943045/d0897e1d-a07d-4b5f-98db-c2cb9d0a3f88)


## Main Changes

Modified ClassNotFoundException exception error message.

## Verifying these changes

- [ ] Trivial rework / code cleanup without any test coverage. (No Need)
- [ ] Already covered by existing tests, such as *(please modify tests here)*.
- [x] Need tests and can be verified as follows:

First, modify the "hugegraph.properties" configuration file to use MySQL as the database. Start the program without importing the MySQL driver package and check the error message.
![image](https://github.com/apache/incubator-hugegraph/assets/55943045/6eac5956-4295-4d99-b6a9-937600f0b466)


## Does this PR potentially affect the following parts?

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ]  Nope
- [ ]  Dependencies (add/update license info) <!-- Don't forget to add/update the info in "LICENSE" & "NOTICE" files (both in root & dist module) -->
- [ ]  Modify configurations
- [ ]  The public API
- [x]  Other affects (typed here)

Updated error message.

## Documentation Status

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ]  `Doc - TODO` <!-- Your PR changes impact docs and you will update later -->
- [ ]  `Doc - Done` <!-- Related docs have been already added or updated -->
- [x]  `Doc - No Need` <!-- Your PR changes don't impact/need docs -->
