### PR TITLE
fix：asf invalid notification scheme 'discussions_status'

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -57,5 +57,5 @@ notifications:
   issues: issues@hugegraph.apache.org
   issues_status: dev@hugegraph.apache.org
   issues_comment: issues@hugegraph.apache.org
-  discussions_status: dev@hugegraph.apache.org
+  discussions: dev@hugegraph.apache.org
   discussions_comment: issues@hugegraph.apache.org


### PR DESCRIPTION
## Purpose of the PR

Error while running notifications feature from .asf.yaml in incubator-hugegraph!
![image](https://github.com/apache/incubator-hugegraph/assets/55943045/974405bb-959a-4b69-ae7b-82605138811d)


## Main Changes

fix：asf invalid notification scheme 'discussions_status'

## Verifying these changes

- [ ] Trivial rework / code cleanup without any test coverage. (No Need)
- [ ] Already covered by existing tests, such as *(please modify tests here)*.
- [ ] Need tests and can be verified as follows:

## Does this PR potentially affect the following parts?

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ]  Nope
- [ ]  Dependencies (add/update license info) <!-- Don't forget to add/update the info in "LICENSE" & "NOTICE" files (both in root & dist module) -->
- [ ]  Modify configurations
- [ ]  The public API
- [x]  Other affects (typed here)

fix：asf invalid notification scheme 'discussions_status'

## Documentation Status

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ]  `Doc - TODO` <!-- Your PR changes impact docs and you will update later -->
- [ ]  `Doc - Done` <!-- Related docs have been already added or updated -->
- [x]  `Doc - No Need` <!-- Your PR changes don't impact/need docs -->
