### PR TITLE
feat(api&core):  in oltp apis, add statistics info and support full info about vertices and edges

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,8 @@ upload-files/
 demo*
 gen-java
 *.class
+swagger-ui-*
+hugegraph-dist/dist.sh
 
 ### STS ###
 .apt_generated

--- a/.gitignore
+++ b/.gitignore
@@ -7,8 +7,6 @@ upload-files/
 demo*
 gen-java
 *.class
-swagger-ui-*
-hugegraph-dist/dist.sh
 
 ### STS ###
 .apt_generated

--- a/hugegraph-api/src/main/java/org/apache/hugegraph/api/API.java
+++ b/hugegraph-api/src/main/java/org/apache/hugegraph/api/API.java
@@ -48,21 +48,21 @@ public class API {
     public static final String TEXT_PLAIN = MediaType.TEXT_PLAIN;
     public static final String APPLICATION_JSON = MediaType.APPLICATION_JSON;
     public static final String APPLICATION_JSON_WITH_CHARSET =
-            APPLICATION_JSON + ";charset=" + CHARSET;
+                               APPLICATION_JSON + ";charset=" + CHARSET;
     public static final String JSON = MediaType.APPLICATION_JSON_TYPE
-            .getSubtype();
+                                               .getSubtype();
     public static final String ACTION_APPEND = "append";
     public static final String ACTION_ELIMINATE = "eliminate";
     public static final String ACTION_CLEAR = "clear";
     protected static final Logger LOG = Log.logger(API.class);
     private static final Meter SUCCEED_METER =
-            MetricsUtil.registerMeter(API.class, "commit-succeed");
+                         MetricsUtil.registerMeter(API.class, "commit-succeed");
     private static final Meter ILLEGAL_ARG_ERROR_METER =
-            MetricsUtil.registerMeter(API.class, "illegal-arg");
+                         MetricsUtil.registerMeter(API.class, "illegal-arg");
     private static final Meter EXPECTED_ERROR_METER =
-            MetricsUtil.registerMeter(API.class, "expected-error");
+                         MetricsUtil.registerMeter(API.class, "expected-error");
     private static final Meter UNKNOWN_ERROR_METER =
-            MetricsUtil.registerMeter(API.class, "unknown-error");
+                         MetricsUtil.registerMeter(API.class, "unknown-error");
 
     public static HugeGraph graph(GraphManager manager, String graph) {
         HugeGraph g = manager.graph(graph);
@@ -224,6 +224,9 @@ public class API {
             } else if (current instanceof Long) {
                 Long currentLong = (Long) current;
                 measures.put(key, new MutableLong(currentLong + value));
+            } else {
+                throw new NotSupportedException("addCount() method's 'value' datatype must be " +
+                                                "Long or MutableLong");
             }
         }
 

--- a/hugegraph-api/src/main/java/org/apache/hugegraph/api/API.java
+++ b/hugegraph-api/src/main/java/org/apache/hugegraph/api/API.java
@@ -44,29 +44,25 @@ import jakarta.ws.rs.core.MediaType;
 
 public class API {
 
-    protected static final Logger LOG = Log.logger(API.class);
-
     public static final String CHARSET = "UTF-8";
-
     public static final String TEXT_PLAIN = MediaType.TEXT_PLAIN;
     public static final String APPLICATION_JSON = MediaType.APPLICATION_JSON;
     public static final String APPLICATION_JSON_WITH_CHARSET =
-                               APPLICATION_JSON + ";charset=" + CHARSET;
+            APPLICATION_JSON + ";charset=" + CHARSET;
     public static final String JSON = MediaType.APPLICATION_JSON_TYPE
-                                               .getSubtype();
-
+            .getSubtype();
     public static final String ACTION_APPEND = "append";
     public static final String ACTION_ELIMINATE = "eliminate";
     public static final String ACTION_CLEAR = "clear";
-
+    protected static final Logger LOG = Log.logger(API.class);
     private static final Meter SUCCEED_METER =
-                         MetricsUtil.registerMeter(API.class, "commit-succeed");
+            MetricsUtil.registerMeter(API.class, "commit-succeed");
     private static final Meter ILLEGAL_ARG_ERROR_METER =
-                         MetricsUtil.registerMeter(API.class, "illegal-arg");
+            MetricsUtil.registerMeter(API.class, "illegal-arg");
     private static final Meter EXPECTED_ERROR_METER =
-                         MetricsUtil.registerMeter(API.class, "expected-error");
+            MetricsUtil.registerMeter(API.class, "expected-error");
     private static final Meter UNKNOWN_ERROR_METER =
-                         MetricsUtil.registerMeter(API.class, "unknown-error");
+            MetricsUtil.registerMeter(API.class, "unknown-error");
 
     public static HugeGraph graph(GraphManager manager, String graph) {
         HugeGraph g = manager.graph(graph);
@@ -193,17 +189,17 @@ public class API {
 
         public static final String EDGE_ITER = "edge_iterations";
         public static final String VERTICE_ITER = "vertice_iterations";
-        public static final String COST = "cost";
+        public static final String COST = "cost(ns)";
         private final long timeStart;
         private final Map<String, Object> measures;
 
         public ApiMeasurer() {
-            this.timeStart = System.currentTimeMillis();
+            this.timeStart = System.nanoTime();
             this.measures = InsertionOrderUtil.newMap();
         }
 
         public Map<String, Object> measures() {
-            measures.put(COST, System.currentTimeMillis() - timeStart);
+            measures.put(COST, System.nanoTime() - timeStart);
             return measures;
         }
 
@@ -224,8 +220,7 @@ public class API {
             if (current == null) {
                 measures.put(key, new MutableLong(value));
             } else if (current instanceof MutableLong) {
-                MutableLong currentMutableLong = (MutableLong) current;
-                currentMutableLong.add(value);
+                ((MutableLong) measures.computeIfAbsent(key, MutableLong::new)).add(value);
             } else if (current instanceof Long) {
                 Long currentLong = (Long) current;
                 measures.put(key, new MutableLong(currentLong + value));

--- a/hugegraph-api/src/main/java/org/apache/hugegraph/api/traversers/AllShortestPathsAPI.java
+++ b/hugegraph-api/src/main/java/org/apache/hugegraph/api/traversers/AllShortestPathsAPI.java
@@ -81,7 +81,7 @@ public class AllShortestPathsAPI extends API {
         LOG.debug("Graph [{}] get shortest path from '{}', to '{}' with " +
                   "direction {}, edge label {}, max depth '{}', " +
                   "max degree '{}', skipped degree '{}', capacity '{}', " +
-                  "with vertex '{}' and with edge '{}'",
+                  "with_vertex '{}' and with_edge '{}'",
                   graph, source, target, direction, edgeLabel, depth,
                   maxDegree, skipDegree, capacity, withVertex, withEdge);
 

--- a/hugegraph-api/src/main/java/org/apache/hugegraph/api/traversers/AllShortestPathsAPI.java
+++ b/hugegraph-api/src/main/java/org/apache/hugegraph/api/traversers/AllShortestPathsAPI.java
@@ -20,19 +20,10 @@ package org.apache.hugegraph.api.traversers;
 import static org.apache.hugegraph.traversal.algorithm.HugeTraverser.DEFAULT_CAPACITY;
 import static org.apache.hugegraph.traversal.algorithm.HugeTraverser.DEFAULT_MAX_DEGREE;
 
+import java.util.HashSet;
+import java.util.Iterator;
 import java.util.List;
-
-import io.swagger.v3.oas.annotations.tags.Tag;
-import jakarta.inject.Singleton;
-import jakarta.ws.rs.DefaultValue;
-import jakarta.ws.rs.GET;
-import jakarta.ws.rs.Path;
-import jakarta.ws.rs.PathParam;
-import jakarta.ws.rs.Produces;
-import jakarta.ws.rs.QueryParam;
-import jakarta.ws.rs.core.Context;
-
-import org.slf4j.Logger;
+import java.util.Set;
 
 import org.apache.hugegraph.HugeGraph;
 import org.apache.hugegraph.api.API;
@@ -44,8 +35,21 @@ import org.apache.hugegraph.traversal.algorithm.HugeTraverser;
 import org.apache.hugegraph.traversal.algorithm.ShortestPathTraverser;
 import org.apache.hugegraph.type.define.Directions;
 import org.apache.hugegraph.util.Log;
+import org.apache.tinkerpop.gremlin.structure.Edge;
+import org.slf4j.Logger;
+
 import com.codahale.metrics.annotation.Timed;
 import com.google.common.collect.ImmutableList;
+
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.inject.Singleton;
+import jakarta.ws.rs.DefaultValue;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.QueryParam;
+import jakarta.ws.rs.core.Context;
 
 @Path("graphs/{graph}/traversers/allshortestpaths")
 @Singleton
@@ -68,13 +72,20 @@ public class AllShortestPathsAPI extends API {
                       @DefaultValue(DEFAULT_MAX_DEGREE) long maxDegree,
                       @QueryParam("skip_degree")
                       @DefaultValue("0") long skipDegree,
+                      @QueryParam("with_vertex")
+                      @DefaultValue("false") boolean withVertex,
+                      @QueryParam("with_edge")
+                      @DefaultValue("false") boolean withEdge,
                       @QueryParam("capacity")
                       @DefaultValue(DEFAULT_CAPACITY) long capacity) {
         LOG.debug("Graph [{}] get shortest path from '{}', to '{}' with " +
                   "direction {}, edge label {}, max depth '{}', " +
-                  "max degree '{}', skipped degree '{}' and capacity '{}'",
+                  "max degree '{}', skipped degree '{}', capacity '{}', " +
+                  "with vertex '{}' and with edge '{}'",
                   graph, source, target, direction, edgeLabel, depth,
-                  maxDegree, skipDegree, capacity);
+                  maxDegree, skipDegree, capacity, withVertex, withEdge);
+
+        ApiMeasure measure = new ApiMeasure();
 
         Id sourceId = VertexAPI.checkAndParseVertexId(source);
         Id targetId = VertexAPI.checkAndParseVertexId(target);
@@ -86,8 +97,34 @@ public class AllShortestPathsAPI extends API {
         List<String> edgeLabels = edgeLabel == null ? ImmutableList.of() :
                                   ImmutableList.of(edgeLabel);
         HugeTraverser.PathSet paths = traverser.allShortestPaths(
-                                      sourceId, targetId, dir, edgeLabels,
-                                      depth, maxDegree, skipDegree, capacity);
-        return manager.serializer(g).writePaths("paths", paths, false);
+                sourceId, targetId, dir, edgeLabels,
+                depth, maxDegree, skipDegree, capacity);
+
+        measure.addIterCount(traverser.vertexIterCounter.get(),
+                             traverser.edgeIterCounter.get());
+
+        Iterator<?> iterVertex;
+        Set<Id> vertexIds = new HashSet<>();
+        for (HugeTraverser.Path path : paths) {
+            vertexIds.addAll(path.vertices());
+        }
+        if (withVertex && !vertexIds.isEmpty()) {
+            iterVertex = g.vertices(vertexIds.toArray());
+            measure.addIterCount(vertexIds.size(), 0L);
+        } else {
+            iterVertex = vertexIds.iterator();
+        }
+
+        Iterator<?> iterEdge;
+        Set<Edge> edges = paths.getEdges();
+        if (withEdge && !edges.isEmpty()) {
+            iterEdge = edges.iterator();
+        } else {
+            iterEdge = HugeTraverser.EdgeRecord.getEdgeIds(edges).iterator();
+        }
+
+        return manager.serializer(g, measure.getResult())
+                      .writePaths("paths", paths, false,
+                                  iterVertex, iterEdge);
     }
 }

--- a/hugegraph-api/src/main/java/org/apache/hugegraph/api/traversers/AllShortestPathsAPI.java
+++ b/hugegraph-api/src/main/java/org/apache/hugegraph/api/traversers/AllShortestPathsAPI.java
@@ -85,7 +85,7 @@ public class AllShortestPathsAPI extends API {
                   graph, source, target, direction, edgeLabel, depth,
                   maxDegree, skipDegree, capacity, withVertex, withEdge);
 
-        ApiMeasure measure = new ApiMeasure();
+        ApiMeasurer measure = new ApiMeasurer();
 
         Id sourceId = VertexAPI.checkAndParseVertexId(source);
         Id targetId = VertexAPI.checkAndParseVertexId(target);
@@ -96,9 +96,9 @@ public class AllShortestPathsAPI extends API {
         ShortestPathTraverser traverser = new ShortestPathTraverser(g);
         List<String> edgeLabels = edgeLabel == null ? ImmutableList.of() :
                                   ImmutableList.of(edgeLabel);
-        HugeTraverser.PathSet paths = traverser.allShortestPaths(
-                sourceId, targetId, dir, edgeLabels,
-                depth, maxDegree, skipDegree, capacity);
+        HugeTraverser.PathSet paths = traverser.allShortestPaths(sourceId, targetId, dir,
+                                                                 edgeLabels, depth, maxDegree,
+                                                                 skipDegree, capacity);
 
         measure.addIterCount(traverser.vertexIterCounter.get(),
                              traverser.edgeIterCounter.get());
@@ -123,7 +123,7 @@ public class AllShortestPathsAPI extends API {
             iterEdge = HugeTraverser.EdgeRecord.getEdgeIds(edges).iterator();
         }
 
-        return manager.serializer(g, measure.getResult())
+        return manager.serializer(g, measure.measures())
                       .writePaths("paths", paths, false,
                                   iterVertex, iterEdge);
     }

--- a/hugegraph-api/src/main/java/org/apache/hugegraph/api/traversers/CrosspointsAPI.java
+++ b/hugegraph-api/src/main/java/org/apache/hugegraph/api/traversers/CrosspointsAPI.java
@@ -21,18 +21,6 @@ import static org.apache.hugegraph.traversal.algorithm.HugeTraverser.DEFAULT_CAP
 import static org.apache.hugegraph.traversal.algorithm.HugeTraverser.DEFAULT_MAX_DEGREE;
 import static org.apache.hugegraph.traversal.algorithm.HugeTraverser.DEFAULT_PATHS_LIMIT;
 
-import io.swagger.v3.oas.annotations.tags.Tag;
-import jakarta.inject.Singleton;
-import jakarta.ws.rs.DefaultValue;
-import jakarta.ws.rs.GET;
-import jakarta.ws.rs.Path;
-import jakarta.ws.rs.PathParam;
-import jakarta.ws.rs.Produces;
-import jakarta.ws.rs.QueryParam;
-import jakarta.ws.rs.core.Context;
-
-import org.slf4j.Logger;
-
 import org.apache.hugegraph.HugeGraph;
 import org.apache.hugegraph.api.API;
 import org.apache.hugegraph.api.graph.EdgeAPI;
@@ -43,7 +31,19 @@ import org.apache.hugegraph.traversal.algorithm.HugeTraverser;
 import org.apache.hugegraph.traversal.algorithm.PathsTraverser;
 import org.apache.hugegraph.type.define.Directions;
 import org.apache.hugegraph.util.Log;
+import org.slf4j.Logger;
+
 import com.codahale.metrics.annotation.Timed;
+
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.inject.Singleton;
+import jakarta.ws.rs.DefaultValue;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.QueryParam;
+import jakarta.ws.rs.core.Context;
 
 @Path("graphs/{graph}/traversers/crosspoints")
 @Singleton
@@ -74,6 +74,7 @@ public class CrosspointsAPI extends API {
                   graph, source, target, direction, edgeLabel,
                   depth, maxDegree, capacity, limit);
 
+        ApiMeasure measure = new ApiMeasure();
         Id sourceId = VertexAPI.checkAndParseVertexId(source);
         Id targetId = VertexAPI.checkAndParseVertexId(target);
         Directions dir = Directions.convert(EdgeAPI.parseDirection(direction));
@@ -84,6 +85,9 @@ public class CrosspointsAPI extends API {
                                                       dir, edgeLabel, depth,
                                                       maxDegree, capacity,
                                                       limit);
-        return manager.serializer(g).writePaths("crosspoints", paths, true);
+        measure.addIterCount(traverser.vertexIterCounter.get(),
+                             traverser.edgeIterCounter.get());
+        return manager.serializer(g, measure.getResult())
+                      .writePaths("crosspoints", paths, true);
     }
 }

--- a/hugegraph-api/src/main/java/org/apache/hugegraph/api/traversers/CrosspointsAPI.java
+++ b/hugegraph-api/src/main/java/org/apache/hugegraph/api/traversers/CrosspointsAPI.java
@@ -74,7 +74,7 @@ public class CrosspointsAPI extends API {
                   graph, source, target, direction, edgeLabel,
                   depth, maxDegree, capacity, limit);
 
-        ApiMeasure measure = new ApiMeasure();
+        ApiMeasurer measure = new ApiMeasurer();
         Id sourceId = VertexAPI.checkAndParseVertexId(source);
         Id targetId = VertexAPI.checkAndParseVertexId(target);
         Directions dir = Directions.convert(EdgeAPI.parseDirection(direction));
@@ -87,7 +87,7 @@ public class CrosspointsAPI extends API {
                                                       limit);
         measure.addIterCount(traverser.vertexIterCounter.get(),
                              traverser.edgeIterCounter.get());
-        return manager.serializer(g, measure.getResult())
+        return manager.serializer(g, measure.measures())
                       .writePaths("crosspoints", paths, true);
     }
 }

--- a/hugegraph-api/src/main/java/org/apache/hugegraph/api/traversers/CustomizedCrosspointsAPI.java
+++ b/hugegraph-api/src/main/java/org/apache/hugegraph/api/traversers/CustomizedCrosspointsAPI.java
@@ -22,11 +22,29 @@ import static org.apache.hugegraph.traversal.algorithm.HugeTraverser.DEFAULT_MAX
 import static org.apache.hugegraph.traversal.algorithm.HugeTraverser.DEFAULT_PATHS_LIMIT;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+
+import org.apache.hugegraph.HugeGraph;
+import org.apache.hugegraph.api.API;
+import org.apache.hugegraph.backend.id.Id;
+import org.apache.hugegraph.core.GraphManager;
+import org.apache.hugegraph.traversal.algorithm.CustomizedCrosspointsTraverser;
+import org.apache.hugegraph.traversal.algorithm.HugeTraverser;
+import org.apache.hugegraph.type.define.Directions;
+import org.apache.hugegraph.util.E;
+import org.apache.hugegraph.util.Log;
+import org.apache.tinkerpop.gremlin.structure.Edge;
+import org.apache.tinkerpop.gremlin.structure.Vertex;
+import org.slf4j.Logger;
+
+import com.codahale.metrics.annotation.Timed;
+import com.fasterxml.jackson.annotation.JsonAlias;
+import com.fasterxml.jackson.annotation.JsonProperty;
 
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.inject.Singleton;
@@ -37,29 +55,28 @@ import jakarta.ws.rs.PathParam;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.core.Context;
 
-import org.apache.tinkerpop.gremlin.structure.Vertex;
-import org.apache.hugegraph.core.GraphManager;
-import org.slf4j.Logger;
-
-import org.apache.hugegraph.HugeGraph;
-import org.apache.hugegraph.api.API;
-import org.apache.hugegraph.backend.id.Id;
-import org.apache.hugegraph.backend.query.QueryResults;
-import org.apache.hugegraph.traversal.algorithm.CustomizedCrosspointsTraverser;
-import org.apache.hugegraph.traversal.algorithm.HugeTraverser;
-import org.apache.hugegraph.type.define.Directions;
-import org.apache.hugegraph.util.E;
-import org.apache.hugegraph.util.Log;
-import com.codahale.metrics.annotation.Timed;
-import com.fasterxml.jackson.annotation.JsonAlias;
-import com.fasterxml.jackson.annotation.JsonProperty;
-
 @Path("graphs/{graph}/traversers/customizedcrosspoints")
 @Singleton
 @Tag(name = "CustomizedCrosspointsAPI")
 public class CustomizedCrosspointsAPI extends API {
 
     private static final Logger LOG = Log.logger(CustomizedCrosspointsAPI.class);
+
+    private static List<CustomizedCrosspointsTraverser.PathPattern> pathPatterns(
+            HugeGraph graph, CrosspointsRequest request) {
+        int stepSize = request.pathPatterns.size();
+        List<CustomizedCrosspointsTraverser.PathPattern> pathPatterns;
+        pathPatterns = new ArrayList<>(stepSize);
+        for (PathPattern pattern : request.pathPatterns) {
+            CustomizedCrosspointsTraverser.PathPattern pathPattern;
+            pathPattern = new CustomizedCrosspointsTraverser.PathPattern();
+            for (Step step : pattern.steps) {
+                pathPattern.add(step.jsonToStep(graph));
+            }
+            pathPatterns.add(pathPattern);
+        }
+        return pathPatterns;
+    }
 
     @POST
     @Timed
@@ -78,55 +95,56 @@ public class CustomizedCrosspointsAPI extends API {
                         "The steps of crosspoints request can't be empty");
 
         LOG.debug("Graph [{}] get customized crosspoints from source vertex " +
-                  "'{}', with path_pattern '{}', with_path '{}', with_vertex " +
-                  "'{}', capacity '{}' and limit '{}'", graph, request.sources,
-                  request.pathPatterns, request.withPath, request.withVertex,
-                  request.capacity, request.limit);
+                  "'{}', with path_pattern '{}', with path '{}', with vertex " +
+                  "'{}', capacity '{}', limit '{}' and with edge '{}'",
+                  graph, request.sources, request.pathPatterns, request.withPath,
+                  request.withVertex, request.capacity, request.limit, request.withEdge);
+
+        ApiMeasure measure = new ApiMeasure();
 
         HugeGraph g = graph(manager, graph);
         Iterator<Vertex> sources = request.sources.vertices(g);
-        List<CustomizedCrosspointsTraverser.PathPattern> patterns;
-        patterns = pathPatterns(g, request);
 
         CustomizedCrosspointsTraverser traverser =
-                                       new CustomizedCrosspointsTraverser(g);
-        CustomizedCrosspointsTraverser.CrosspointsPaths paths;
-        paths = traverser.crosspointsPaths(sources, patterns, request.capacity,
-                                           request.limit);
-        Iterator<Vertex> iter = QueryResults.emptyIterator();
-        if (!request.withVertex) {
-            return manager.serializer(g).writeCrosspoints(paths, iter,
-                                                          request.withPath);
-        }
-        Set<Id> ids = new HashSet<>();
+                new CustomizedCrosspointsTraverser(g);
+
+        List<CustomizedCrosspointsTraverser.PathPattern> patterns = pathPatterns(g, request);
+        CustomizedCrosspointsTraverser.CrosspointsPaths paths =
+                traverser.crosspointsPaths(sources, patterns, request.capacity, request.limit);
+
+        measure.addIterCount(traverser.vertexIterCounter.get(),
+                             traverser.edgeIterCounter.get());
+
+
+        Iterator<?> iterVertex;
+        Set<Id> vertexIds = new HashSet<>();
         if (request.withPath) {
-            for (HugeTraverser.Path p : paths.paths()) {
-                ids.addAll(p.vertices());
+            for (HugeTraverser.Path path : paths.paths()) {
+                vertexIds.addAll(path.vertices());
             }
         } else {
-            ids = paths.crosspoints();
+            vertexIds = paths.crosspoints();
         }
-        if (!ids.isEmpty()) {
-            iter = g.vertices(ids.toArray());
+        if (request.withVertex && !vertexIds.isEmpty()) {
+            iterVertex = g.vertices(vertexIds.toArray());
+            measure.addIterCount(vertexIds.size(), 0L);
+        } else {
+            iterVertex = vertexIds.iterator();
         }
-        return manager.serializer(g).writeCrosspoints(paths, iter,
-                                                      request.withPath);
-    }
 
-    private static List<CustomizedCrosspointsTraverser.PathPattern>
-                   pathPatterns(HugeGraph graph, CrosspointsRequest request) {
-        int stepSize = request.pathPatterns.size();
-        List<CustomizedCrosspointsTraverser.PathPattern> pathPatterns;
-        pathPatterns = new ArrayList<>(stepSize);
-        for (PathPattern pattern : request.pathPatterns) {
-            CustomizedCrosspointsTraverser.PathPattern pathPattern;
-            pathPattern = new CustomizedCrosspointsTraverser.PathPattern();
-            for (Step step : pattern.steps) {
-                pathPattern.add(step.jsonToStep(graph));
+        Iterator<?> iterEdge = Collections.emptyIterator();
+        if (request.withPath) {
+            Set<Edge> edges = traverser.getEdgeRecord().getEdges(paths.paths());
+            if (request.withEdge) {
+                iterEdge = edges.iterator();
+            } else {
+                iterEdge = HugeTraverser.EdgeRecord.getEdgeIds(edges).iterator();
             }
-            pathPatterns.add(pathPattern);
         }
-        return pathPatterns;
+
+        return manager.serializer(g, measure.getResult())
+                      .writeCrosspoints(paths, iterVertex,
+                                        iterEdge, request.withPath);
     }
 
     private static class CrosspointsRequest {
@@ -143,14 +161,16 @@ public class CustomizedCrosspointsAPI extends API {
         public boolean withPath = false;
         @JsonProperty("with_vertex")
         public boolean withVertex = false;
+        @JsonProperty("with_edge")
+        public boolean withEdge = false;
 
         @Override
         public String toString() {
             return String.format("CrosspointsRequest{sourceVertex=%s," +
                                  "pathPatterns=%s,withPath=%s,withVertex=%s," +
-                                 "capacity=%s,limit=%s}", this.sources,
-                                 this.pathPatterns, this.withPath,
-                                 this.withVertex, this.capacity, this.limit);
+                                 "capacity=%s,limit=%s,withEdge=%s}", this.sources,
+                                 this.pathPatterns, this.withPath, this.withVertex,
+                                 this.capacity, this.limit, this.withEdge);
         }
     }
 

--- a/hugegraph-api/src/main/java/org/apache/hugegraph/api/traversers/CustomizedCrosspointsAPI.java
+++ b/hugegraph-api/src/main/java/org/apache/hugegraph/api/traversers/CustomizedCrosspointsAPI.java
@@ -65,11 +65,10 @@ public class CustomizedCrosspointsAPI extends API {
     private static List<CustomizedCrosspointsTraverser.PathPattern> pathPatterns(
             HugeGraph graph, CrosspointsRequest request) {
         int stepSize = request.pathPatterns.size();
-        List<CustomizedCrosspointsTraverser.PathPattern> pathPatterns;
-        pathPatterns = new ArrayList<>(stepSize);
+        List<CustomizedCrosspointsTraverser.PathPattern> pathPatterns = new ArrayList<>(stepSize);
         for (PathPattern pattern : request.pathPatterns) {
-            CustomizedCrosspointsTraverser.PathPattern pathPattern;
-            pathPattern = new CustomizedCrosspointsTraverser.PathPattern();
+            CustomizedCrosspointsTraverser.PathPattern pathPattern =
+                    new CustomizedCrosspointsTraverser.PathPattern();
             for (Step step : pattern.steps) {
                 pathPattern.add(step.jsonToStep(graph));
             }
@@ -100,7 +99,7 @@ public class CustomizedCrosspointsAPI extends API {
                   graph, request.sources, request.pathPatterns, request.withPath,
                   request.withVertex, request.capacity, request.limit, request.withEdge);
 
-        ApiMeasure measure = new ApiMeasure();
+        ApiMeasurer measure = new ApiMeasurer();
 
         HugeGraph g = graph(manager, graph);
         Iterator<Vertex> sources = request.sources.vertices(g);
@@ -142,7 +141,7 @@ public class CustomizedCrosspointsAPI extends API {
             }
         }
 
-        return manager.serializer(g, measure.getResult())
+        return manager.serializer(g, measure.measures())
                       .writeCrosspoints(paths, iterVertex,
                                         iterEdge, request.withPath);
     }

--- a/hugegraph-api/src/main/java/org/apache/hugegraph/api/traversers/CustomizedCrosspointsAPI.java
+++ b/hugegraph-api/src/main/java/org/apache/hugegraph/api/traversers/CustomizedCrosspointsAPI.java
@@ -133,7 +133,7 @@ public class CustomizedCrosspointsAPI extends API {
 
         Iterator<?> iterEdge = Collections.emptyIterator();
         if (request.withPath) {
-            Set<Edge> edges = traverser.getEdgeRecord().getEdges(paths.paths());
+            Set<Edge> edges = traverser.edgeResults().getEdges(paths.paths());
             if (request.withEdge) {
                 iterEdge = edges.iterator();
             } else {

--- a/hugegraph-api/src/main/java/org/apache/hugegraph/api/traversers/CustomizedCrosspointsAPI.java
+++ b/hugegraph-api/src/main/java/org/apache/hugegraph/api/traversers/CustomizedCrosspointsAPI.java
@@ -94,8 +94,8 @@ public class CustomizedCrosspointsAPI extends API {
                         "The steps of crosspoints request can't be empty");
 
         LOG.debug("Graph [{}] get customized crosspoints from source vertex " +
-                  "'{}', with path_pattern '{}', with path '{}', with vertex " +
-                  "'{}', capacity '{}', limit '{}' and with edge '{}'",
+                  "'{}', with path_pattern '{}', with path '{}', with_vertex " +
+                  "'{}', capacity '{}', limit '{}' and with_edge '{}'",
                   graph, request.sources, request.pathPatterns, request.withPath,
                   request.withVertex, request.capacity, request.limit, request.withEdge);
 

--- a/hugegraph-api/src/main/java/org/apache/hugegraph/api/traversers/CustomizedPathsAPI.java
+++ b/hugegraph-api/src/main/java/org/apache/hugegraph/api/traversers/CustomizedPathsAPI.java
@@ -65,10 +65,10 @@ public class CustomizedPathsAPI extends API {
     private static final Logger LOG = Log.logger(CustomizedPathsAPI.class);
 
     private static List<WeightedEdgeStep> step(HugeGraph graph,
-                                               PathRequest req) {
-        int stepSize = req.steps.size();
+                                               PathRequest request) {
+        int stepSize = request.steps.size();
         List<WeightedEdgeStep> steps = new ArrayList<>(stepSize);
-        for (Step step : req.steps) {
+        for (Step step : request.steps) {
             steps.add(step.jsonToStep(graph));
         }
         return steps;
@@ -92,7 +92,7 @@ public class CustomizedPathsAPI extends API {
 
         LOG.debug("Graph [{}] get customized paths from source vertex '{}', " +
                   "with steps '{}', sort by '{}', capacity '{}', limit '{}', " +
-                  "with vertex '{}' and with edge '{}'", graph, request.sources, request.steps,
+                  "with_vertex '{}' and with_edge '{}'", graph, request.sources, request.steps,
                   request.sortBy, request.capacity, request.limit,
                   request.withVertex, request.withEdge);
 
@@ -129,7 +129,7 @@ public class CustomizedPathsAPI extends API {
         }
 
         Iterator<?> iterEdge;
-        Set<Edge> edges = traverser.getEdgeRecord().getEdges(paths);
+        Set<Edge> edges = traverser.edgeResults().getEdges(paths);
         if (request.withEdge && !edges.isEmpty()) {
             iterEdge = edges.iterator();
         } else {

--- a/hugegraph-api/src/main/java/org/apache/hugegraph/api/traversers/CustomizedPathsAPI.java
+++ b/hugegraph-api/src/main/java/org/apache/hugegraph/api/traversers/CustomizedPathsAPI.java
@@ -96,7 +96,7 @@ public class CustomizedPathsAPI extends API {
                   request.sortBy, request.capacity, request.limit,
                   request.withVertex, request.withEdge);
 
-        ApiMeasure measure = new ApiMeasure();
+        ApiMeasurer measure = new ApiMeasurer();
 
         HugeGraph g = graph(manager, graph);
         Iterator<Vertex> sources = request.sources.vertices(g);
@@ -136,7 +136,7 @@ public class CustomizedPathsAPI extends API {
             iterEdge = HugeTraverser.EdgeRecord.getEdgeIds(edges).iterator();
         }
 
-        return manager.serializer(g, measure.getResult())
+        return manager.serializer(g, measure.measures())
                       .writePaths("paths", paths, false,
                                   iterVertex, iterEdge);
     }

--- a/hugegraph-api/src/main/java/org/apache/hugegraph/api/traversers/CustomizedPathsAPI.java
+++ b/hugegraph-api/src/main/java/org/apache/hugegraph/api/traversers/CustomizedPathsAPI.java
@@ -30,6 +30,24 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import org.apache.hugegraph.HugeGraph;
+import org.apache.hugegraph.api.API;
+import org.apache.hugegraph.backend.id.Id;
+import org.apache.hugegraph.core.GraphManager;
+import org.apache.hugegraph.traversal.algorithm.CustomizePathsTraverser;
+import org.apache.hugegraph.traversal.algorithm.HugeTraverser;
+import org.apache.hugegraph.traversal.algorithm.steps.WeightedEdgeStep;
+import org.apache.hugegraph.type.define.Directions;
+import org.apache.hugegraph.util.E;
+import org.apache.hugegraph.util.Log;
+import org.apache.tinkerpop.gremlin.structure.Edge;
+import org.apache.tinkerpop.gremlin.structure.Vertex;
+import org.slf4j.Logger;
+
+import com.codahale.metrics.annotation.Timed;
+import com.fasterxml.jackson.annotation.JsonAlias;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.inject.Singleton;
 import jakarta.ws.rs.Consumes;
@@ -39,30 +57,22 @@ import jakarta.ws.rs.PathParam;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.core.Context;
 
-import org.apache.tinkerpop.gremlin.structure.Vertex;
-import org.apache.hugegraph.core.GraphManager;
-import org.slf4j.Logger;
-
-import org.apache.hugegraph.HugeGraph;
-import org.apache.hugegraph.api.API;
-import org.apache.hugegraph.backend.id.Id;
-import org.apache.hugegraph.backend.query.QueryResults;
-import org.apache.hugegraph.traversal.algorithm.CustomizePathsTraverser;
-import org.apache.hugegraph.traversal.algorithm.HugeTraverser;
-import org.apache.hugegraph.traversal.algorithm.steps.WeightedEdgeStep;
-import org.apache.hugegraph.type.define.Directions;
-import org.apache.hugegraph.util.E;
-import org.apache.hugegraph.util.Log;
-import com.codahale.metrics.annotation.Timed;
-import com.fasterxml.jackson.annotation.JsonAlias;
-import com.fasterxml.jackson.annotation.JsonProperty;
-
 @Path("graphs/{graph}/traversers/customizedpaths")
 @Singleton
 @Tag(name = "CustomizedPathsAPI")
 public class CustomizedPathsAPI extends API {
 
     private static final Logger LOG = Log.logger(CustomizedPathsAPI.class);
+
+    private static List<WeightedEdgeStep> step(HugeGraph graph,
+                                               PathRequest req) {
+        int stepSize = req.steps.size();
+        List<WeightedEdgeStep> steps = new ArrayList<>(stepSize);
+        for (Step step : req.steps) {
+            steps.add(step.jsonToStep(graph));
+        }
+        return steps;
+    }
 
     @POST
     @Timed
@@ -81,10 +91,12 @@ public class CustomizedPathsAPI extends API {
         }
 
         LOG.debug("Graph [{}] get customized paths from source vertex '{}', " +
-                  "with steps '{}', sort by '{}', capacity '{}', limit '{}' " +
-                  "and with_vertex '{}'", graph, request.sources, request.steps,
+                  "with steps '{}', sort by '{}', capacity '{}', limit '{}', " +
+                  "with vertex '{}' and with edge '{}'", graph, request.sources, request.steps,
                   request.sortBy, request.capacity, request.limit,
-                  request.withVertex);
+                  request.withVertex, request.withEdge);
+
+        ApiMeasure measure = new ApiMeasure();
 
         HugeGraph g = graph(manager, graph);
         Iterator<Vertex> sources = request.sources.vertices(g);
@@ -95,6 +107,8 @@ public class CustomizedPathsAPI extends API {
         List<HugeTraverser.Path> paths;
         paths = traverser.customizedPaths(sources, steps, sorted,
                                           request.capacity, request.limit);
+        measure.addIterCount(traverser.vertexIterCounter.get(),
+                             traverser.edgeIterCounter.get());
 
         if (sorted) {
             boolean incr = request.sortBy == SortBy.INCR;
@@ -102,29 +116,35 @@ public class CustomizedPathsAPI extends API {
                                                      request.limit);
         }
 
-        if (!request.withVertex) {
-            return manager.serializer(g).writePaths("paths", paths, false);
+        Iterator<?> iterVertex;
+        Set<Id> vertexIds = new HashSet<>();
+        for (HugeTraverser.Path path : paths) {
+            vertexIds.addAll(path.vertices());
+        }
+        if (request.withVertex && !vertexIds.isEmpty()) {
+            iterVertex = g.vertices(vertexIds.toArray());
+            measure.addIterCount(vertexIds.size(), 0L);
+        } else {
+            iterVertex = vertexIds.iterator();
         }
 
-        Set<Id> ids = new HashSet<>();
-        for (HugeTraverser.Path p : paths) {
-            ids.addAll(p.vertices());
+        Iterator<?> iterEdge;
+        Set<Edge> edges = traverser.getEdgeRecord().getEdges(paths);
+        if (request.withEdge && !edges.isEmpty()) {
+            iterEdge = edges.iterator();
+        } else {
+            iterEdge = HugeTraverser.EdgeRecord.getEdgeIds(edges).iterator();
         }
-        Iterator<Vertex> iter = QueryResults.emptyIterator();
-        if (!ids.isEmpty()) {
-            iter = g.vertices(ids.toArray());
-        }
-        return manager.serializer(g).writePaths("paths", paths, false, iter);
+
+        return manager.serializer(g, measure.getResult())
+                      .writePaths("paths", paths, false,
+                                  iterVertex, iterEdge);
     }
 
-    private static List<WeightedEdgeStep> step(HugeGraph graph,
-                                               PathRequest req) {
-        int stepSize = req.steps.size();
-        List<WeightedEdgeStep> steps = new ArrayList<>(stepSize);
-        for (Step step : req.steps) {
-            steps.add(step.jsonToStep(graph));
-        }
-        return steps;
+    private enum SortBy {
+        INCR,
+        DECR,
+        NONE
     }
 
     private static class PathRequest {
@@ -142,13 +162,16 @@ public class CustomizedPathsAPI extends API {
         @JsonProperty("with_vertex")
         public boolean withVertex = false;
 
+        @JsonProperty("with_edge")
+        public boolean withEdge = false;
+
         @Override
         public String toString() {
             return String.format("PathRequest{sourceVertex=%s,steps=%s," +
                                  "sortBy=%s,capacity=%s,limit=%s," +
-                                 "withVertex=%s}", this.sources, this.steps,
+                                 "withVertex=%s,withEdge=%s}", this.sources, this.steps,
                                  this.sortBy, this.capacity, this.limit,
-                                 this.withVertex);
+                                 this.withVertex, this.withEdge);
         }
     }
 
@@ -189,11 +212,5 @@ public class CustomizedPathsAPI extends API {
                                         this.skipDegree, this.weightBy,
                                         this.defaultWeight, this.sample);
         }
-    }
-
-    private enum SortBy {
-        INCR,
-        DECR,
-        NONE
     }
 }

--- a/hugegraph-api/src/main/java/org/apache/hugegraph/api/traversers/EdgesAPI.java
+++ b/hugegraph-api/src/main/java/org/apache/hugegraph/api/traversers/EdgesAPI.java
@@ -22,6 +22,22 @@ import static org.apache.hugegraph.traversal.algorithm.HugeTraverser.DEFAULT_PAG
 import java.util.Iterator;
 import java.util.List;
 
+import org.apache.hugegraph.HugeGraph;
+import org.apache.hugegraph.api.API;
+import org.apache.hugegraph.api.filter.CompressInterceptor.Compress;
+import org.apache.hugegraph.backend.id.Id;
+import org.apache.hugegraph.backend.query.ConditionQuery;
+import org.apache.hugegraph.backend.store.Shard;
+import org.apache.hugegraph.core.GraphManager;
+import org.apache.hugegraph.structure.HugeEdge;
+import org.apache.hugegraph.type.HugeType;
+import org.apache.hugegraph.util.E;
+import org.apache.hugegraph.util.Log;
+import org.apache.tinkerpop.gremlin.structure.Edge;
+import org.slf4j.Logger;
+
+import com.codahale.metrics.annotation.Timed;
+
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.inject.Singleton;
 import jakarta.ws.rs.DefaultValue;
@@ -31,22 +47,6 @@ import jakarta.ws.rs.PathParam;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.QueryParam;
 import jakarta.ws.rs.core.Context;
-
-import org.apache.tinkerpop.gremlin.structure.Edge;
-import org.apache.hugegraph.core.GraphManager;
-import org.slf4j.Logger;
-
-import org.apache.hugegraph.HugeGraph;
-import org.apache.hugegraph.api.API;
-import org.apache.hugegraph.api.filter.CompressInterceptor.Compress;
-import org.apache.hugegraph.backend.id.Id;
-import org.apache.hugegraph.backend.query.ConditionQuery;
-import org.apache.hugegraph.backend.store.Shard;
-import org.apache.hugegraph.structure.HugeEdge;
-import org.apache.hugegraph.type.HugeType;
-import org.apache.hugegraph.util.E;
-import org.apache.hugegraph.util.Log;
-import com.codahale.metrics.annotation.Timed;
 
 @Path("graphs/{graph}/traversers/edges")
 @Singleton

--- a/hugegraph-api/src/main/java/org/apache/hugegraph/api/traversers/FusiformSimilarityAPI.java
+++ b/hugegraph-api/src/main/java/org/apache/hugegraph/api/traversers/FusiformSimilarityAPI.java
@@ -101,8 +101,7 @@ public class FusiformSimilarityAPI extends API {
         E.checkArgument(sources != null && sources.hasNext(),
                         "The source vertices can't be empty");
 
-        FusiformSimilarityTraverser traverser =
-                new FusiformSimilarityTraverser(g);
+        FusiformSimilarityTraverser traverser = new FusiformSimilarityTraverser(g);
         SimilarsMap result = traverser.fusiformSimilarity(
                 sources, request.direction, request.label,
                 request.minNeighbors, request.alpha,

--- a/hugegraph-api/src/main/java/org/apache/hugegraph/api/traversers/FusiformSimilarityAPI.java
+++ b/hugegraph-api/src/main/java/org/apache/hugegraph/api/traversers/FusiformSimilarityAPI.java
@@ -23,6 +23,23 @@ import static org.apache.hugegraph.traversal.algorithm.HugeTraverser.DEFAULT_PAT
 import static org.apache.hugegraph.traversal.algorithm.HugeTraverser.NO_LIMIT;
 
 import java.util.Iterator;
+import java.util.Set;
+
+import org.apache.hugegraph.HugeGraph;
+import org.apache.hugegraph.api.API;
+import org.apache.hugegraph.backend.id.Id;
+import org.apache.hugegraph.core.GraphManager;
+import org.apache.hugegraph.traversal.algorithm.FusiformSimilarityTraverser;
+import org.apache.hugegraph.traversal.algorithm.FusiformSimilarityTraverser.SimilarsMap;
+import org.apache.hugegraph.type.define.Directions;
+import org.apache.hugegraph.util.E;
+import org.apache.hugegraph.util.Log;
+import org.apache.tinkerpop.gremlin.structure.Vertex;
+import org.apache.tinkerpop.gremlin.structure.util.CloseableIterator;
+import org.slf4j.Logger;
+
+import com.codahale.metrics.annotation.Timed;
+import com.fasterxml.jackson.annotation.JsonProperty;
 
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.inject.Singleton;
@@ -32,22 +49,6 @@ import jakarta.ws.rs.Path;
 import jakarta.ws.rs.PathParam;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.core.Context;
-
-import org.apache.tinkerpop.gremlin.structure.Vertex;
-import org.apache.tinkerpop.gremlin.structure.util.CloseableIterator;
-import org.apache.hugegraph.core.GraphManager;
-import org.slf4j.Logger;
-
-import org.apache.hugegraph.HugeGraph;
-import org.apache.hugegraph.api.API;
-import org.apache.hugegraph.backend.query.QueryResults;
-import org.apache.hugegraph.traversal.algorithm.FusiformSimilarityTraverser;
-import org.apache.hugegraph.traversal.algorithm.FusiformSimilarityTraverser.SimilarsMap;
-import org.apache.hugegraph.type.define.Directions;
-import org.apache.hugegraph.util.E;
-import org.apache.hugegraph.util.Log;
-import com.codahale.metrics.annotation.Timed;
-import com.fasterxml.jackson.annotation.JsonProperty;
 
 @Path("graphs/{graph}/traversers/fusiformsimilarity")
 @Singleton
@@ -64,7 +65,7 @@ public class FusiformSimilarityAPI extends API {
                        @PathParam("graph") String graph,
                        FusiformSimilarityRequest request) {
         E.checkArgumentNotNull(request, "The fusiform similarity " +
-                               "request body can't be null");
+                                        "request body can't be null");
         E.checkArgumentNotNull(request.sources,
                                "The sources of fusiform similarity " +
                                "request can't be null");
@@ -94,28 +95,38 @@ public class FusiformSimilarityAPI extends API {
                   request.minNeighbors, request.alpha, request.minSimilars,
                   request.groupProperty, request.minGroups);
 
+        ApiMeasure measure = new ApiMeasure();
         HugeGraph g = graph(manager, graph);
         Iterator<Vertex> sources = request.sources.vertices(g);
         E.checkArgument(sources != null && sources.hasNext(),
                         "The source vertices can't be empty");
 
         FusiformSimilarityTraverser traverser =
-                                    new FusiformSimilarityTraverser(g);
+                new FusiformSimilarityTraverser(g);
         SimilarsMap result = traverser.fusiformSimilarity(
-                             sources, request.direction, request.label,
-                             request.minNeighbors, request.alpha,
-                             request.minSimilars, request.top,
-                             request.groupProperty, request.minGroups,
-                             request.maxDegree, request.capacity,
-                             request.limit, request.withIntermediary);
+                sources, request.direction, request.label,
+                request.minNeighbors, request.alpha,
+                request.minSimilars, request.top,
+                request.groupProperty, request.minGroups,
+                request.maxDegree, request.capacity,
+                request.limit, request.withIntermediary);
 
         CloseableIterator.closeIterator(sources);
 
-        Iterator<Vertex> iterator = QueryResults.emptyIterator();
-        if (request.withVertex && !result.isEmpty()) {
-            iterator = g.vertices(result.vertices().toArray());
+        measure.addIterCount(traverser.vertexIterCounter.get(),
+                             traverser.edgeIterCounter.get());
+
+        Iterator<?> iterVertex;
+        Set<Id> vertexIds = result.vertices();
+        if (request.withVertex && !vertexIds.isEmpty()) {
+            iterVertex = g.vertices(vertexIds.toArray());
+            measure.addIterCount(vertexIds.size(), 0);
+        } else {
+            iterVertex = vertexIds.iterator();
         }
-        return manager.serializer(g).writeSimilars(result, iterator);
+
+        return manager.serializer(g, measure.getResult())
+                      .writeSimilars(result, iterVertex);
     }
 
     private static class FusiformSimilarityRequest {

--- a/hugegraph-api/src/main/java/org/apache/hugegraph/api/traversers/FusiformSimilarityAPI.java
+++ b/hugegraph-api/src/main/java/org/apache/hugegraph/api/traversers/FusiformSimilarityAPI.java
@@ -95,7 +95,7 @@ public class FusiformSimilarityAPI extends API {
                   request.minNeighbors, request.alpha, request.minSimilars,
                   request.groupProperty, request.minGroups);
 
-        ApiMeasure measure = new ApiMeasure();
+        ApiMeasurer measure = new ApiMeasurer();
         HugeGraph g = graph(manager, graph);
         Iterator<Vertex> sources = request.sources.vertices(g);
         E.checkArgument(sources != null && sources.hasNext(),
@@ -125,7 +125,7 @@ public class FusiformSimilarityAPI extends API {
             iterVertex = vertexIds.iterator();
         }
 
-        return manager.serializer(g, measure.getResult())
+        return manager.serializer(g, measure.measures())
                       .writeSimilars(result, iterVertex);
     }
 

--- a/hugegraph-api/src/main/java/org/apache/hugegraph/api/traversers/JaccardSimilarityAPI.java
+++ b/hugegraph-api/src/main/java/org/apache/hugegraph/api/traversers/JaccardSimilarityAPI.java
@@ -74,7 +74,7 @@ public class JaccardSimilarityAPI extends TraverserAPI {
                   "with direction {}, edge label {} and max degree '{}'",
                   graph, vertex, other, direction, edgeLabel, maxDegree);
 
-        ApiMeasure measure = new ApiMeasure();
+        ApiMeasurer measure = new ApiMeasurer();
 
         Id sourceId = VertexAPI.checkAndParseVertexId(vertex);
         Id targetId = VertexAPI.checkAndParseVertexId(other);
@@ -90,7 +90,7 @@ public class JaccardSimilarityAPI extends TraverserAPI {
                                  traverser.edgeIterCounter.get());
         }
 
-        return manager.serializer(g, measure.getResult())
+        return manager.serializer(g, measure.measures())
                       .writeMap(ImmutableMap.of("jaccard_similarity", similarity));
     }
 
@@ -114,7 +114,7 @@ public class JaccardSimilarityAPI extends TraverserAPI {
                   graph, request.vertex, request.step,
                   request.top, request.capacity);
 
-        ApiMeasure measure = new ApiMeasure();
+        ApiMeasurer measure = new ApiMeasurer();
 
         HugeGraph g = graph(manager, graph);
         Id sourceId = HugeVertex.getIdValue(request.vertex);
@@ -129,7 +129,7 @@ public class JaccardSimilarityAPI extends TraverserAPI {
             measure.addIterCount(traverser.vertexIterCounter.get(),
                                  traverser.edgeIterCounter.get());
         }
-        return manager.serializer(g, measure.getResult())
+        return manager.serializer(g, measure.measures())
                       .writeMap(ImmutableMap.of("jaccard_similarity", results));
     }
 

--- a/hugegraph-api/src/main/java/org/apache/hugegraph/api/traversers/JaccardSimilarityAPI.java
+++ b/hugegraph-api/src/main/java/org/apache/hugegraph/api/traversers/JaccardSimilarityAPI.java
@@ -18,10 +18,27 @@
 package org.apache.hugegraph.api.traversers;
 
 import static org.apache.hugegraph.traversal.algorithm.HugeTraverser.DEFAULT_CAPACITY;
-import static org.apache.hugegraph.traversal.algorithm.HugeTraverser.DEFAULT_MAX_DEGREE;
 import static org.apache.hugegraph.traversal.algorithm.HugeTraverser.DEFAULT_LIMIT;
+import static org.apache.hugegraph.traversal.algorithm.HugeTraverser.DEFAULT_MAX_DEGREE;
 
 import java.util.Map;
+
+import org.apache.hugegraph.HugeGraph;
+import org.apache.hugegraph.api.graph.EdgeAPI;
+import org.apache.hugegraph.api.graph.VertexAPI;
+import org.apache.hugegraph.backend.id.Id;
+import org.apache.hugegraph.core.GraphManager;
+import org.apache.hugegraph.structure.HugeVertex;
+import org.apache.hugegraph.traversal.algorithm.JaccardSimilarTraverser;
+import org.apache.hugegraph.traversal.algorithm.steps.EdgeStep;
+import org.apache.hugegraph.type.define.Directions;
+import org.apache.hugegraph.util.E;
+import org.apache.hugegraph.util.Log;
+import org.slf4j.Logger;
+
+import com.codahale.metrics.annotation.Timed;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.collect.ImmutableMap;
 
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.inject.Singleton;
@@ -34,24 +51,6 @@ import jakarta.ws.rs.PathParam;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.QueryParam;
 import jakarta.ws.rs.core.Context;
-
-import org.apache.hugegraph.core.GraphManager;
-import org.slf4j.Logger;
-
-import org.apache.hugegraph.HugeGraph;
-import org.apache.hugegraph.api.graph.EdgeAPI;
-import org.apache.hugegraph.api.graph.VertexAPI;
-import org.apache.hugegraph.backend.id.Id;
-import org.apache.hugegraph.structure.HugeVertex;
-import org.apache.hugegraph.traversal.algorithm.steps.EdgeStep;
-import org.apache.hugegraph.traversal.algorithm.JaccardSimilarTraverser;
-import org.apache.hugegraph.type.define.Directions;
-import org.apache.hugegraph.util.E;
-import org.apache.hugegraph.util.JsonUtil;
-import org.apache.hugegraph.util.Log;
-import com.codahale.metrics.annotation.Timed;
-import com.fasterxml.jackson.annotation.JsonProperty;
-import com.google.common.collect.ImmutableMap;
 
 @Path("graphs/{graph}/traversers/jaccardsimilarity")
 @Singleton
@@ -75,6 +74,8 @@ public class JaccardSimilarityAPI extends TraverserAPI {
                   "with direction {}, edge label {} and max degree '{}'",
                   graph, vertex, other, direction, edgeLabel, maxDegree);
 
+        ApiMeasure measure = new ApiMeasure();
+
         Id sourceId = VertexAPI.checkAndParseVertexId(vertex);
         Id targetId = VertexAPI.checkAndParseVertexId(other);
         Directions dir = Directions.convert(EdgeAPI.parseDirection(direction));
@@ -82,12 +83,15 @@ public class JaccardSimilarityAPI extends TraverserAPI {
         HugeGraph g = graph(manager, graph);
         double similarity;
         try (JaccardSimilarTraverser traverser =
-                                     new JaccardSimilarTraverser(g)) {
+                     new JaccardSimilarTraverser(g)) {
             similarity = traverser.jaccardSimilarity(sourceId, targetId, dir,
                                                      edgeLabel, maxDegree);
+            measure.addIterCount(traverser.vertexIterCounter.get(),
+                                 traverser.edgeIterCounter.get());
         }
-        return JsonUtil.toJson(ImmutableMap.of("jaccard_similarity",
-                                               similarity));
+
+        return manager.serializer(g, measure.getResult())
+                      .writeMap(ImmutableMap.of("jaccard_similarity", similarity));
     }
 
     @POST
@@ -110,6 +114,8 @@ public class JaccardSimilarityAPI extends TraverserAPI {
                   graph, request.vertex, request.step,
                   request.top, request.capacity);
 
+        ApiMeasure measure = new ApiMeasure();
+
         HugeGraph g = graph(manager, graph);
         Id sourceId = HugeVertex.getIdValue(request.vertex);
 
@@ -117,11 +123,14 @@ public class JaccardSimilarityAPI extends TraverserAPI {
 
         Map<Id, Double> results;
         try (JaccardSimilarTraverser traverser =
-                                     new JaccardSimilarTraverser(g)) {
+                     new JaccardSimilarTraverser(g)) {
             results = traverser.jaccardSimilars(sourceId, step, request.top,
                                                 request.capacity);
+            measure.addIterCount(traverser.vertexIterCounter.get(),
+                                 traverser.edgeIterCounter.get());
         }
-        return manager.serializer(g).writeMap(results);
+        return manager.serializer(g, measure.getResult())
+                      .writeMap(ImmutableMap.of("jaccard_similarity", results));
     }
 
     private static class Request {

--- a/hugegraph-api/src/main/java/org/apache/hugegraph/api/traversers/KneighborAPI.java
+++ b/hugegraph-api/src/main/java/org/apache/hugegraph/api/traversers/KneighborAPI.java
@@ -124,7 +124,7 @@ public class KneighborAPI extends TraverserAPI {
                         "The steps of request can't be null");
         if (request.countOnly) {
             E.checkArgument(!request.withVertex && !request.withPath && !request.withEdge,
-                            "Can't return vertex or path or edge when count only");
+                            "Can't return vertex, edge or path when count only");
         }
 
         LOG.debug("Graph [{}] get customized kneighbor from source vertex " +
@@ -185,7 +185,7 @@ public class KneighborAPI extends TraverserAPI {
 
         Iterator<?> iterEdge = Collections.emptyIterator();
         if (request.withPath) {
-            Set<Edge> edges = results.getEdgeIdRecord().getEdges(paths);
+            Set<Edge> edges = results.edgeResults().getEdges(paths);
             if (request.withEdge) {
                 iterEdge = edges.iterator();
             } else {

--- a/hugegraph-api/src/main/java/org/apache/hugegraph/api/traversers/KneighborAPI.java
+++ b/hugegraph-api/src/main/java/org/apache/hugegraph/api/traversers/KneighborAPI.java
@@ -89,7 +89,7 @@ public class KneighborAPI extends TraverserAPI {
                   graph, sourceV, direction, edgeLabel, depth,
                   maxDegree, limit);
 
-        ApiMeasure measure = new ApiMeasure();
+        ApiMeasurer measure = new ApiMeasurer();
 
         Id source = VertexAPI.checkAndParseVertexId(sourceV);
         Directions dir = Directions.convert(EdgeAPI.parseDirection(direction));
@@ -104,10 +104,10 @@ public class KneighborAPI extends TraverserAPI {
                                  traverser.edgeIterCounter.get());
         }
         if (countOnly) {
-            return manager.serializer(g, measure.getResult()).writeMap(
-                    ImmutableMap.of("vertices_size", ids.size()));
+            return manager.serializer(g, measure.measures())
+                          .writeMap(ImmutableMap.of("vertices_size", ids.size()));
         }
-        return manager.serializer(g, measure.getResult()).writeList("vertices", ids);
+        return manager.serializer(g, measure.measures()).writeList("vertices", ids);
     }
 
     @POST
@@ -134,7 +134,7 @@ public class KneighborAPI extends TraverserAPI {
                   request.countOnly, request.withVertex, request.withPath,
                   request.withEdge);
 
-        ApiMeasure measure = new ApiMeasure();
+        ApiMeasurer measure = new ApiMeasurer();
 
         HugeGraph g = graph(manager, graph);
         Id sourceId = HugeVertex.getIdValue(request.source);
@@ -163,7 +163,7 @@ public class KneighborAPI extends TraverserAPI {
         }
 
         if (request.countOnly) {
-            return manager.serializer(g, measure.getResult())
+            return manager.serializer(g, measure.measures())
                           .writeNodesWithPath("kneighbor", neighbors, size, paths,
                                               QueryResults.emptyIterator(),
                                               QueryResults.emptyIterator());
@@ -193,7 +193,7 @@ public class KneighborAPI extends TraverserAPI {
             }
         }
 
-        return manager.serializer(g, measure.getResult())
+        return manager.serializer(g, measure.measures())
                       .writeNodesWithPath("kneighbor", neighbors,
                                           size, paths, iterVertex, iterEdge);
     }

--- a/hugegraph-api/src/main/java/org/apache/hugegraph/api/traversers/KneighborAPI.java
+++ b/hugegraph-api/src/main/java/org/apache/hugegraph/api/traversers/KneighborAPI.java
@@ -21,6 +21,7 @@ import static org.apache.hugegraph.traversal.algorithm.HugeTraverser.DEFAULT_ELE
 import static org.apache.hugegraph.traversal.algorithm.HugeTraverser.DEFAULT_MAX_DEGREE;
 import static org.apache.hugegraph.traversal.algorithm.HugeTraverser.NO_LIMIT;
 
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
@@ -40,12 +41,13 @@ import org.apache.hugegraph.traversal.algorithm.steps.EdgeStep;
 import org.apache.hugegraph.type.define.Directions;
 import org.apache.hugegraph.util.E;
 import org.apache.hugegraph.util.Log;
-import org.apache.tinkerpop.gremlin.structure.Vertex;
+import org.apache.tinkerpop.gremlin.structure.Edge;
 import org.slf4j.Logger;
 
 import com.codahale.metrics.annotation.Timed;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.inject.Singleton;
@@ -75,6 +77,8 @@ public class KneighborAPI extends TraverserAPI {
                       @QueryParam("direction") String direction,
                       @QueryParam("label") String edgeLabel,
                       @QueryParam("max_depth") int depth,
+                      @QueryParam("count_only")
+                      @DefaultValue("false") boolean countOnly,
                       @QueryParam("max_degree")
                       @DefaultValue(DEFAULT_MAX_DEGREE) long maxDegree,
                       @QueryParam("limit")
@@ -85,6 +89,8 @@ public class KneighborAPI extends TraverserAPI {
                   graph, sourceV, direction, edgeLabel, depth,
                   maxDegree, limit);
 
+        ApiMeasure measure = new ApiMeasure();
+
         Id source = VertexAPI.checkAndParseVertexId(sourceV);
         Directions dir = Directions.convert(EdgeAPI.parseDirection(direction));
 
@@ -94,8 +100,14 @@ public class KneighborAPI extends TraverserAPI {
         try (KneighborTraverser traverser = new KneighborTraverser(g)) {
             ids = traverser.kneighbor(source, dir, edgeLabel,
                                       depth, maxDegree, limit);
+            measure.addIterCount(traverser.vertexIterCounter.get(),
+                                 traverser.edgeIterCounter.get());
         }
-        return manager.serializer(g).writeList("vertices", ids);
+        if (countOnly) {
+            return manager.serializer(g, measure.getResult()).writeMap(
+                    ImmutableMap.of("vertices_size", ids.size()));
+        }
+        return manager.serializer(g, measure.getResult()).writeList("vertices", ids);
     }
 
     @POST
@@ -111,15 +123,18 @@ public class KneighborAPI extends TraverserAPI {
         E.checkArgument(request.step != null,
                         "The steps of request can't be null");
         if (request.countOnly) {
-            E.checkArgument(!request.withVertex && !request.withPath,
-                            "Can't return vertex or path when count only");
+            E.checkArgument(!request.withVertex && !request.withPath && !request.withEdge,
+                            "Can't return vertex or path or edge when count only");
         }
 
         LOG.debug("Graph [{}] get customized kneighbor from source vertex " +
                   "'{}', with step '{}', limit '{}', count_only '{}', " +
-                  "with_vertex '{}' and with_path '{}'",
+                  "with_vertex '{}', with_path '{}' and with_edge '{}'",
                   graph, request.source, request.step, request.limit,
-                  request.countOnly, request.withVertex, request.withPath);
+                  request.countOnly, request.withVertex, request.withPath,
+                  request.withEdge);
+
+        ApiMeasure measure = new ApiMeasure();
 
         HugeGraph g = graph(manager, graph);
         Id sourceId = HugeVertex.getIdValue(request.source);
@@ -131,6 +146,8 @@ public class KneighborAPI extends TraverserAPI {
             results = traverser.customizedKneighbor(sourceId, step,
                                                     request.maxDepth,
                                                     request.limit);
+            measure.addIterCount(traverser.vertexIterCounter.get(),
+                                 traverser.edgeIterCounter.get());
         }
 
         long size = results.size();
@@ -144,20 +161,41 @@ public class KneighborAPI extends TraverserAPI {
         if (request.withPath) {
             paths.addAll(results.paths(request.limit));
         }
-        Iterator<Vertex> iter = QueryResults.emptyIterator();
-        if (request.withVertex && !request.countOnly) {
-            Set<Id> ids = new HashSet<>(neighbors);
-            if (request.withPath) {
-                for (HugeTraverser.Path p : paths) {
-                    ids.addAll(p.vertices());
-                }
-            }
-            if (!ids.isEmpty()) {
-                iter = g.vertices(ids.toArray());
+
+        if (request.countOnly) {
+            return manager.serializer(g, measure.getResult())
+                          .writeNodesWithPath("kneighbor", neighbors, size, paths,
+                                              QueryResults.emptyIterator(),
+                                              QueryResults.emptyIterator());
+        }
+
+        Iterator<?> iterVertex;
+        Set<Id> vertexIds = new HashSet<>(neighbors);
+        if (request.withPath) {
+            for (HugeTraverser.Path p : paths) {
+                vertexIds.addAll(p.vertices());
             }
         }
-        return manager.serializer(g).writeNodesWithPath("kneighbor", neighbors,
-                                                        size, paths, iter);
+        if (request.withVertex && !vertexIds.isEmpty()) {
+            iterVertex = g.vertices(vertexIds.toArray());
+            measure.addIterCount(vertexIds.size(), 0L);
+        } else {
+            iterVertex = vertexIds.iterator();
+        }
+
+        Iterator<?> iterEdge = Collections.emptyIterator();
+        if (request.withPath) {
+            Set<Edge> edges = results.getEdgeIdRecord().getEdges(paths);
+            if (request.withEdge) {
+                iterEdge = edges.iterator();
+            } else {
+                iterEdge = HugeTraverser.EdgeRecord.getEdgeIds(edges).iterator();
+            }
+        }
+
+        return manager.serializer(g, measure.getResult())
+                      .writeNodesWithPath("kneighbor", neighbors,
+                                          size, paths, iterVertex, iterEdge);
     }
 
     private static class Request {
@@ -176,14 +214,16 @@ public class KneighborAPI extends TraverserAPI {
         public boolean withVertex = false;
         @JsonProperty("with_path")
         public boolean withPath = false;
+        @JsonProperty("with_edge")
+        public boolean withEdge = false;
 
         @Override
         public String toString() {
             return String.format("PathRequest{source=%s,step=%s,maxDepth=%s" +
                                  "limit=%s,countOnly=%s,withVertex=%s," +
-                                 "withPath=%s}", this.source, this.step,
+                                 "withPath=%s,withEdge=%s}", this.source, this.step,
                                  this.maxDepth, this.limit, this.countOnly,
-                                 this.withVertex, this.withPath);
+                                 this.withVertex, this.withPath, this.withEdge);
         }
     }
 }

--- a/hugegraph-api/src/main/java/org/apache/hugegraph/api/traversers/KoutAPI.java
+++ b/hugegraph-api/src/main/java/org/apache/hugegraph/api/traversers/KoutAPI.java
@@ -94,7 +94,7 @@ public class KoutAPI extends TraverserAPI {
                   graph, source, direction, edgeLabel, depth,
                   nearest, maxDegree, capacity, limit);
 
-        ApiMeasure measure = new ApiMeasure();
+        ApiMeasurer measure = new ApiMeasurer();
 
         Id sourceId = VertexAPI.checkAndParseVertexId(source);
         Directions dir = Directions.convert(EdgeAPI.parseDirection(direction));
@@ -110,10 +110,10 @@ public class KoutAPI extends TraverserAPI {
         }
 
         if (count_only) {
-            return manager.serializer(g, measure.getResult()).writeMap(ImmutableMap.of(
+            return manager.serializer(g, measure.measures()).writeMap(ImmutableMap.of(
                     "vertices_size", ids.size()));
         }
-        return manager.serializer(g, measure.getResult()).writeList("vertices", ids);
+        return manager.serializer(g, measure.measures()).writeList("vertices", ids);
     }
 
     @POST
@@ -142,7 +142,7 @@ public class KoutAPI extends TraverserAPI {
                   request.limit, request.withVertex, request.withPath,
                   request.withEdge);
 
-        ApiMeasure measure = new ApiMeasure();
+        ApiMeasurer measure = new ApiMeasurer();
 
         HugeGraph g = graph(manager, graph);
         Id sourceId = HugeVertex.getIdValue(request.source);
@@ -171,7 +171,7 @@ public class KoutAPI extends TraverserAPI {
         }
 
         if (request.countOnly) {
-            return manager.serializer(g, measure.getResult())
+            return manager.serializer(g, measure.measures())
                           .writeNodesWithPath("kneighbor", neighbors, size, paths,
                                               QueryResults.emptyIterator(),
                                               QueryResults.emptyIterator());
@@ -201,7 +201,7 @@ public class KoutAPI extends TraverserAPI {
             }
         }
 
-        return manager.serializer(g, measure.getResult())
+        return manager.serializer(g, measure.measures())
                       .writeNodesWithPath("kout", neighbors, size, paths,
                                           iterVertex, iterEdge);
     }

--- a/hugegraph-api/src/main/java/org/apache/hugegraph/api/traversers/KoutAPI.java
+++ b/hugegraph-api/src/main/java/org/apache/hugegraph/api/traversers/KoutAPI.java
@@ -110,8 +110,8 @@ public class KoutAPI extends TraverserAPI {
         }
 
         if (count_only) {
-            return manager.serializer(g, measure.measures()).writeMap(ImmutableMap.of(
-                    "vertices_size", ids.size()));
+            return manager.serializer(g, measure.measures())
+                          .writeMap(ImmutableMap.of("vertices_size", ids.size()));
         }
         return manager.serializer(g, measure.measures()).writeList("vertices", ids);
     }
@@ -130,7 +130,7 @@ public class KoutAPI extends TraverserAPI {
                         "The steps of request can't be null");
         if (request.countOnly) {
             E.checkArgument(!request.withVertex && !request.withPath && !request.withEdge,
-                            "Can't return vertex or path or edge when count only");
+                            "Can't return vertex, edge or path when count only");
         }
 
         LOG.debug("Graph [{}] get customized kout from source vertex '{}', " +
@@ -193,7 +193,7 @@ public class KoutAPI extends TraverserAPI {
 
         Iterator<?> iterEdge = Collections.emptyIterator();
         if (request.withPath) {
-            Set<Edge> edges = results.getEdgeIdRecord().getEdges(paths);
+            Set<Edge> edges = results.edgeResults().getEdges(paths);
             if (request.withEdge) {
                 iterEdge = edges.iterator();
             } else {
@@ -226,7 +226,6 @@ public class KoutAPI extends TraverserAPI {
         public boolean withVertex = false;
         @JsonProperty("with_path")
         public boolean withPath = false;
-
         @JsonProperty("with_edge")
         public boolean withEdge = false;
 

--- a/hugegraph-api/src/main/java/org/apache/hugegraph/api/traversers/KoutAPI.java
+++ b/hugegraph-api/src/main/java/org/apache/hugegraph/api/traversers/KoutAPI.java
@@ -22,6 +22,7 @@ import static org.apache.hugegraph.traversal.algorithm.HugeTraverser.DEFAULT_ELE
 import static org.apache.hugegraph.traversal.algorithm.HugeTraverser.DEFAULT_MAX_DEGREE;
 import static org.apache.hugegraph.traversal.algorithm.HugeTraverser.NO_LIMIT;
 
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
@@ -41,12 +42,13 @@ import org.apache.hugegraph.traversal.algorithm.steps.EdgeStep;
 import org.apache.hugegraph.type.define.Directions;
 import org.apache.hugegraph.util.E;
 import org.apache.hugegraph.util.Log;
-import org.apache.tinkerpop.gremlin.structure.Vertex;
+import org.apache.tinkerpop.gremlin.structure.Edge;
 import org.slf4j.Logger;
 
 import com.codahale.metrics.annotation.Timed;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.inject.Singleton;
@@ -78,6 +80,8 @@ public class KoutAPI extends TraverserAPI {
                       @QueryParam("max_depth") int depth,
                       @QueryParam("nearest")
                       @DefaultValue("true") boolean nearest,
+                      @QueryParam("count_only")
+                      @DefaultValue("false") boolean count_only,
                       @QueryParam("max_degree")
                       @DefaultValue(DEFAULT_MAX_DEGREE) long maxDegree,
                       @QueryParam("capacity")
@@ -87,8 +91,10 @@ public class KoutAPI extends TraverserAPI {
         LOG.debug("Graph [{}] get k-out from '{}' with " +
                   "direction '{}', edge label '{}', max depth '{}', nearest " +
                   "'{}', max degree '{}', capacity '{}' and limit '{}'",
-                  graph, source, direction, edgeLabel, depth, nearest,
-                  maxDegree, capacity, limit);
+                  graph, source, direction, edgeLabel, depth,
+                  nearest, maxDegree, capacity, limit);
+
+        ApiMeasure measure = new ApiMeasure();
 
         Id sourceId = VertexAPI.checkAndParseVertexId(source);
         Directions dir = Directions.convert(EdgeAPI.parseDirection(direction));
@@ -99,8 +105,15 @@ public class KoutAPI extends TraverserAPI {
         try (KoutTraverser traverser = new KoutTraverser(g)) {
             ids = traverser.kout(sourceId, dir, edgeLabel, depth,
                                  nearest, maxDegree, capacity, limit);
+            measure.addIterCount(traverser.vertexIterCounter.get(),
+                                 traverser.edgeIterCounter.get());
         }
-        return manager.serializer(g).writeList("vertices", ids);
+
+        if (count_only) {
+            return manager.serializer(g, measure.getResult()).writeMap(ImmutableMap.of(
+                    "vertices_size", ids.size()));
+        }
+        return manager.serializer(g, measure.getResult()).writeList("vertices", ids);
     }
 
     @POST
@@ -116,23 +129,25 @@ public class KoutAPI extends TraverserAPI {
         E.checkArgument(request.step != null,
                         "The steps of request can't be null");
         if (request.countOnly) {
-            E.checkArgument(!request.withVertex && !request.withPath,
-                            "Can't return vertex or path when count only");
+            E.checkArgument(!request.withVertex && !request.withPath && !request.withEdge,
+                            "Can't return vertex or path or edge when count only");
         }
 
         LOG.debug("Graph [{}] get customized kout from source vertex '{}', " +
                   "with step '{}', max_depth '{}', nearest '{}', " +
                   "count_only '{}', capacity '{}', limit '{}', " +
-                  "with_vertex '{}' and with_path '{}'",
+                  "with_vertex '{}', with_path '{}' and with_edge '{}'",
                   graph, request.source, request.step, request.maxDepth,
                   request.nearest, request.countOnly, request.capacity,
-                  request.limit, request.withVertex, request.withPath);
+                  request.limit, request.withVertex, request.withPath,
+                  request.withEdge);
+
+        ApiMeasure measure = new ApiMeasure();
 
         HugeGraph g = graph(manager, graph);
         Id sourceId = HugeVertex.getIdValue(request.source);
 
         EdgeStep step = step(g, request.step);
-
         KoutRecords results;
         try (KoutTraverser traverser = new KoutTraverser(g)) {
             results = traverser.customizedKout(sourceId, step,
@@ -140,8 +155,9 @@ public class KoutAPI extends TraverserAPI {
                                                request.nearest,
                                                request.capacity,
                                                request.limit);
+            measure.addIterCount(traverser.vertexIterCounter.get(),
+                                 traverser.edgeIterCounter.get());
         }
-
         long size = results.size();
         if (request.limit != NO_LIMIT && size > request.limit) {
             size = request.limit;
@@ -154,20 +170,40 @@ public class KoutAPI extends TraverserAPI {
             paths.addAll(results.paths(request.limit));
         }
 
-        Iterator<Vertex> iter = QueryResults.emptyIterator();
-        if (request.withVertex && !request.countOnly) {
-            Set<Id> ids = new HashSet<>(neighbors);
-            if (request.withPath) {
-                for (HugeTraverser.Path p : paths) {
-                    ids.addAll(p.vertices());
-                }
-            }
-            if (!ids.isEmpty()) {
-                iter = g.vertices(ids.toArray());
+        if (request.countOnly) {
+            return manager.serializer(g, measure.getResult())
+                          .writeNodesWithPath("kneighbor", neighbors, size, paths,
+                                              QueryResults.emptyIterator(),
+                                              QueryResults.emptyIterator());
+        }
+
+        Iterator<?> iterVertex;
+        Set<Id> vertexIds = new HashSet<>(neighbors);
+        if (request.withPath) {
+            for (HugeTraverser.Path p : results.paths(request.limit)) {
+                vertexIds.addAll(p.vertices());
             }
         }
-        return manager.serializer(g).writeNodesWithPath("kout", neighbors,
-                                                        size, paths, iter);
+        if (request.withVertex && !vertexIds.isEmpty()) {
+            iterVertex = g.vertices(vertexIds.toArray());
+            measure.addIterCount(vertexIds.size(), 0L);
+        } else {
+            iterVertex = vertexIds.iterator();
+        }
+
+        Iterator<?> iterEdge = Collections.emptyIterator();
+        if (request.withPath) {
+            Set<Edge> edges = results.getEdgeIdRecord().getEdges(paths);
+            if (request.withEdge) {
+                iterEdge = edges.iterator();
+            } else {
+                iterEdge = HugeTraverser.EdgeRecord.getEdgeIds(edges).iterator();
+            }
+        }
+
+        return manager.serializer(g, measure.getResult())
+                      .writeNodesWithPath("kout", neighbors, size, paths,
+                                          iterVertex, iterEdge);
     }
 
     private static class Request {
@@ -191,14 +227,18 @@ public class KoutAPI extends TraverserAPI {
         @JsonProperty("with_path")
         public boolean withPath = false;
 
+        @JsonProperty("with_edge")
+        public boolean withEdge = false;
+
         @Override
         public String toString() {
             return String.format("KoutRequest{source=%s,step=%s,maxDepth=%s" +
                                  "nearest=%s,countOnly=%s,capacity=%s," +
-                                 "limit=%s,withVertex=%s,withPath=%s}",
-                                 this.source, this.step, this.maxDepth,
-                                 this.nearest, this.countOnly, this.capacity,
-                                 this.limit, this.withVertex, this.withPath);
+                                 "limit=%s,withVertex=%s,withPath=%s," +
+                                 "withEdge=%s}", this.source, this.step,
+                                 this.maxDepth, this.nearest, this.countOnly,
+                                 this.capacity, this.limit, this.withVertex,
+                                 this.withPath, this.withEdge);
         }
     }
 }

--- a/hugegraph-api/src/main/java/org/apache/hugegraph/api/traversers/MultiNodeShortestPathAPI.java
+++ b/hugegraph-api/src/main/java/org/apache/hugegraph/api/traversers/MultiNodeShortestPathAPI.java
@@ -24,6 +24,21 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
 
+import org.apache.hugegraph.HugeGraph;
+import org.apache.hugegraph.backend.id.Id;
+import org.apache.hugegraph.core.GraphManager;
+import org.apache.hugegraph.traversal.algorithm.HugeTraverser;
+import org.apache.hugegraph.traversal.algorithm.MultiNodeShortestPathTraverser;
+import org.apache.hugegraph.traversal.algorithm.steps.EdgeStep;
+import org.apache.hugegraph.util.E;
+import org.apache.hugegraph.util.Log;
+import org.apache.tinkerpop.gremlin.structure.Edge;
+import org.apache.tinkerpop.gremlin.structure.Vertex;
+import org.slf4j.Logger;
+
+import com.codahale.metrics.annotation.Timed;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.inject.Singleton;
 import jakarta.ws.rs.Consumes;
@@ -32,21 +47,6 @@ import jakarta.ws.rs.Path;
 import jakarta.ws.rs.PathParam;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.core.Context;
-
-import org.apache.tinkerpop.gremlin.structure.Vertex;
-import org.apache.hugegraph.core.GraphManager;
-import org.slf4j.Logger;
-
-import org.apache.hugegraph.HugeGraph;
-import org.apache.hugegraph.backend.id.Id;
-import org.apache.hugegraph.backend.query.QueryResults;
-import org.apache.hugegraph.traversal.algorithm.steps.EdgeStep;
-import org.apache.hugegraph.traversal.algorithm.HugeTraverser;
-import org.apache.hugegraph.traversal.algorithm.MultiNodeShortestPathTraverser;
-import org.apache.hugegraph.util.E;
-import org.apache.hugegraph.util.Log;
-import com.codahale.metrics.annotation.Timed;
-import com.fasterxml.jackson.annotation.JsonProperty;
 
 @Path("graphs/{graph}/traversers/multinodeshortestpath")
 @Singleton
@@ -74,32 +74,48 @@ public class MultiNodeShortestPathAPI extends TraverserAPI {
                   graph, request.vertices, request.step, request.maxDepth,
                   request.capacity, request.withVertex);
 
+        ApiMeasure measure = new ApiMeasure();
+
         HugeGraph g = graph(manager, graph);
         Iterator<Vertex> vertices = request.vertices.vertices(g);
 
         EdgeStep step = step(g, request.step);
 
-        List<HugeTraverser.Path> paths;
+        MultiNodeShortestPathTraverser.WrappedListPath wrappedListPath;
         try (MultiNodeShortestPathTraverser traverser =
-                                        new MultiNodeShortestPathTraverser(g)) {
-            paths = traverser.multiNodeShortestPath(vertices, step,
-                                                    request.maxDepth,
-                                                    request.capacity);
+                     new MultiNodeShortestPathTraverser(g)) {
+            wrappedListPath = traverser.multiNodeShortestPath(vertices, step,
+                                                              request.maxDepth,
+                                                              request.capacity);
+            measure.addIterCount(traverser.vertexIterCounter.get(),
+                                 traverser.edgeIterCounter.get());
         }
 
-        if (!request.withVertex) {
-            return manager.serializer(g).writePaths("paths", paths, false);
+        List<HugeTraverser.Path> paths = wrappedListPath.getPaths();
+
+        Iterator<?> iterVertex;
+        Set<Id> vertexIds = new HashSet<>();
+        for (HugeTraverser.Path path : paths) {
+            vertexIds.addAll(path.vertices());
+        }
+        if (request.withVertex && !vertexIds.isEmpty()) {
+            iterVertex = g.vertices(vertexIds.toArray());
+            measure.addIterCount(vertexIds.size(), 0L);
+        } else {
+            iterVertex = vertexIds.iterator();
         }
 
-        Set<Id> ids = new HashSet<>();
-        for (HugeTraverser.Path p : paths) {
-            ids.addAll(p.vertices());
+        Iterator<?> iterEdge;
+        Set<Edge> edges = wrappedListPath.getEdges();
+        if (request.withEdge && !edges.isEmpty()) {
+            iterEdge = wrappedListPath.getEdges().iterator();
+        } else {
+            iterEdge = HugeTraverser.EdgeRecord.getEdgeIds(edges).iterator();
         }
-        Iterator<Vertex> iter = QueryResults.emptyIterator();
-        if (!ids.isEmpty()) {
-            iter = g.vertices(ids.toArray());
-        }
-        return manager.serializer(g).writePaths("paths", paths, false, iter);
+
+        return manager.serializer(g, measure.getResult())
+                      .writePaths("paths", paths,
+                                  false, iterVertex, iterEdge);
     }
 
     private static class Request {
@@ -114,13 +130,15 @@ public class MultiNodeShortestPathAPI extends TraverserAPI {
         public long capacity = Long.parseLong(DEFAULT_CAPACITY);
         @JsonProperty("with_vertex")
         public boolean withVertex = false;
+        @JsonProperty("with_edge")
+        public boolean withEdge = false;
 
         @Override
         public String toString() {
             return String.format("Request{vertices=%s,step=%s,maxDepth=%s" +
-                                 "capacity=%s,withVertex=%s}",
+                                 "capacity=%s,withVertex=%s,withEdge=%s}",
                                  this.vertices, this.step, this.maxDepth,
-                                 this.capacity, this.withVertex);
+                                 this.capacity, this.withVertex, this.withEdge);
         }
     }
 }

--- a/hugegraph-api/src/main/java/org/apache/hugegraph/api/traversers/MultiNodeShortestPathAPI.java
+++ b/hugegraph-api/src/main/java/org/apache/hugegraph/api/traversers/MultiNodeShortestPathAPI.java
@@ -74,7 +74,7 @@ public class MultiNodeShortestPathAPI extends TraverserAPI {
                   graph, request.vertices, request.step, request.maxDepth,
                   request.capacity, request.withVertex);
 
-        ApiMeasure measure = new ApiMeasure();
+        ApiMeasurer measure = new ApiMeasurer();
 
         HugeGraph g = graph(manager, graph);
         Iterator<Vertex> vertices = request.vertices.vertices(g);
@@ -91,7 +91,7 @@ public class MultiNodeShortestPathAPI extends TraverserAPI {
                                  traverser.edgeIterCounter.get());
         }
 
-        List<HugeTraverser.Path> paths = wrappedListPath.getPaths();
+        List<HugeTraverser.Path> paths = wrappedListPath.paths();
 
         Iterator<?> iterVertex;
         Set<Id> vertexIds = new HashSet<>();
@@ -106,14 +106,14 @@ public class MultiNodeShortestPathAPI extends TraverserAPI {
         }
 
         Iterator<?> iterEdge;
-        Set<Edge> edges = wrappedListPath.getEdges();
+        Set<Edge> edges = wrappedListPath.edges();
         if (request.withEdge && !edges.isEmpty()) {
-            iterEdge = wrappedListPath.getEdges().iterator();
+            iterEdge = wrappedListPath.edges().iterator();
         } else {
             iterEdge = HugeTraverser.EdgeRecord.getEdgeIds(edges).iterator();
         }
 
-        return manager.serializer(g, measure.getResult())
+        return manager.serializer(g, measure.measures())
                       .writePaths("paths", paths,
                                   false, iterVertex, iterEdge);
     }

--- a/hugegraph-api/src/main/java/org/apache/hugegraph/api/traversers/PathsAPI.java
+++ b/hugegraph-api/src/main/java/org/apache/hugegraph/api/traversers/PathsAPI.java
@@ -125,7 +125,7 @@ public class PathsAPI extends TraverserAPI {
 
         LOG.debug("Graph [{}] get paths from source vertices '{}', target " +
                   "vertices '{}', with step '{}', max depth '{}', " +
-                  "capacity '{}', limit '{}', with vertex '{}' and with edge '{}'",
+                  "capacity '{}', limit '{}', with_vertex '{}' and with_edge '{}'",
                   graph, request.sources, request.targets, request.step,
                   request.depth, request.capacity, request.limit,
                   request.withVertex, request.withEdge);

--- a/hugegraph-api/src/main/java/org/apache/hugegraph/api/traversers/PathsAPI.java
+++ b/hugegraph-api/src/main/java/org/apache/hugegraph/api/traversers/PathsAPI.java
@@ -27,6 +27,25 @@ import java.util.HashSet;
 import java.util.Iterator;
 import java.util.Set;
 
+import org.apache.hugegraph.HugeGraph;
+import org.apache.hugegraph.api.graph.EdgeAPI;
+import org.apache.hugegraph.api.graph.VertexAPI;
+import org.apache.hugegraph.backend.id.Id;
+import org.apache.hugegraph.core.GraphManager;
+import org.apache.hugegraph.traversal.algorithm.CollectionPathsTraverser;
+import org.apache.hugegraph.traversal.algorithm.HugeTraverser;
+import org.apache.hugegraph.traversal.algorithm.PathsTraverser;
+import org.apache.hugegraph.traversal.algorithm.steps.EdgeStep;
+import org.apache.hugegraph.type.define.Directions;
+import org.apache.hugegraph.util.E;
+import org.apache.hugegraph.util.Log;
+import org.apache.tinkerpop.gremlin.structure.Edge;
+import org.apache.tinkerpop.gremlin.structure.Vertex;
+import org.slf4j.Logger;
+
+import com.codahale.metrics.annotation.Timed;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.inject.Singleton;
 import jakarta.ws.rs.Consumes;
@@ -38,25 +57,6 @@ import jakarta.ws.rs.PathParam;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.QueryParam;
 import jakarta.ws.rs.core.Context;
-
-import org.apache.tinkerpop.gremlin.structure.Vertex;
-import org.apache.hugegraph.core.GraphManager;
-import org.slf4j.Logger;
-
-import org.apache.hugegraph.HugeGraph;
-import org.apache.hugegraph.api.graph.EdgeAPI;
-import org.apache.hugegraph.api.graph.VertexAPI;
-import org.apache.hugegraph.backend.id.Id;
-import org.apache.hugegraph.backend.query.QueryResults;
-import org.apache.hugegraph.traversal.algorithm.CollectionPathsTraverser;
-import org.apache.hugegraph.traversal.algorithm.HugeTraverser;
-import org.apache.hugegraph.traversal.algorithm.PathsTraverser;
-import org.apache.hugegraph.traversal.algorithm.steps.EdgeStep;
-import org.apache.hugegraph.type.define.Directions;
-import org.apache.hugegraph.util.E;
-import org.apache.hugegraph.util.Log;
-import com.codahale.metrics.annotation.Timed;
-import com.fasterxml.jackson.annotation.JsonProperty;
 
 @Path("graphs/{graph}/traversers/paths")
 @Singleton
@@ -87,6 +87,8 @@ public class PathsAPI extends TraverserAPI {
                   graph, source, target, direction, edgeLabel, depth,
                   maxDegree, capacity, limit);
 
+        ApiMeasure measure = new ApiMeasure();
+
         Id sourceId = VertexAPI.checkAndParseVertexId(source);
         Id targetId = VertexAPI.checkAndParseVertexId(target);
         Directions dir = Directions.convert(EdgeAPI.parseDirection(direction));
@@ -97,7 +99,10 @@ public class PathsAPI extends TraverserAPI {
                                                       dir.opposite(), edgeLabel,
                                                       depth, maxDegree, capacity,
                                                       limit);
-        return manager.serializer(g).writePaths("paths", paths, false);
+        measure.addIterCount(traverser.vertexIterCounter.get(),
+                             traverser.edgeIterCounter.get());
+        return manager.serializer(g, measure.getResult())
+                      .writePaths("paths", paths, false);
     }
 
     @POST
@@ -120,10 +125,12 @@ public class PathsAPI extends TraverserAPI {
 
         LOG.debug("Graph [{}] get paths from source vertices '{}', target " +
                   "vertices '{}', with step '{}', max depth '{}', " +
-                  "capacity '{}', limit '{}' and with_vertex '{}'",
+                  "capacity '{}', limit '{}', with vertex '{}' and with edge '{}'",
                   graph, request.sources, request.targets, request.step,
                   request.depth, request.capacity, request.limit,
-                  request.withVertex);
+                  request.withVertex, request.withEdge);
+
+        ApiMeasure measure = new ApiMeasure();
 
         HugeGraph g = graph(manager, graph);
         Iterator<Vertex> sources = request.sources.vertices(g);
@@ -131,24 +138,38 @@ public class PathsAPI extends TraverserAPI {
         EdgeStep step = step(g, request.step);
 
         CollectionPathsTraverser traverser = new CollectionPathsTraverser(g);
-        Collection<HugeTraverser.Path> paths;
-        paths = traverser.paths(sources, targets, step, request.depth,
-                                request.nearest, request.capacity,
-                                request.limit);
+        CollectionPathsTraverser.WrappedPathCollection
+                wrappedPathCollection = traverser.paths(sources, targets,
+                                                        step, request.depth,
+                                                        request.nearest, request.capacity,
+                                                        request.limit);
+        Collection<HugeTraverser.Path> paths = wrappedPathCollection.getPaths();
+        measure.addIterCount(traverser.vertexIterCounter.get(),
+                             traverser.edgeIterCounter.get());
 
-        if (!request.withVertex) {
-            return manager.serializer(g).writePaths("paths", paths, false);
+        Iterator<?> iterVertex;
+        Set<Id> vertexIds = new HashSet<>();
+        for (HugeTraverser.Path path : paths) {
+            vertexIds.addAll(path.vertices());
+        }
+        if (request.withVertex && !vertexIds.isEmpty()) {
+            iterVertex = g.vertices(vertexIds.toArray());
+            measure.addIterCount(vertexIds.size(), 0L);
+        } else {
+            iterVertex = vertexIds.iterator();
         }
 
-        Set<Id> ids = new HashSet<>();
-        for (HugeTraverser.Path p : paths) {
-            ids.addAll(p.vertices());
+        Iterator<?> iterEdge;
+        Set<Edge> edges = wrappedPathCollection.getEdges();
+        if (request.withEdge && !edges.isEmpty()) {
+            iterEdge = edges.iterator();
+        } else {
+            iterEdge = HugeTraverser.EdgeRecord.getEdgeIds(edges).iterator();
         }
-        Iterator<Vertex> iter = QueryResults.emptyIterator();
-        if (!ids.isEmpty()) {
-            iter = g.vertices(ids.toArray());
-        }
-        return manager.serializer(g).writePaths("paths", paths, false, iter);
+
+        return manager.serializer(g, measure.getResult())
+                      .writePaths("paths", paths, false,
+                                  iterVertex, iterEdge);
     }
 
     private static class Request {
@@ -170,14 +191,17 @@ public class PathsAPI extends TraverserAPI {
         @JsonProperty("with_vertex")
         public boolean withVertex = false;
 
+        @JsonProperty("with_edge")
+        public boolean withEdge = false;
+
         @Override
         public String toString() {
             return String.format("PathRequest{sources=%s,targets=%s,step=%s," +
                                  "maxDepth=%s,nearest=%s,capacity=%s," +
-                                 "limit=%s,withVertex=%s}", this.sources,
-                                 this.targets, this.step, this.depth,
-                                 this.nearest, this.capacity,
-                                 this.limit, this.withVertex);
+                                 "limit=%s,withVertex=%s,withEdge=%s}",
+                                 this.sources, this.targets, this.step,
+                                 this.depth, this.nearest, this.capacity,
+                                 this.limit, this.withVertex, this.withEdge);
         }
     }
 }

--- a/hugegraph-api/src/main/java/org/apache/hugegraph/api/traversers/PathsAPI.java
+++ b/hugegraph-api/src/main/java/org/apache/hugegraph/api/traversers/PathsAPI.java
@@ -87,7 +87,7 @@ public class PathsAPI extends TraverserAPI {
                   graph, source, target, direction, edgeLabel, depth,
                   maxDegree, capacity, limit);
 
-        ApiMeasure measure = new ApiMeasure();
+        ApiMeasurer measure = new ApiMeasurer();
 
         Id sourceId = VertexAPI.checkAndParseVertexId(source);
         Id targetId = VertexAPI.checkAndParseVertexId(target);
@@ -101,7 +101,7 @@ public class PathsAPI extends TraverserAPI {
                                                       limit);
         measure.addIterCount(traverser.vertexIterCounter.get(),
                              traverser.edgeIterCounter.get());
-        return manager.serializer(g, measure.getResult())
+        return manager.serializer(g, measure.measures())
                       .writePaths("paths", paths, false);
     }
 
@@ -130,7 +130,7 @@ public class PathsAPI extends TraverserAPI {
                   request.depth, request.capacity, request.limit,
                   request.withVertex, request.withEdge);
 
-        ApiMeasure measure = new ApiMeasure();
+        ApiMeasurer measure = new ApiMeasurer();
 
         HugeGraph g = graph(manager, graph);
         Iterator<Vertex> sources = request.sources.vertices(g);
@@ -143,7 +143,7 @@ public class PathsAPI extends TraverserAPI {
                                                         step, request.depth,
                                                         request.nearest, request.capacity,
                                                         request.limit);
-        Collection<HugeTraverser.Path> paths = wrappedPathCollection.getPaths();
+        Collection<HugeTraverser.Path> paths = wrappedPathCollection.paths();
         measure.addIterCount(traverser.vertexIterCounter.get(),
                              traverser.edgeIterCounter.get());
 
@@ -160,14 +160,14 @@ public class PathsAPI extends TraverserAPI {
         }
 
         Iterator<?> iterEdge;
-        Set<Edge> edges = wrappedPathCollection.getEdges();
+        Set<Edge> edges = wrappedPathCollection.edges();
         if (request.withEdge && !edges.isEmpty()) {
             iterEdge = edges.iterator();
         } else {
             iterEdge = HugeTraverser.EdgeRecord.getEdgeIds(edges).iterator();
         }
 
-        return manager.serializer(g, measure.getResult())
+        return manager.serializer(g, measure.measures())
                       .writePaths("paths", paths, false,
                                   iterVertex, iterEdge);
     }

--- a/hugegraph-api/src/main/java/org/apache/hugegraph/api/traversers/RaysAPI.java
+++ b/hugegraph-api/src/main/java/org/apache/hugegraph/api/traversers/RaysAPI.java
@@ -21,6 +21,25 @@ import static org.apache.hugegraph.traversal.algorithm.HugeTraverser.DEFAULT_CAP
 import static org.apache.hugegraph.traversal.algorithm.HugeTraverser.DEFAULT_MAX_DEGREE;
 import static org.apache.hugegraph.traversal.algorithm.HugeTraverser.DEFAULT_PATHS_LIMIT;
 
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.Set;
+
+import org.apache.hugegraph.HugeGraph;
+import org.apache.hugegraph.api.API;
+import org.apache.hugegraph.api.graph.EdgeAPI;
+import org.apache.hugegraph.api.graph.VertexAPI;
+import org.apache.hugegraph.backend.id.Id;
+import org.apache.hugegraph.core.GraphManager;
+import org.apache.hugegraph.traversal.algorithm.HugeTraverser;
+import org.apache.hugegraph.traversal.algorithm.SubGraphTraverser;
+import org.apache.hugegraph.type.define.Directions;
+import org.apache.hugegraph.util.Log;
+import org.apache.tinkerpop.gremlin.structure.Edge;
+import org.slf4j.Logger;
+
+import com.codahale.metrics.annotation.Timed;
+
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.inject.Singleton;
 import jakarta.ws.rs.DefaultValue;
@@ -30,20 +49,6 @@ import jakarta.ws.rs.PathParam;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.QueryParam;
 import jakarta.ws.rs.core.Context;
-
-import org.apache.hugegraph.core.GraphManager;
-import org.slf4j.Logger;
-
-import org.apache.hugegraph.HugeGraph;
-import org.apache.hugegraph.api.API;
-import org.apache.hugegraph.api.graph.EdgeAPI;
-import org.apache.hugegraph.api.graph.VertexAPI;
-import org.apache.hugegraph.backend.id.Id;
-import org.apache.hugegraph.traversal.algorithm.HugeTraverser;
-import org.apache.hugegraph.traversal.algorithm.SubGraphTraverser;
-import org.apache.hugegraph.type.define.Directions;
-import org.apache.hugegraph.util.Log;
-import com.codahale.metrics.annotation.Timed;
 
 @Path("graphs/{graph}/traversers/rays")
 @Singleton
@@ -66,12 +71,17 @@ public class RaysAPI extends API {
                       @QueryParam("capacity")
                       @DefaultValue(DEFAULT_CAPACITY) long capacity,
                       @QueryParam("limit")
-                      @DefaultValue(DEFAULT_PATHS_LIMIT) int limit) {
+                      @DefaultValue(DEFAULT_PATHS_LIMIT) int limit,
+                      @QueryParam("with_vertex")
+                      @DefaultValue("false") boolean withVertex,
+                      @QueryParam("with_edge")
+                      @DefaultValue("false") boolean withEdge) {
         LOG.debug("Graph [{}] get rays paths from '{}' with " +
                   "direction '{}', edge label '{}', max depth '{}', " +
                   "max degree '{}', capacity '{}' and limit '{}'",
                   graph, sourceV, direction, edgeLabel, depth, maxDegree,
                   capacity, limit);
+        ApiMeasure measure = new ApiMeasure();
 
         Id source = VertexAPI.checkAndParseVertexId(sourceV);
         Directions dir = Directions.convert(EdgeAPI.parseDirection(direction));
@@ -80,8 +90,33 @@ public class RaysAPI extends API {
 
         SubGraphTraverser traverser = new SubGraphTraverser(g);
         HugeTraverser.PathSet paths = traverser.rays(source, dir, edgeLabel,
-                                                     depth, maxDegree,
-                                                     capacity, limit);
-        return manager.serializer(g).writePaths("rays", paths, false);
+                                                     depth, maxDegree, capacity,
+                                                     limit);
+        measure.addIterCount(traverser.vertexIterCounter.get(),
+                             traverser.edgeIterCounter.get());
+
+        Iterator<?> iterVertex;
+        Set<Id> vertexIds = new HashSet<>();
+        for (HugeTraverser.Path path : paths) {
+            vertexIds.addAll(path.vertices());
+        }
+        if (withVertex && !vertexIds.isEmpty()) {
+            iterVertex = g.vertices(vertexIds.toArray());
+            measure.addIterCount(vertexIds.size(), 0L);
+        } else {
+            iterVertex = vertexIds.iterator();
+        }
+
+        Iterator<?> iterEdge;
+        Set<Edge> edges = paths.getEdges();
+        if (withEdge && !edges.isEmpty()) {
+            iterEdge = edges.iterator();
+        } else {
+            iterEdge = HugeTraverser.EdgeRecord.getEdgeIds(edges).iterator();
+        }
+        
+        return manager.serializer(g, measure.getResult())
+                      .writePaths("rays", paths, false,
+                                  iterVertex, iterEdge);
     }
 }

--- a/hugegraph-api/src/main/java/org/apache/hugegraph/api/traversers/RaysAPI.java
+++ b/hugegraph-api/src/main/java/org/apache/hugegraph/api/traversers/RaysAPI.java
@@ -81,7 +81,7 @@ public class RaysAPI extends API {
                   "max degree '{}', capacity '{}' and limit '{}'",
                   graph, sourceV, direction, edgeLabel, depth, maxDegree,
                   capacity, limit);
-        ApiMeasure measure = new ApiMeasure();
+        ApiMeasurer measure = new ApiMeasurer();
 
         Id source = VertexAPI.checkAndParseVertexId(sourceV);
         Directions dir = Directions.convert(EdgeAPI.parseDirection(direction));
@@ -114,8 +114,8 @@ public class RaysAPI extends API {
         } else {
             iterEdge = HugeTraverser.EdgeRecord.getEdgeIds(edges).iterator();
         }
-        
-        return manager.serializer(g, measure.getResult())
+
+        return manager.serializer(g, measure.measures())
                       .writePaths("rays", paths, false,
                                   iterVertex, iterEdge);
     }

--- a/hugegraph-api/src/main/java/org/apache/hugegraph/api/traversers/RingsAPI.java
+++ b/hugegraph-api/src/main/java/org/apache/hugegraph/api/traversers/RingsAPI.java
@@ -85,7 +85,7 @@ public class RingsAPI extends API {
                   graph, sourceV, direction, edgeLabel, depth, sourceInRing,
                   maxDegree, capacity, limit, withVertex, withEdge);
 
-        ApiMeasure measure = new ApiMeasure();
+        ApiMeasurer measure = new ApiMeasurer();
         Id source = VertexAPI.checkAndParseVertexId(sourceV);
         Directions dir = Directions.convert(EdgeAPI.parseDirection(direction));
 
@@ -119,7 +119,7 @@ public class RingsAPI extends API {
             iterEdge = HugeTraverser.EdgeRecord.getEdgeIds(edges).iterator();
         }
 
-        return manager.serializer(g, measure.getResult())
+        return manager.serializer(g, measure.measures())
                       .writePaths("rings", paths, false,
                                   iterVertex, iterEdge);
     }

--- a/hugegraph-api/src/main/java/org/apache/hugegraph/api/traversers/RingsAPI.java
+++ b/hugegraph-api/src/main/java/org/apache/hugegraph/api/traversers/RingsAPI.java
@@ -21,6 +21,25 @@ import static org.apache.hugegraph.traversal.algorithm.HugeTraverser.DEFAULT_CAP
 import static org.apache.hugegraph.traversal.algorithm.HugeTraverser.DEFAULT_MAX_DEGREE;
 import static org.apache.hugegraph.traversal.algorithm.HugeTraverser.DEFAULT_PATHS_LIMIT;
 
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.Set;
+
+import org.apache.hugegraph.HugeGraph;
+import org.apache.hugegraph.api.API;
+import org.apache.hugegraph.api.graph.EdgeAPI;
+import org.apache.hugegraph.api.graph.VertexAPI;
+import org.apache.hugegraph.backend.id.Id;
+import org.apache.hugegraph.core.GraphManager;
+import org.apache.hugegraph.traversal.algorithm.HugeTraverser;
+import org.apache.hugegraph.traversal.algorithm.SubGraphTraverser;
+import org.apache.hugegraph.type.define.Directions;
+import org.apache.hugegraph.util.Log;
+import org.apache.tinkerpop.gremlin.structure.Edge;
+import org.slf4j.Logger;
+
+import com.codahale.metrics.annotation.Timed;
+
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.inject.Singleton;
 import jakarta.ws.rs.DefaultValue;
@@ -30,20 +49,6 @@ import jakarta.ws.rs.PathParam;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.QueryParam;
 import jakarta.ws.rs.core.Context;
-
-import org.apache.hugegraph.core.GraphManager;
-import org.slf4j.Logger;
-
-import org.apache.hugegraph.HugeGraph;
-import org.apache.hugegraph.api.API;
-import org.apache.hugegraph.api.graph.EdgeAPI;
-import org.apache.hugegraph.api.graph.VertexAPI;
-import org.apache.hugegraph.backend.id.Id;
-import org.apache.hugegraph.traversal.algorithm.HugeTraverser;
-import org.apache.hugegraph.traversal.algorithm.SubGraphTraverser;
-import org.apache.hugegraph.type.define.Directions;
-import org.apache.hugegraph.util.Log;
-import com.codahale.metrics.annotation.Timed;
 
 @Path("graphs/{graph}/traversers/rings")
 @Singleton
@@ -68,14 +73,19 @@ public class RingsAPI extends API {
                       @QueryParam("capacity")
                       @DefaultValue(DEFAULT_CAPACITY) long capacity,
                       @QueryParam("limit")
-                      @DefaultValue(DEFAULT_PATHS_LIMIT) int limit) {
+                      @DefaultValue(DEFAULT_PATHS_LIMIT) int limit,
+                      @QueryParam("with_vertex")
+                      @DefaultValue("false") boolean withVertex,
+                      @QueryParam("with_edge")
+                      @DefaultValue("false") boolean withEdge) {
         LOG.debug("Graph [{}] get rings paths reachable from '{}' with " +
                   "direction '{}', edge label '{}', max depth '{}', " +
-                  "source in ring '{}', max degree '{}', capacity '{}' " +
-                  "and limit '{}'",
+                  "source in ring '{}', max degree '{}', capacity '{}', " +
+                  "limit '{}', with vertex '{}' and with edge '{}'",
                   graph, sourceV, direction, edgeLabel, depth, sourceInRing,
-                  maxDegree, capacity, limit);
+                  maxDegree, capacity, limit, withVertex, withEdge);
 
+        ApiMeasure measure = new ApiMeasure();
         Id source = VertexAPI.checkAndParseVertexId(sourceV);
         Directions dir = Directions.convert(EdgeAPI.parseDirection(direction));
 
@@ -83,8 +93,34 @@ public class RingsAPI extends API {
 
         SubGraphTraverser traverser = new SubGraphTraverser(g);
         HugeTraverser.PathSet paths = traverser.rings(source, dir, edgeLabel,
-                                                      depth, sourceInRing,
-                                                      maxDegree, capacity, limit);
-        return manager.serializer(g).writePaths("rings", paths, false);
+                                                      depth, sourceInRing, maxDegree,
+                                                      capacity, limit);
+
+        measure.addIterCount(traverser.vertexIterCounter.get(),
+                             traverser.edgeIterCounter.get());
+
+        Iterator<?> iterVertex;
+        Set<Id> vertexIds = new HashSet<>();
+        for (HugeTraverser.Path path : paths) {
+            vertexIds.addAll(path.vertices());
+        }
+        if (withVertex && !vertexIds.isEmpty()) {
+            iterVertex = g.vertices(vertexIds.toArray());
+            measure.addIterCount(vertexIds.size(), 0L);
+        } else {
+            iterVertex = vertexIds.iterator();
+        }
+
+        Iterator<?> iterEdge;
+        Set<Edge> edges = paths.getEdges();
+        if (withEdge && !edges.isEmpty()) {
+            iterEdge = edges.iterator();
+        } else {
+            iterEdge = HugeTraverser.EdgeRecord.getEdgeIds(edges).iterator();
+        }
+
+        return manager.serializer(g, measure.getResult())
+                      .writePaths("rings", paths, false,
+                                  iterVertex, iterEdge);
     }
 }

--- a/hugegraph-api/src/main/java/org/apache/hugegraph/api/traversers/RingsAPI.java
+++ b/hugegraph-api/src/main/java/org/apache/hugegraph/api/traversers/RingsAPI.java
@@ -81,7 +81,7 @@ public class RingsAPI extends API {
         LOG.debug("Graph [{}] get rings paths reachable from '{}' with " +
                   "direction '{}', edge label '{}', max depth '{}', " +
                   "source in ring '{}', max degree '{}', capacity '{}', " +
-                  "limit '{}', with vertex '{}' and with edge '{}'",
+                  "limit '{}', with_vertex '{}' and with_edge '{}'",
                   graph, sourceV, direction, edgeLabel, depth, sourceInRing,
                   maxDegree, capacity, limit, withVertex, withEdge);
 

--- a/hugegraph-api/src/main/java/org/apache/hugegraph/api/traversers/SameNeighborsAPI.java
+++ b/hugegraph-api/src/main/java/org/apache/hugegraph/api/traversers/SameNeighborsAPI.java
@@ -20,19 +20,11 @@ package org.apache.hugegraph.api.traversers;
 import static org.apache.hugegraph.traversal.algorithm.HugeTraverser.DEFAULT_ELEMENTS_LIMIT;
 import static org.apache.hugegraph.traversal.algorithm.HugeTraverser.DEFAULT_MAX_DEGREE;
 
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
 import java.util.Set;
-
-import io.swagger.v3.oas.annotations.tags.Tag;
-import jakarta.inject.Singleton;
-import jakarta.ws.rs.DefaultValue;
-import jakarta.ws.rs.GET;
-import jakarta.ws.rs.Path;
-import jakarta.ws.rs.PathParam;
-import jakarta.ws.rs.Produces;
-import jakarta.ws.rs.QueryParam;
-import jakarta.ws.rs.core.Context;
-
-import org.slf4j.Logger;
 
 import org.apache.hugegraph.HugeGraph;
 import org.apache.hugegraph.api.API;
@@ -40,10 +32,28 @@ import org.apache.hugegraph.api.graph.EdgeAPI;
 import org.apache.hugegraph.api.graph.VertexAPI;
 import org.apache.hugegraph.backend.id.Id;
 import org.apache.hugegraph.core.GraphManager;
+import org.apache.hugegraph.structure.HugeVertex;
 import org.apache.hugegraph.traversal.algorithm.SameNeighborTraverser;
 import org.apache.hugegraph.type.define.Directions;
+import org.apache.hugegraph.util.E;
 import org.apache.hugegraph.util.Log;
+import org.slf4j.Logger;
+
 import com.codahale.metrics.annotation.Timed;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.ImmutableMap;
+
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.inject.Singleton;
+import jakarta.ws.rs.DefaultValue;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.QueryParam;
+import jakarta.ws.rs.core.Context;
 
 @Path("graphs/{graph}/traversers/sameneighbors")
 @Singleton
@@ -69,6 +79,8 @@ public class SameNeighborsAPI extends API {
                   "direction {}, edge label {}, max degree '{}' and limit '{}'",
                   graph, vertex, other, direction, edgeLabel, maxDegree, limit);
 
+        ApiMeasure measure = new ApiMeasure();
+
         Id sourceId = VertexAPI.checkAndParseVertexId(vertex);
         Id targetId = VertexAPI.checkAndParseVertexId(other);
         Directions dir = Directions.convert(EdgeAPI.parseDirection(direction));
@@ -77,6 +89,81 @@ public class SameNeighborsAPI extends API {
         SameNeighborTraverser traverser = new SameNeighborTraverser(g);
         Set<Id> neighbors = traverser.sameNeighbors(sourceId, targetId, dir,
                                                     edgeLabel, maxDegree, limit);
-        return manager.serializer(g).writeList("same_neighbors", neighbors);
+
+        measure.addIterCount(traverser.vertexIterCounter.get(),
+                             traverser.edgeIterCounter.get());
+
+        return manager.serializer(g, measure.getResult())
+                      .writeList("same_neighbors", neighbors);
+    }
+
+    @POST
+    @Timed
+    @Produces(APPLICATION_JSON_WITH_CHARSET)
+    public String sameNeighbors(@Context GraphManager manager,
+                                @PathParam("graph") String graph,
+                                Request request) {
+        LOG.debug("Graph [{}] get same neighbors among batch, '{}'", graph, request.toString());
+
+        ApiMeasure measure = new ApiMeasure();
+
+        Directions dir = Directions.convert(EdgeAPI.parseDirection(request.direction));
+        HugeGraph g = graph(manager, graph);
+        SameNeighborTraverser traverser = new SameNeighborTraverser(g);
+
+        List<Object> vertexList = request.vertexList;
+        E.checkArgument(vertexList.size() >= 2, "vertex_list size can't " +
+                                                "be less than 2");
+
+        List<Id> vertexIds = new ArrayList<>();
+        for (Object obj : vertexList) {
+            vertexIds.add(HugeVertex.getIdValue(obj));
+        }
+
+        Set<Id> neighbors = traverser.sameNeighbors(vertexIds, dir, request.labels,
+                                                    request.maxDegree, request.limit);
+        measure.addIterCount(traverser.vertexIterCounter.get(),
+                             traverser.edgeIterCounter.get());
+
+        Iterator<?> iterVertex;
+        Set<Id> ids = new HashSet<>(neighbors);
+        ids.addAll(vertexIds);
+        if (request.withVertex && !ids.isEmpty()) {
+            iterVertex = g.vertices(ids.toArray());
+        } else {
+            iterVertex = ids.iterator();
+        }
+        return manager.serializer(g, measure.getResult())
+                      .writeMap(ImmutableMap.of("same_neighbors", neighbors,
+                                                "vertices", iterVertex));
+    }
+
+    private static class Request {
+        @JsonProperty("max_degree")
+        public long maxDegree = Long.parseLong(DEFAULT_MAX_DEGREE);
+        @JsonProperty("limit")
+        public long limit = Long.parseLong(DEFAULT_ELEMENTS_LIMIT);
+        @JsonProperty("vertex_list")
+        private List<Object> vertexList;
+        @JsonProperty("direction")
+        private String direction;
+        @JsonProperty("labels")
+        private List<String> labels;
+        @JsonProperty("with_vertex")
+        private boolean withVertex = false;
+
+        @Override
+        public String toString() {
+            ObjectMapper om = new ObjectMapper();
+            String vertexStr;
+            try {
+                vertexStr = om.writeValueAsString(this.vertexList);
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+            return String.format("SameNeighborsBatchRequest{vertex=%s,direction=%s,label=%s," +
+                                 "max_degree=%d,limit=%d,with_vertex=%s", vertexStr, this.direction,
+                                 this.labels, this.maxDegree, this.limit, this.withVertex);
+        }
     }
 }

--- a/hugegraph-api/src/main/java/org/apache/hugegraph/api/traversers/SameNeighborsAPI.java
+++ b/hugegraph-api/src/main/java/org/apache/hugegraph/api/traversers/SameNeighborsAPI.java
@@ -142,7 +142,7 @@ public class SameNeighborsAPI extends API {
         @JsonProperty("max_degree")
         public long maxDegree = Long.parseLong(DEFAULT_MAX_DEGREE);
         @JsonProperty("limit")
-        public long limit = Long.parseLong(DEFAULT_ELEMENTS_LIMIT);
+        public int limit = Integer.parseInt(DEFAULT_ELEMENTS_LIMIT);
         @JsonProperty("vertex_list")
         private List<Object> vertexList;
         @JsonProperty("direction")

--- a/hugegraph-api/src/main/java/org/apache/hugegraph/api/traversers/SameNeighborsAPI.java
+++ b/hugegraph-api/src/main/java/org/apache/hugegraph/api/traversers/SameNeighborsAPI.java
@@ -41,7 +41,6 @@ import org.slf4j.Logger;
 
 import com.codahale.metrics.annotation.Timed;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableMap;
 
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -139,6 +138,7 @@ public class SameNeighborsAPI extends API {
     }
 
     private static class Request {
+
         @JsonProperty("max_degree")
         public long maxDegree = Long.parseLong(DEFAULT_MAX_DEGREE);
         @JsonProperty("limit")
@@ -154,16 +154,11 @@ public class SameNeighborsAPI extends API {
 
         @Override
         public String toString() {
-            ObjectMapper om = new ObjectMapper();
-            String vertexStr;
-            try {
-                vertexStr = om.writeValueAsString(this.vertexList);
-            } catch (Exception e) {
-                throw new RuntimeException(e);
-            }
-            return String.format("SameNeighborsBatchRequest{vertex=%s,direction=%s,label=%s," +
-                                 "max_degree=%d,limit=%d,with_vertex=%s", vertexStr, this.direction,
-                                 this.labels, this.maxDegree, this.limit, this.withVertex);
+            return String.format("SameNeighborsBatchRequest{vertex_list=%s," +
+                                 "direction=%s,label=%s,max_degree=%d," +
+                                 "limit=%d,with_vertex=%s",
+                                 this.vertexList, this.direction, this.labels,
+                                 this.maxDegree, this.limit, this.withVertex);
         }
     }
 }

--- a/hugegraph-api/src/main/java/org/apache/hugegraph/api/traversers/SameNeighborsAPI.java
+++ b/hugegraph-api/src/main/java/org/apache/hugegraph/api/traversers/SameNeighborsAPI.java
@@ -79,7 +79,7 @@ public class SameNeighborsAPI extends API {
                   "direction {}, edge label {}, max degree '{}' and limit '{}'",
                   graph, vertex, other, direction, edgeLabel, maxDegree, limit);
 
-        ApiMeasure measure = new ApiMeasure();
+        ApiMeasurer measure = new ApiMeasurer();
 
         Id sourceId = VertexAPI.checkAndParseVertexId(vertex);
         Id targetId = VertexAPI.checkAndParseVertexId(other);
@@ -93,7 +93,7 @@ public class SameNeighborsAPI extends API {
         measure.addIterCount(traverser.vertexIterCounter.get(),
                              traverser.edgeIterCounter.get());
 
-        return manager.serializer(g, measure.getResult())
+        return manager.serializer(g, measure.measures())
                       .writeList("same_neighbors", neighbors);
     }
 
@@ -105,7 +105,7 @@ public class SameNeighborsAPI extends API {
                                 Request request) {
         LOG.debug("Graph [{}] get same neighbors among batch, '{}'", graph, request.toString());
 
-        ApiMeasure measure = new ApiMeasure();
+        ApiMeasurer measure = new ApiMeasurer();
 
         Directions dir = Directions.convert(EdgeAPI.parseDirection(request.direction));
         HugeGraph g = graph(manager, graph);
@@ -133,7 +133,7 @@ public class SameNeighborsAPI extends API {
         } else {
             iterVertex = ids.iterator();
         }
-        return manager.serializer(g, measure.getResult())
+        return manager.serializer(g, measure.measures())
                       .writeMap(ImmutableMap.of("same_neighbors", neighbors,
                                                 "vertices", iterVertex));
     }

--- a/hugegraph-api/src/main/java/org/apache/hugegraph/api/traversers/ShortestPathAPI.java
+++ b/hugegraph-api/src/main/java/org/apache/hugegraph/api/traversers/ShortestPathAPI.java
@@ -81,7 +81,7 @@ public class ShortestPathAPI extends API {
         LOG.debug("Graph [{}] get shortest path from '{}', to '{}' with " +
                   "direction {}, edge label {}, max depth '{}', " +
                   "max degree '{}', skipped maxDegree '{}', capacity '{}', " +
-                  "with vertex '{}' and with edge '{}'",
+                  "with_vertex '{}' and with_edge '{}'",
                   graph, source, target, direction, edgeLabel, depth,
                   maxDegree, skipDegree, capacity, withVertex, withEdge);
 

--- a/hugegraph-api/src/main/java/org/apache/hugegraph/api/traversers/ShortestPathAPI.java
+++ b/hugegraph-api/src/main/java/org/apache/hugegraph/api/traversers/ShortestPathAPI.java
@@ -20,7 +20,26 @@ package org.apache.hugegraph.api.traversers;
 import static org.apache.hugegraph.traversal.algorithm.HugeTraverser.DEFAULT_CAPACITY;
 import static org.apache.hugegraph.traversal.algorithm.HugeTraverser.DEFAULT_MAX_DEGREE;
 
+import java.util.Iterator;
 import java.util.List;
+import java.util.Set;
+
+import org.apache.hugegraph.HugeGraph;
+import org.apache.hugegraph.api.API;
+import org.apache.hugegraph.api.graph.EdgeAPI;
+import org.apache.hugegraph.api.graph.VertexAPI;
+import org.apache.hugegraph.backend.id.Id;
+import org.apache.hugegraph.core.GraphManager;
+import org.apache.hugegraph.traversal.algorithm.HugeTraverser;
+import org.apache.hugegraph.traversal.algorithm.ShortestPathTraverser;
+import org.apache.hugegraph.type.define.Directions;
+import org.apache.hugegraph.util.Log;
+import org.apache.tinkerpop.gremlin.structure.Edge;
+import org.slf4j.Logger;
+
+import com.codahale.metrics.annotation.Timed;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.inject.Singleton;
@@ -31,21 +50,6 @@ import jakarta.ws.rs.PathParam;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.QueryParam;
 import jakarta.ws.rs.core.Context;
-
-import org.apache.hugegraph.core.GraphManager;
-import org.slf4j.Logger;
-
-import org.apache.hugegraph.HugeGraph;
-import org.apache.hugegraph.api.API;
-import org.apache.hugegraph.api.graph.EdgeAPI;
-import org.apache.hugegraph.api.graph.VertexAPI;
-import org.apache.hugegraph.backend.id.Id;
-import org.apache.hugegraph.traversal.algorithm.HugeTraverser;
-import org.apache.hugegraph.traversal.algorithm.ShortestPathTraverser;
-import org.apache.hugegraph.type.define.Directions;
-import org.apache.hugegraph.util.Log;
-import com.codahale.metrics.annotation.Timed;
-import com.google.common.collect.ImmutableList;
 
 @Path("graphs/{graph}/traversers/shortestpath")
 @Singleton
@@ -68,13 +72,21 @@ public class ShortestPathAPI extends API {
                       @DefaultValue(DEFAULT_MAX_DEGREE) long maxDegree,
                       @QueryParam("skip_degree")
                       @DefaultValue("0") long skipDegree,
+                      @QueryParam("with_vertex")
+                      @DefaultValue("false") boolean withVertex,
+                      @QueryParam("with_edge")
+                      @DefaultValue("false") boolean withEdge,
                       @QueryParam("capacity")
                       @DefaultValue(DEFAULT_CAPACITY) long capacity) {
         LOG.debug("Graph [{}] get shortest path from '{}', to '{}' with " +
                   "direction {}, edge label {}, max depth '{}', " +
-                  "max degree '{}', skipped maxDegree '{}' and capacity '{}'",
+                  "max degree '{}', skipped maxDegree '{}', capacity '{}', " +
+                  "with vertex '{}' and with edge '{}'",
                   graph, source, target, direction, edgeLabel, depth,
-                  maxDegree, skipDegree, capacity);
+                  maxDegree, skipDegree, capacity, withVertex, withEdge);
+
+        ApiMeasure measure = new ApiMeasure();
+
         Id sourceId = VertexAPI.checkAndParseVertexId(source);
         Id targetId = VertexAPI.checkAndParseVertexId(target);
         Directions dir = Directions.convert(EdgeAPI.parseDirection(direction));
@@ -89,6 +101,29 @@ public class ShortestPathAPI extends API {
                                                          dir, edgeLabels, depth,
                                                          maxDegree, skipDegree,
                                                          capacity);
-        return manager.serializer(g).writeList("path", path.vertices());
+        measure.addIterCount(traverser.vertexIterCounter.get(),
+                             traverser.edgeIterCounter.get());
+
+        Iterator<?> iterVertex;
+        List<Id> vertexIds = path.vertices();
+        if (withVertex && !vertexIds.isEmpty()) {
+            iterVertex = g.vertices(vertexIds.toArray());
+            measure.addIterCount(path.vertices().size(), 0L);
+        } else {
+            iterVertex = vertexIds.iterator();
+        }
+
+        Iterator<?> iterEdge;
+        Set<Edge> edges = path.getEdges();
+        if (withEdge) {
+            iterEdge = edges.iterator();
+        } else {
+            iterEdge = HugeTraverser.EdgeRecord.getEdgeIds(edges).iterator();
+        }
+
+        return manager.serializer(g, measure.getResult())
+                      .writeMap(ImmutableMap.of("path", path.vertices(),
+                                                "vertices", iterVertex,
+                                                "edges", iterEdge));
     }
 }

--- a/hugegraph-api/src/main/java/org/apache/hugegraph/api/traversers/ShortestPathAPI.java
+++ b/hugegraph-api/src/main/java/org/apache/hugegraph/api/traversers/ShortestPathAPI.java
@@ -85,7 +85,7 @@ public class ShortestPathAPI extends API {
                   graph, source, target, direction, edgeLabel, depth,
                   maxDegree, skipDegree, capacity, withVertex, withEdge);
 
-        ApiMeasure measure = new ApiMeasure();
+        ApiMeasurer measure = new ApiMeasurer();
 
         Id sourceId = VertexAPI.checkAndParseVertexId(source);
         Id targetId = VertexAPI.checkAndParseVertexId(target);
@@ -121,7 +121,7 @@ public class ShortestPathAPI extends API {
             iterEdge = HugeTraverser.EdgeRecord.getEdgeIds(edges).iterator();
         }
 
-        return manager.serializer(g, measure.getResult())
+        return manager.serializer(g, measure.measures())
                       .writeMap(ImmutableMap.of("path", path.vertices(),
                                                 "vertices", iterVertex,
                                                 "edges", iterEdge));

--- a/hugegraph-api/src/main/java/org/apache/hugegraph/api/traversers/SingleSourceShortestPathAPI.java
+++ b/hugegraph-api/src/main/java/org/apache/hugegraph/api/traversers/SingleSourceShortestPathAPI.java
@@ -84,7 +84,7 @@ public class SingleSourceShortestPathAPI extends API {
                   graph, source, direction, edgeLabel,
                   weight, maxDegree, capacity, limit, withVertex, withEdge);
 
-        ApiMeasure measure = new ApiMeasure();
+        ApiMeasurer measure = new ApiMeasurer();
 
         Id sourceId = VertexAPI.checkAndParseVertexId(source);
         Directions dir = Directions.convert(EdgeAPI.parseDirection(direction));
@@ -116,7 +116,7 @@ public class SingleSourceShortestPathAPI extends API {
             iterEdge = HugeTraverser.EdgeRecord.getEdgeIds(edges).iterator();
         }
 
-        return manager.serializer(g, measure.getResult())
+        return manager.serializer(g, measure.measures())
                       .writeWeightedPaths(paths, iterVertex, iterEdge);
     }
 }

--- a/hugegraph-api/src/main/java/org/apache/hugegraph/api/traversers/SingleSourceShortestPathAPI.java
+++ b/hugegraph-api/src/main/java/org/apache/hugegraph/api/traversers/SingleSourceShortestPathAPI.java
@@ -22,6 +22,22 @@ import static org.apache.hugegraph.traversal.algorithm.HugeTraverser.DEFAULT_MAX
 import static org.apache.hugegraph.traversal.algorithm.HugeTraverser.DEFAULT_PATHS_LIMIT;
 
 import java.util.Iterator;
+import java.util.Set;
+
+import org.apache.hugegraph.HugeGraph;
+import org.apache.hugegraph.api.API;
+import org.apache.hugegraph.api.graph.EdgeAPI;
+import org.apache.hugegraph.api.graph.VertexAPI;
+import org.apache.hugegraph.backend.id.Id;
+import org.apache.hugegraph.core.GraphManager;
+import org.apache.hugegraph.traversal.algorithm.HugeTraverser;
+import org.apache.hugegraph.traversal.algorithm.SingleSourceShortestPathTraverser;
+import org.apache.hugegraph.type.define.Directions;
+import org.apache.hugegraph.util.Log;
+import org.apache.tinkerpop.gremlin.structure.Edge;
+import org.slf4j.Logger;
+
+import com.codahale.metrics.annotation.Timed;
 
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.inject.Singleton;
@@ -32,22 +48,6 @@ import jakarta.ws.rs.PathParam;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.QueryParam;
 import jakarta.ws.rs.core.Context;
-
-import org.apache.tinkerpop.gremlin.structure.Vertex;
-import org.apache.hugegraph.core.GraphManager;
-import org.slf4j.Logger;
-
-import org.apache.hugegraph.HugeGraph;
-import org.apache.hugegraph.api.API;
-import org.apache.hugegraph.api.graph.EdgeAPI;
-import org.apache.hugegraph.api.graph.VertexAPI;
-import org.apache.hugegraph.backend.id.Id;
-import org.apache.hugegraph.backend.query.QueryResults;
-import org.apache.hugegraph.traversal.algorithm.SingleSourceShortestPathTraverser;
-import org.apache.hugegraph.traversal.algorithm.SingleSourceShortestPathTraverser.WeightedPaths;
-import org.apache.hugegraph.type.define.Directions;
-import org.apache.hugegraph.util.Log;
-import com.codahale.metrics.annotation.Timed;
 
 @Path("graphs/{graph}/traversers/singlesourceshortestpath")
 @Singleton
@@ -69,16 +69,22 @@ public class SingleSourceShortestPathAPI extends API {
                       @DefaultValue(DEFAULT_MAX_DEGREE) long maxDegree,
                       @QueryParam("skip_degree")
                       @DefaultValue("0") long skipDegree,
+                      @QueryParam("with_vertex")
+                      @DefaultValue("false") boolean withVertex,
+                      @QueryParam("with_edge")
+                      @DefaultValue("false") boolean withEdge,
                       @QueryParam("capacity")
                       @DefaultValue(DEFAULT_CAPACITY) long capacity,
                       @QueryParam("limit")
-                      @DefaultValue(DEFAULT_PATHS_LIMIT) int limit,
-                      @QueryParam("with_vertex") boolean withVertex) {
+                      @DefaultValue(DEFAULT_PATHS_LIMIT) int limit) {
         LOG.debug("Graph [{}] get single source shortest path from '{}' " +
                   "with direction {}, edge label {}, weight property {}, " +
-                  "max degree '{}', limit '{}' and with vertex '{}'",
+                  "max degree '{}', capacity '{}', limit '{}', " +
+                  "with vertex '{}' and with edge '{}'",
                   graph, source, direction, edgeLabel,
-                  weight, maxDegree, withVertex);
+                  weight, maxDegree, capacity, limit, withVertex, withEdge);
+
+        ApiMeasure measure = new ApiMeasure();
 
         Id sourceId = VertexAPI.checkAndParseVertexId(source);
         Directions dir = Directions.convert(EdgeAPI.parseDirection(direction));
@@ -86,14 +92,31 @@ public class SingleSourceShortestPathAPI extends API {
         HugeGraph g = graph(manager, graph);
         SingleSourceShortestPathTraverser traverser =
                 new SingleSourceShortestPathTraverser(g);
-        WeightedPaths paths = traverser.singleSourceShortestPaths(
-                              sourceId, dir, edgeLabel, weight,
-                              maxDegree, skipDegree, capacity, limit);
-        Iterator<Vertex> iterator = QueryResults.emptyIterator();
-        assert paths != null;
-        if (!paths.isEmpty() && withVertex) {
-            iterator = g.vertices(paths.vertices().toArray());
+        SingleSourceShortestPathTraverser.WeightedPaths paths =
+                traverser.singleSourceShortestPaths(
+                        sourceId, dir, edgeLabel, weight,
+                        maxDegree, skipDegree, capacity, limit);
+        measure.addIterCount(traverser.vertexIterCounter.get(),
+                             traverser.edgeIterCounter.get());
+
+        Iterator<?> iterVertex;
+        Set<Id> vertexIds = paths.vertices();
+        if (withVertex && !vertexIds.isEmpty()) {
+            iterVertex = g.vertices(vertexIds.toArray());
+            measure.addIterCount(vertexIds.size(), 0L);
+        } else {
+            iterVertex = vertexIds.iterator();
         }
-        return manager.serializer(g).writeWeightedPaths(paths, iterator);
+
+        Iterator<?> iterEdge;
+        Set<Edge> edges = paths.getEdges();
+        if (withEdge && !edges.isEmpty()) {
+            iterEdge = edges.iterator();
+        } else {
+            iterEdge = HugeTraverser.EdgeRecord.getEdgeIds(edges).iterator();
+        }
+
+        return manager.serializer(g, measure.getResult())
+                      .writeWeightedPaths(paths, iterVertex, iterEdge);
     }
 }

--- a/hugegraph-api/src/main/java/org/apache/hugegraph/api/traversers/SingleSourceShortestPathAPI.java
+++ b/hugegraph-api/src/main/java/org/apache/hugegraph/api/traversers/SingleSourceShortestPathAPI.java
@@ -80,7 +80,7 @@ public class SingleSourceShortestPathAPI extends API {
         LOG.debug("Graph [{}] get single source shortest path from '{}' " +
                   "with direction {}, edge label {}, weight property {}, " +
                   "max degree '{}', capacity '{}', limit '{}', " +
-                  "with vertex '{}' and with edge '{}'",
+                  "with_vertex '{}' and with_edge '{}'",
                   graph, source, direction, edgeLabel,
                   weight, maxDegree, capacity, limit, withVertex, withEdge);
 

--- a/hugegraph-api/src/main/java/org/apache/hugegraph/api/traversers/TemplatePathsAPI.java
+++ b/hugegraph-api/src/main/java/org/apache/hugegraph/api/traversers/TemplatePathsAPI.java
@@ -90,7 +90,7 @@ public class TemplatePathsAPI extends TraverserAPI {
 
         LOG.debug("Graph [{}] get template paths from source vertices '{}', " +
                   "target vertices '{}', with steps '{}', " +
-                  "capacity '{}', limit '{}', with vertex '{}' and with edge '{}'",
+                  "capacity '{}', limit '{}', with_vertex '{}' and with_edge '{}'",
                   graph, request.sources, request.targets, request.steps,
                   request.capacity, request.limit, request.withVertex, request.withEdge);
 

--- a/hugegraph-api/src/main/java/org/apache/hugegraph/api/traversers/TemplatePathsAPI.java
+++ b/hugegraph-api/src/main/java/org/apache/hugegraph/api/traversers/TemplatePathsAPI.java
@@ -26,6 +26,21 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
 
+import org.apache.hugegraph.HugeGraph;
+import org.apache.hugegraph.backend.id.Id;
+import org.apache.hugegraph.core.GraphManager;
+import org.apache.hugegraph.traversal.algorithm.HugeTraverser;
+import org.apache.hugegraph.traversal.algorithm.TemplatePathsTraverser;
+import org.apache.hugegraph.traversal.algorithm.steps.RepeatEdgeStep;
+import org.apache.hugegraph.util.E;
+import org.apache.hugegraph.util.Log;
+import org.apache.tinkerpop.gremlin.structure.Edge;
+import org.apache.tinkerpop.gremlin.structure.Vertex;
+import org.slf4j.Logger;
+
+import com.codahale.metrics.annotation.Timed;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.inject.Singleton;
 import jakarta.ws.rs.Consumes;
@@ -35,27 +50,28 @@ import jakarta.ws.rs.PathParam;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.core.Context;
 
-import org.apache.tinkerpop.gremlin.structure.Vertex;
-import org.apache.hugegraph.core.GraphManager;
-import org.slf4j.Logger;
-
-import org.apache.hugegraph.HugeGraph;
-import org.apache.hugegraph.backend.id.Id;
-import org.apache.hugegraph.backend.query.QueryResults;
-import org.apache.hugegraph.traversal.algorithm.HugeTraverser;
-import org.apache.hugegraph.traversal.algorithm.TemplatePathsTraverser;
-import org.apache.hugegraph.traversal.algorithm.steps.RepeatEdgeStep;
-import org.apache.hugegraph.util.E;
-import org.apache.hugegraph.util.Log;
-import com.codahale.metrics.annotation.Timed;
-import com.fasterxml.jackson.annotation.JsonProperty;
-
 @Path("graphs/{graph}/traversers/templatepaths")
 @Singleton
 @Tag(name = "TemplatePathsAPI")
 public class TemplatePathsAPI extends TraverserAPI {
 
     private static final Logger LOG = Log.logger(TemplatePathsAPI.class);
+
+    private static List<RepeatEdgeStep> steps(HugeGraph g,
+                                              List<TemplatePathStep> steps) {
+        List<RepeatEdgeStep> edgeSteps = new ArrayList<>(steps.size());
+        for (TemplatePathStep step : steps) {
+            edgeSteps.add(repeatEdgeStep(g, step));
+        }
+        return edgeSteps;
+    }
+
+    private static RepeatEdgeStep repeatEdgeStep(HugeGraph graph,
+                                                 TemplatePathStep step) {
+        return new RepeatEdgeStep(graph, step.direction, step.labels,
+                                  step.properties, step.maxDegree,
+                                  step.skipDegree, step.maxTimes);
+    }
 
     @POST
     @Timed
@@ -74,9 +90,11 @@ public class TemplatePathsAPI extends TraverserAPI {
 
         LOG.debug("Graph [{}] get template paths from source vertices '{}', " +
                   "target vertices '{}', with steps '{}', " +
-                  "capacity '{}', limit '{}' and with_vertex '{}'",
+                  "capacity '{}', limit '{}', with vertex '{}' and with edge '{}'",
                   graph, request.sources, request.targets, request.steps,
-                  request.capacity, request.limit, request.withVertex);
+                  request.capacity, request.limit, request.withVertex, request.withEdge);
+
+        ApiMeasure measure = new ApiMeasure();
 
         HugeGraph g = graph(manager, graph);
         Iterator<Vertex> sources = request.sources.vertices(g);
@@ -84,40 +102,38 @@ public class TemplatePathsAPI extends TraverserAPI {
         List<RepeatEdgeStep> steps = steps(g, request.steps);
 
         TemplatePathsTraverser traverser = new TemplatePathsTraverser(g);
-        Set<HugeTraverser.Path> paths;
-        paths = traverser.templatePaths(sources, targets, steps,
+        TemplatePathsTraverser.WrappedPathSet wrappedPathSet =
+                traverser.templatePaths(sources, targets, steps,
                                         request.withRing, request.capacity,
                                         request.limit);
+        measure.addIterCount(traverser.vertexIterCounter.get(),
+                             traverser.edgeIterCounter.get());
 
-        if (!request.withVertex) {
-            return manager.serializer(g).writePaths("paths", paths, false);
+        Set<HugeTraverser.Path> paths = wrappedPathSet.getPaths();
+
+        Iterator<?> iterVertex;
+        Set<Id> vertexIds = new HashSet<>();
+        for (HugeTraverser.Path path : paths) {
+            vertexIds.addAll(path.vertices());
+        }
+        if (request.withVertex && !vertexIds.isEmpty()) {
+            iterVertex = g.vertices(vertexIds.toArray());
+            measure.addIterCount(vertexIds.size(), 0L);
+        } else {
+            iterVertex = vertexIds.iterator();
         }
 
-        Set<Id> ids = new HashSet<>();
-        for (HugeTraverser.Path p : paths) {
-            ids.addAll(p.vertices());
+        Iterator<?> iterEdge;
+        Set<Edge> edges = wrappedPathSet.getEdges();
+        if (request.withEdge && !edges.isEmpty()) {
+            iterEdge = edges.iterator();
+        } else {
+            iterEdge = HugeTraverser.EdgeRecord.getEdgeIds(edges).iterator();
         }
-        Iterator<Vertex> iter = QueryResults.emptyIterator();
-        if (!ids.isEmpty()) {
-            iter = g.vertices(ids.toArray());
-        }
-        return manager.serializer(g).writePaths("paths", paths, false, iter);
-    }
 
-    private static List<RepeatEdgeStep> steps(HugeGraph g,
-                                              List<TemplatePathStep> steps) {
-        List<RepeatEdgeStep> edgeSteps = new ArrayList<>(steps.size());
-        for (TemplatePathStep step : steps) {
-            edgeSteps.add(repeatEdgeStep(g, step));
-        }
-        return edgeSteps;
-    }
-
-    private static RepeatEdgeStep repeatEdgeStep(HugeGraph graph,
-                                                 TemplatePathStep step) {
-        return new RepeatEdgeStep(graph, step.direction, step.labels,
-                                  step.properties, step.maxDegree,
-                                  step.skipDegree, step.maxTimes);
+        return manager.serializer(g, measure.getResult())
+                      .writePaths("paths", paths, false,
+                                  iterVertex, iterEdge);
     }
 
     private static class Request {
@@ -136,15 +152,17 @@ public class TemplatePathsAPI extends TraverserAPI {
         public int limit = Integer.parseInt(DEFAULT_PATHS_LIMIT);
         @JsonProperty("with_vertex")
         public boolean withVertex = false;
+        @JsonProperty("with_edge")
+        public boolean withEdge = false;
 
         @Override
         public String toString() {
             return String.format("TemplatePathsRequest{sources=%s,targets=%s," +
                                  "steps=%s,withRing=%s,capacity=%s,limit=%s," +
-                                 "withVertex=%s}",
+                                 "withVertex=%s,withEdge=%s}",
                                  this.sources, this.targets, this.steps,
                                  this.withRing, this.capacity, this.limit,
-                                 this.withVertex);
+                                 this.withVertex, this.withEdge);
         }
     }
 

--- a/hugegraph-api/src/main/java/org/apache/hugegraph/api/traversers/TemplatePathsAPI.java
+++ b/hugegraph-api/src/main/java/org/apache/hugegraph/api/traversers/TemplatePathsAPI.java
@@ -94,7 +94,7 @@ public class TemplatePathsAPI extends TraverserAPI {
                   graph, request.sources, request.targets, request.steps,
                   request.capacity, request.limit, request.withVertex, request.withEdge);
 
-        ApiMeasure measure = new ApiMeasure();
+        ApiMeasurer measure = new ApiMeasurer();
 
         HugeGraph g = graph(manager, graph);
         Iterator<Vertex> sources = request.sources.vertices(g);
@@ -109,7 +109,7 @@ public class TemplatePathsAPI extends TraverserAPI {
         measure.addIterCount(traverser.vertexIterCounter.get(),
                              traverser.edgeIterCounter.get());
 
-        Set<HugeTraverser.Path> paths = wrappedPathSet.getPaths();
+        Set<HugeTraverser.Path> paths = wrappedPathSet.paths();
 
         Iterator<?> iterVertex;
         Set<Id> vertexIds = new HashSet<>();
@@ -124,14 +124,14 @@ public class TemplatePathsAPI extends TraverserAPI {
         }
 
         Iterator<?> iterEdge;
-        Set<Edge> edges = wrappedPathSet.getEdges();
+        Set<Edge> edges = wrappedPathSet.edges();
         if (request.withEdge && !edges.isEmpty()) {
             iterEdge = edges.iterator();
         } else {
             iterEdge = HugeTraverser.EdgeRecord.getEdgeIds(edges).iterator();
         }
 
-        return manager.serializer(g, measure.getResult())
+        return manager.serializer(g, measure.measures())
                       .writePaths("paths", paths, false,
                                   iterVertex, iterEdge);
     }

--- a/hugegraph-api/src/main/java/org/apache/hugegraph/api/traversers/VerticesAPI.java
+++ b/hugegraph-api/src/main/java/org/apache/hugegraph/api/traversers/VerticesAPI.java
@@ -22,6 +22,22 @@ import static org.apache.hugegraph.traversal.algorithm.HugeTraverser.DEFAULT_PAG
 import java.util.Iterator;
 import java.util.List;
 
+import org.apache.hugegraph.HugeGraph;
+import org.apache.hugegraph.api.API;
+import org.apache.hugegraph.api.filter.CompressInterceptor.Compress;
+import org.apache.hugegraph.api.graph.VertexAPI;
+import org.apache.hugegraph.backend.id.Id;
+import org.apache.hugegraph.backend.query.ConditionQuery;
+import org.apache.hugegraph.backend.store.Shard;
+import org.apache.hugegraph.core.GraphManager;
+import org.apache.hugegraph.type.HugeType;
+import org.apache.hugegraph.util.E;
+import org.apache.hugegraph.util.Log;
+import org.apache.tinkerpop.gremlin.structure.Vertex;
+import org.slf4j.Logger;
+
+import com.codahale.metrics.annotation.Timed;
+
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.inject.Singleton;
 import jakarta.ws.rs.DefaultValue;
@@ -31,22 +47,6 @@ import jakarta.ws.rs.PathParam;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.QueryParam;
 import jakarta.ws.rs.core.Context;
-
-import org.apache.tinkerpop.gremlin.structure.Vertex;
-import org.apache.hugegraph.core.GraphManager;
-import org.slf4j.Logger;
-
-import org.apache.hugegraph.HugeGraph;
-import org.apache.hugegraph.api.API;
-import org.apache.hugegraph.api.filter.CompressInterceptor.Compress;
-import org.apache.hugegraph.api.graph.VertexAPI;
-import org.apache.hugegraph.backend.id.Id;
-import org.apache.hugegraph.backend.query.ConditionQuery;
-import org.apache.hugegraph.backend.store.Shard;
-import org.apache.hugegraph.type.HugeType;
-import org.apache.hugegraph.util.E;
-import org.apache.hugegraph.util.Log;
-import com.codahale.metrics.annotation.Timed;
 
 @Path("graphs/{graph}/traversers/vertices")
 @Singleton

--- a/hugegraph-api/src/main/java/org/apache/hugegraph/api/traversers/WeightedShortestPathAPI.java
+++ b/hugegraph-api/src/main/java/org/apache/hugegraph/api/traversers/WeightedShortestPathAPI.java
@@ -81,7 +81,7 @@ public class WeightedShortestPathAPI extends API {
         LOG.debug("Graph [{}] get weighted shortest path between '{}' and " +
                   "'{}' with direction {}, edge label {}, weight property {}, " +
                   "max degree '{}', skip degree '{}', capacity '{}', " +
-                  "with vertex '{}' and with edge '{}'",
+                  "with_vertex '{}' and with_edge '{}'",
                   graph, source, target, direction, edgeLabel, weight,
                   maxDegree, skipDegree, capacity, withVertex, withEdge);
 

--- a/hugegraph-api/src/main/java/org/apache/hugegraph/api/traversers/WeightedShortestPathAPI.java
+++ b/hugegraph-api/src/main/java/org/apache/hugegraph/api/traversers/WeightedShortestPathAPI.java
@@ -21,6 +21,25 @@ import static org.apache.hugegraph.traversal.algorithm.HugeTraverser.DEFAULT_CAP
 import static org.apache.hugegraph.traversal.algorithm.HugeTraverser.DEFAULT_MAX_DEGREE;
 
 import java.util.Iterator;
+import java.util.List;
+import java.util.Set;
+
+import org.apache.hugegraph.HugeGraph;
+import org.apache.hugegraph.api.API;
+import org.apache.hugegraph.api.graph.EdgeAPI;
+import org.apache.hugegraph.api.graph.VertexAPI;
+import org.apache.hugegraph.backend.id.Id;
+import org.apache.hugegraph.backend.query.QueryResults;
+import org.apache.hugegraph.core.GraphManager;
+import org.apache.hugegraph.traversal.algorithm.HugeTraverser;
+import org.apache.hugegraph.traversal.algorithm.SingleSourceShortestPathTraverser;
+import org.apache.hugegraph.type.define.Directions;
+import org.apache.hugegraph.util.E;
+import org.apache.hugegraph.util.Log;
+import org.apache.tinkerpop.gremlin.structure.Edge;
+import org.slf4j.Logger;
+
+import com.codahale.metrics.annotation.Timed;
 
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.inject.Singleton;
@@ -31,23 +50,6 @@ import jakarta.ws.rs.PathParam;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.QueryParam;
 import jakarta.ws.rs.core.Context;
-
-import org.apache.tinkerpop.gremlin.structure.Vertex;
-import org.apache.hugegraph.core.GraphManager;
-import org.slf4j.Logger;
-
-import org.apache.hugegraph.HugeGraph;
-import org.apache.hugegraph.api.API;
-import org.apache.hugegraph.api.graph.EdgeAPI;
-import org.apache.hugegraph.api.graph.VertexAPI;
-import org.apache.hugegraph.backend.id.Id;
-import org.apache.hugegraph.backend.query.QueryResults;
-import org.apache.hugegraph.traversal.algorithm.SingleSourceShortestPathTraverser;
-import org.apache.hugegraph.traversal.algorithm.SingleSourceShortestPathTraverser.NodeWithWeight;
-import org.apache.hugegraph.type.define.Directions;
-import org.apache.hugegraph.util.E;
-import org.apache.hugegraph.util.Log;
-import com.codahale.metrics.annotation.Timed;
 
 @Path("graphs/{graph}/traversers/weightedshortestpath")
 @Singleton
@@ -70,16 +72,20 @@ public class WeightedShortestPathAPI extends API {
                       @DefaultValue(DEFAULT_MAX_DEGREE) long maxDegree,
                       @QueryParam("skip_degree")
                       @DefaultValue("0") long skipDegree,
+                      @QueryParam("with_vertex")
+                      @DefaultValue("false") boolean withVertex,
+                      @QueryParam("with_edge")
+                      @DefaultValue("false") boolean withEdge,
                       @QueryParam("capacity")
-                      @DefaultValue(DEFAULT_CAPACITY) long capacity,
-                      @QueryParam("with_vertex") boolean withVertex) {
+                      @DefaultValue(DEFAULT_CAPACITY) long capacity) {
         LOG.debug("Graph [{}] get weighted shortest path between '{}' and " +
                   "'{}' with direction {}, edge label {}, weight property {}, " +
                   "max degree '{}', skip degree '{}', capacity '{}', " +
-                  "and with vertex '{}'",
+                  "with vertex '{}' and with edge '{}'",
                   graph, source, target, direction, edgeLabel, weight,
-                  maxDegree, skipDegree, capacity, withVertex);
+                  maxDegree, skipDegree, capacity, withVertex, withEdge);
 
+        ApiMeasure measure = new ApiMeasure();
         Id sourceId = VertexAPI.checkAndParseVertexId(source);
         Id targetId = VertexAPI.checkAndParseVertexId(target);
         Directions dir = Directions.convert(EdgeAPI.parseDirection(direction));
@@ -89,14 +95,38 @@ public class WeightedShortestPathAPI extends API {
         SingleSourceShortestPathTraverser traverser =
                 new SingleSourceShortestPathTraverser(g);
 
-        NodeWithWeight path = traverser.weightedShortestPath(
-                              sourceId, targetId, dir, edgeLabel, weight,
-                              maxDegree, skipDegree, capacity);
-        Iterator<Vertex> iterator = QueryResults.emptyIterator();
-        if (path != null && withVertex) {
-            assert !path.node().path().isEmpty();
-            iterator = g.vertices(path.node().path().toArray());
+        SingleSourceShortestPathTraverser.NodeWithWeight node =
+                traverser.weightedShortestPath(sourceId, targetId,
+                                               dir, edgeLabel, weight,
+                                               maxDegree, skipDegree, capacity);
+        measure.addIterCount(traverser.vertexIterCounter.get(),
+                             traverser.edgeIterCounter.get());
+
+        if (node == null) {
+            return manager.serializer(g, measure.getResult())
+                          .writeWeightedPath(null,
+                                             QueryResults.emptyIterator(),
+                                             QueryResults.emptyIterator());
         }
-        return manager.serializer(g).writeWeightedPath(path, iterator);
+
+        Iterator<?> iterVertex;
+        List<Id> vertexIds = node.node().path();
+        if (withVertex && !vertexIds.isEmpty()) {
+            iterVertex = g.vertices(vertexIds.toArray());
+            measure.addIterCount(vertexIds.size(), 0L);
+        } else {
+            iterVertex = vertexIds.iterator();
+        }
+
+        Iterator<?> iterEdge;
+        Set<Edge> edges = node.getEdges();
+        if (withEdge && !edges.isEmpty()) {
+            iterEdge = edges.iterator();
+        } else {
+            iterEdge = HugeTraverser.EdgeRecord.getEdgeIds(edges).iterator();
+        }
+
+        return manager.serializer(g, measure.getResult())
+                      .writeWeightedPath(node, iterVertex, iterEdge);
     }
 }

--- a/hugegraph-api/src/main/java/org/apache/hugegraph/api/traversers/WeightedShortestPathAPI.java
+++ b/hugegraph-api/src/main/java/org/apache/hugegraph/api/traversers/WeightedShortestPathAPI.java
@@ -85,7 +85,7 @@ public class WeightedShortestPathAPI extends API {
                   graph, source, target, direction, edgeLabel, weight,
                   maxDegree, skipDegree, capacity, withVertex, withEdge);
 
-        ApiMeasure measure = new ApiMeasure();
+        ApiMeasurer measure = new ApiMeasurer();
         Id sourceId = VertexAPI.checkAndParseVertexId(source);
         Id targetId = VertexAPI.checkAndParseVertexId(target);
         Directions dir = Directions.convert(EdgeAPI.parseDirection(direction));
@@ -103,7 +103,7 @@ public class WeightedShortestPathAPI extends API {
                              traverser.edgeIterCounter.get());
 
         if (node == null) {
-            return manager.serializer(g, measure.getResult())
+            return manager.serializer(g, measure.measures())
                           .writeWeightedPath(null,
                                              QueryResults.emptyIterator(),
                                              QueryResults.emptyIterator());
@@ -126,7 +126,7 @@ public class WeightedShortestPathAPI extends API {
             iterEdge = HugeTraverser.EdgeRecord.getEdgeIds(edges).iterator();
         }
 
-        return manager.serializer(g, measure.getResult())
+        return manager.serializer(g, measure.measures())
                       .writeWeightedPath(node, iterVertex, iterEdge);
     }
 }

--- a/hugegraph-api/src/main/java/org/apache/hugegraph/config/ServerOptions.java
+++ b/hugegraph-api/src/main/java/org/apache/hugegraph/config/ServerOptions.java
@@ -25,20 +25,6 @@ import static org.apache.hugegraph.config.OptionChecker.rangeInt;
 
 public class ServerOptions extends OptionHolder {
 
-    private ServerOptions() {
-        super();
-    }
-
-    private static volatile ServerOptions instance;
-
-    public static synchronized ServerOptions instance() {
-        if (instance == null) {
-            instance = new ServerOptions();
-            instance.registerOptions();
-        }
-        return instance;
-    }
-
     public static final ConfigOption<String> REST_SERVER_URL =
             new ConfigOption<>(
                     "restserver.url",
@@ -46,7 +32,6 @@ public class ServerOptions extends OptionHolder {
                     disallowEmpty(),
                     "http://127.0.0.1:8080"
             );
-
     public static final ConfigOption<String> SERVER_ID =
             new ConfigOption<>(
                     "server.id",
@@ -54,7 +39,6 @@ public class ServerOptions extends OptionHolder {
                     disallowEmpty(),
                     "server-1"
             );
-
     public static final ConfigOption<String> SERVER_ROLE =
             new ConfigOption<>(
                     "server.role",
@@ -63,7 +47,6 @@ public class ServerOptions extends OptionHolder {
                     allowValues("master", "worker", "computer"),
                     "master"
             );
-
     public static final ConfigOption<Integer> MAX_WORKER_THREADS =
             new ConfigOption<>(
                     "restserver.max_worker_threads",
@@ -71,7 +54,6 @@ public class ServerOptions extends OptionHolder {
                     rangeInt(2, Integer.MAX_VALUE),
                     2 * CoreOptions.CPUS
             );
-
     public static final ConfigOption<Integer> MIN_FREE_MEMORY =
             new ConfigOption<>(
                     "restserver.min_free_memory",
@@ -81,7 +63,6 @@ public class ServerOptions extends OptionHolder {
                     nonNegativeInt(),
                     64
             );
-
     public static final ConfigOption<Integer> REQUEST_TIMEOUT =
             new ConfigOption<>(
                     "restserver.request_timeout",
@@ -90,7 +71,6 @@ public class ServerOptions extends OptionHolder {
                     rangeInt(-1, Integer.MAX_VALUE),
                     30
             );
-
     public static final ConfigOption<Integer> CONN_IDLE_TIMEOUT =
             new ConfigOption<>(
                     "restserver.connection_idle_timeout",
@@ -99,7 +79,6 @@ public class ServerOptions extends OptionHolder {
                     rangeInt(-1, Integer.MAX_VALUE),
                     30
             );
-
     public static final ConfigOption<Integer> CONN_MAX_REQUESTS =
             new ConfigOption<>(
                     "restserver.connection_max_requests",
@@ -108,7 +87,6 @@ public class ServerOptions extends OptionHolder {
                     rangeInt(-1, Integer.MAX_VALUE),
                     256
             );
-
     public static final ConfigOption<String> GREMLIN_SERVER_URL =
             new ConfigOption<>(
                     "gremlinserver.url",
@@ -116,7 +94,6 @@ public class ServerOptions extends OptionHolder {
                     disallowEmpty(),
                     "http://127.0.0.1:8182"
             );
-
     public static final ConfigOption<Integer> GREMLIN_SERVER_TIMEOUT =
             new ConfigOption<>(
                     "gremlinserver.timeout",
@@ -124,7 +101,6 @@ public class ServerOptions extends OptionHolder {
                     positiveInt(),
                     30
             );
-
     public static final ConfigOption<Integer> GREMLIN_SERVER_MAX_ROUTE =
             new ConfigOption<>(
                     "gremlinserver.max_route",
@@ -132,7 +108,6 @@ public class ServerOptions extends OptionHolder {
                     positiveInt(),
                     2 * CoreOptions.CPUS
             );
-
     public static final ConfigOption<String> GRAPHS =
             new ConfigOption<>(
                     "graphs",
@@ -140,7 +115,6 @@ public class ServerOptions extends OptionHolder {
                     disallowEmpty(),
                     "./conf/graphs"
             );
-
     public static final ConfigOption<Integer> MAX_VERTICES_PER_BATCH =
             new ConfigOption<>(
                     "batch.max_vertices_per_batch",
@@ -148,7 +122,6 @@ public class ServerOptions extends OptionHolder {
                     positiveInt(),
                     500
             );
-
     public static final ConfigOption<Integer> MAX_EDGES_PER_BATCH =
             new ConfigOption<>(
                     "batch.max_edges_per_batch",
@@ -156,7 +129,6 @@ public class ServerOptions extends OptionHolder {
                     positiveInt(),
                     500
             );
-
     public static final ConfigOption<Integer> MAX_WRITE_RATIO =
             new ConfigOption<>(
                     "batch.max_write_ratio",
@@ -165,7 +137,6 @@ public class ServerOptions extends OptionHolder {
                     rangeInt(0, 100),
                     50
             );
-
     public static final ConfigOption<Integer> MAX_WRITE_THREADS =
             new ConfigOption<>(
                     "batch.max_write_threads",
@@ -174,7 +145,6 @@ public class ServerOptions extends OptionHolder {
                     "batch.max_write_ratio * restserver.max_worker_threads.",
                     nonNegativeInt(),
                     0);
-
     public static final ConfigOption<String> RAFT_GROUP_PEERS =
             new ConfigOption<>(
                     "raft.group_peers",
@@ -182,15 +152,13 @@ public class ServerOptions extends OptionHolder {
                     disallowEmpty(),
                     "127.0.0.1:8090"
             );
-
     public static final ConfigOption<Boolean> ALLOW_TRACE =
             new ConfigOption<>(
                     "exception.allow_trace",
                     "Whether to allow exception trace stack.",
                     disallowEmpty(),
-                    false
+                    true
             );
-
     public static final ConfigOption<String> AUTHENTICATOR =
             new ConfigOption<>(
                     "auth.authenticator",
@@ -200,7 +168,6 @@ public class ServerOptions extends OptionHolder {
                     null,
                     ""
             );
-
     public static final ConfigOption<String> AUTH_GRAPH_STORE =
             new ConfigOption<>(
                     "auth.graph_store",
@@ -209,7 +176,6 @@ public class ServerOptions extends OptionHolder {
                     disallowEmpty(),
                     "hugegraph"
             );
-
     public static final ConfigOption<String> AUTH_ADMIN_TOKEN =
             new ConfigOption<>(
                     "auth.admin_token",
@@ -218,7 +184,6 @@ public class ServerOptions extends OptionHolder {
                     disallowEmpty(),
                     "162f7848-0b6d-4faf-b557-3a0797869c55"
             );
-
     public static final ConfigListOption<String> AUTH_USER_TOKENS =
             new ConfigListOption<>(
                     "auth.user_tokens",
@@ -227,7 +192,6 @@ public class ServerOptions extends OptionHolder {
                     disallowEmpty(),
                     "hugegraph:9fd95c9c-711b-415b-b85f-d4df46ba5c31"
             );
-
     public static final ConfigOption<String> AUTH_REMOTE_URL =
             new ConfigOption<>(
                     "auth.remote_url",
@@ -238,7 +202,6 @@ public class ServerOptions extends OptionHolder {
                     null,
                     ""
             );
-
     public static final ConfigOption<String> SSL_KEYSTORE_FILE =
             new ConfigOption<>(
                     "ssl.keystore_file",
@@ -247,7 +210,6 @@ public class ServerOptions extends OptionHolder {
                     disallowEmpty(),
                     "conf/hugegraph-server.keystore"
             );
-
     public static final ConfigOption<String> SSL_KEYSTORE_PASSWORD =
             new ConfigOption<>(
                     "ssl.keystore_password",
@@ -256,7 +218,6 @@ public class ServerOptions extends OptionHolder {
                     null,
                     "hugegraph"
             );
-
     public static final ConfigOption<Boolean> ENABLE_DYNAMIC_CREATE_DROP =
             new ConfigOption<>(
                     "graphs.enable_dynamic_create_drop",
@@ -264,4 +225,17 @@ public class ServerOptions extends OptionHolder {
                     disallowEmpty(),
                     true
             );
+    private static volatile ServerOptions instance;
+
+    private ServerOptions() {
+        super();
+    }
+
+    public static synchronized ServerOptions instance() {
+        if (instance == null) {
+            instance = new ServerOptions();
+            instance.registerOptions();
+        }
+        return instance;
+    }
 }

--- a/hugegraph-api/src/main/java/org/apache/hugegraph/config/ServerOptions.java
+++ b/hugegraph-api/src/main/java/org/apache/hugegraph/config/ServerOptions.java
@@ -25,6 +25,20 @@ import static org.apache.hugegraph.config.OptionChecker.rangeInt;
 
 public class ServerOptions extends OptionHolder {
 
+    private ServerOptions() {
+        super();
+    }
+
+    private static volatile ServerOptions instance;
+
+    public static synchronized ServerOptions instance() {
+        if (instance == null) {
+            instance = new ServerOptions();
+            instance.registerOptions();
+        }
+        return instance;
+    }
+
     public static final ConfigOption<String> REST_SERVER_URL =
             new ConfigOption<>(
                     "restserver.url",
@@ -32,6 +46,7 @@ public class ServerOptions extends OptionHolder {
                     disallowEmpty(),
                     "http://127.0.0.1:8080"
             );
+
     public static final ConfigOption<String> SERVER_ID =
             new ConfigOption<>(
                     "server.id",
@@ -39,6 +54,7 @@ public class ServerOptions extends OptionHolder {
                     disallowEmpty(),
                     "server-1"
             );
+
     public static final ConfigOption<String> SERVER_ROLE =
             new ConfigOption<>(
                     "server.role",
@@ -47,6 +63,7 @@ public class ServerOptions extends OptionHolder {
                     allowValues("master", "worker", "computer"),
                     "master"
             );
+
     public static final ConfigOption<Integer> MAX_WORKER_THREADS =
             new ConfigOption<>(
                     "restserver.max_worker_threads",
@@ -54,6 +71,7 @@ public class ServerOptions extends OptionHolder {
                     rangeInt(2, Integer.MAX_VALUE),
                     2 * CoreOptions.CPUS
             );
+
     public static final ConfigOption<Integer> MIN_FREE_MEMORY =
             new ConfigOption<>(
                     "restserver.min_free_memory",
@@ -63,6 +81,7 @@ public class ServerOptions extends OptionHolder {
                     nonNegativeInt(),
                     64
             );
+
     public static final ConfigOption<Integer> REQUEST_TIMEOUT =
             new ConfigOption<>(
                     "restserver.request_timeout",
@@ -71,6 +90,7 @@ public class ServerOptions extends OptionHolder {
                     rangeInt(-1, Integer.MAX_VALUE),
                     30
             );
+
     public static final ConfigOption<Integer> CONN_IDLE_TIMEOUT =
             new ConfigOption<>(
                     "restserver.connection_idle_timeout",
@@ -79,6 +99,7 @@ public class ServerOptions extends OptionHolder {
                     rangeInt(-1, Integer.MAX_VALUE),
                     30
             );
+
     public static final ConfigOption<Integer> CONN_MAX_REQUESTS =
             new ConfigOption<>(
                     "restserver.connection_max_requests",
@@ -87,6 +108,7 @@ public class ServerOptions extends OptionHolder {
                     rangeInt(-1, Integer.MAX_VALUE),
                     256
             );
+
     public static final ConfigOption<String> GREMLIN_SERVER_URL =
             new ConfigOption<>(
                     "gremlinserver.url",
@@ -94,6 +116,7 @@ public class ServerOptions extends OptionHolder {
                     disallowEmpty(),
                     "http://127.0.0.1:8182"
             );
+
     public static final ConfigOption<Integer> GREMLIN_SERVER_TIMEOUT =
             new ConfigOption<>(
                     "gremlinserver.timeout",
@@ -101,6 +124,7 @@ public class ServerOptions extends OptionHolder {
                     positiveInt(),
                     30
             );
+
     public static final ConfigOption<Integer> GREMLIN_SERVER_MAX_ROUTE =
             new ConfigOption<>(
                     "gremlinserver.max_route",
@@ -108,6 +132,7 @@ public class ServerOptions extends OptionHolder {
                     positiveInt(),
                     2 * CoreOptions.CPUS
             );
+
     public static final ConfigOption<String> GRAPHS =
             new ConfigOption<>(
                     "graphs",
@@ -115,6 +140,7 @@ public class ServerOptions extends OptionHolder {
                     disallowEmpty(),
                     "./conf/graphs"
             );
+
     public static final ConfigOption<Integer> MAX_VERTICES_PER_BATCH =
             new ConfigOption<>(
                     "batch.max_vertices_per_batch",
@@ -122,6 +148,7 @@ public class ServerOptions extends OptionHolder {
                     positiveInt(),
                     500
             );
+
     public static final ConfigOption<Integer> MAX_EDGES_PER_BATCH =
             new ConfigOption<>(
                     "batch.max_edges_per_batch",
@@ -129,6 +156,7 @@ public class ServerOptions extends OptionHolder {
                     positiveInt(),
                     500
             );
+
     public static final ConfigOption<Integer> MAX_WRITE_RATIO =
             new ConfigOption<>(
                     "batch.max_write_ratio",
@@ -137,6 +165,7 @@ public class ServerOptions extends OptionHolder {
                     rangeInt(0, 100),
                     50
             );
+
     public static final ConfigOption<Integer> MAX_WRITE_THREADS =
             new ConfigOption<>(
                     "batch.max_write_threads",
@@ -145,6 +174,7 @@ public class ServerOptions extends OptionHolder {
                     "batch.max_write_ratio * restserver.max_worker_threads.",
                     nonNegativeInt(),
                     0);
+
     public static final ConfigOption<String> RAFT_GROUP_PEERS =
             new ConfigOption<>(
                     "raft.group_peers",
@@ -152,13 +182,15 @@ public class ServerOptions extends OptionHolder {
                     disallowEmpty(),
                     "127.0.0.1:8090"
             );
+
     public static final ConfigOption<Boolean> ALLOW_TRACE =
             new ConfigOption<>(
                     "exception.allow_trace",
                     "Whether to allow exception trace stack.",
                     disallowEmpty(),
-                    true
+                    false
             );
+
     public static final ConfigOption<String> AUTHENTICATOR =
             new ConfigOption<>(
                     "auth.authenticator",
@@ -168,6 +200,7 @@ public class ServerOptions extends OptionHolder {
                     null,
                     ""
             );
+
     public static final ConfigOption<String> AUTH_GRAPH_STORE =
             new ConfigOption<>(
                     "auth.graph_store",
@@ -176,6 +209,7 @@ public class ServerOptions extends OptionHolder {
                     disallowEmpty(),
                     "hugegraph"
             );
+
     public static final ConfigOption<String> AUTH_ADMIN_TOKEN =
             new ConfigOption<>(
                     "auth.admin_token",
@@ -184,6 +218,7 @@ public class ServerOptions extends OptionHolder {
                     disallowEmpty(),
                     "162f7848-0b6d-4faf-b557-3a0797869c55"
             );
+
     public static final ConfigListOption<String> AUTH_USER_TOKENS =
             new ConfigListOption<>(
                     "auth.user_tokens",
@@ -192,6 +227,7 @@ public class ServerOptions extends OptionHolder {
                     disallowEmpty(),
                     "hugegraph:9fd95c9c-711b-415b-b85f-d4df46ba5c31"
             );
+
     public static final ConfigOption<String> AUTH_REMOTE_URL =
             new ConfigOption<>(
                     "auth.remote_url",
@@ -202,6 +238,7 @@ public class ServerOptions extends OptionHolder {
                     null,
                     ""
             );
+
     public static final ConfigOption<String> SSL_KEYSTORE_FILE =
             new ConfigOption<>(
                     "ssl.keystore_file",
@@ -210,6 +247,7 @@ public class ServerOptions extends OptionHolder {
                     disallowEmpty(),
                     "conf/hugegraph-server.keystore"
             );
+
     public static final ConfigOption<String> SSL_KEYSTORE_PASSWORD =
             new ConfigOption<>(
                     "ssl.keystore_password",
@@ -218,6 +256,7 @@ public class ServerOptions extends OptionHolder {
                     null,
                     "hugegraph"
             );
+
     public static final ConfigOption<Boolean> ENABLE_DYNAMIC_CREATE_DROP =
             new ConfigOption<>(
                     "graphs.enable_dynamic_create_drop",
@@ -225,17 +264,4 @@ public class ServerOptions extends OptionHolder {
                     disallowEmpty(),
                     true
             );
-    private static volatile ServerOptions instance;
-
-    private ServerOptions() {
-        super();
-    }
-
-    public static synchronized ServerOptions instance() {
-        if (instance == null) {
-            instance = new ServerOptions();
-            instance.registerOptions();
-        }
-        return instance;
-    }
 }

--- a/hugegraph-api/src/main/java/org/apache/hugegraph/core/GraphManager.java
+++ b/hugegraph-api/src/main/java/org/apache/hugegraph/core/GraphManager.java
@@ -224,6 +224,10 @@ public final class GraphManager {
         return JsonSerializer.instance();
     }
 
+    public Serializer serializer(Graph g, Map<String, Object> apiMeasure) {
+        return JsonSerializer.instance(apiMeasure);
+    }
+
     public void rollbackAll() {
         for (Graph graph : this.graphs.values()) {
             if (graph.features().graph().supportsTransactions() &&

--- a/hugegraph-api/src/main/java/org/apache/hugegraph/serializer/Serializer.java
+++ b/hugegraph-api/src/main/java/org/apache/hugegraph/serializer/Serializer.java
@@ -22,9 +22,6 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 
-import org.apache.tinkerpop.gremlin.structure.Edge;
-import org.apache.tinkerpop.gremlin.structure.Vertex;
-
 import org.apache.hugegraph.auth.SchemaDefine.AuthElement;
 import org.apache.hugegraph.backend.id.Id;
 import org.apache.hugegraph.schema.EdgeLabel;
@@ -37,6 +34,8 @@ import org.apache.hugegraph.traversal.algorithm.FusiformSimilarityTraverser.Simi
 import org.apache.hugegraph.traversal.algorithm.HugeTraverser;
 import org.apache.hugegraph.traversal.algorithm.SingleSourceShortestPathTraverser.NodeWithWeight;
 import org.apache.hugegraph.traversal.algorithm.SingleSourceShortestPathTraverser.WeightedPaths;
+import org.apache.tinkerpop.gremlin.structure.Edge;
+import org.apache.tinkerpop.gremlin.structure.Vertex;
 
 public interface Serializer {
 
@@ -77,23 +76,26 @@ public interface Serializer {
     <V extends AuthElement> String writeAuthElements(String label, List<V> users);
 
     String writePaths(String name, Collection<HugeTraverser.Path> paths,
-                      boolean withCrossPoint, Iterator<Vertex> vertices);
+                      boolean withCrossPoint, Iterator<?> vertices,
+                      Iterator<?> edges);
 
     default String writePaths(String name, Collection<HugeTraverser.Path> paths,
                               boolean withCrossPoint) {
-        return this.writePaths(name, paths, withCrossPoint, null);
+        return this.writePaths(name, paths, withCrossPoint, null, null);
     }
 
-    String writeCrosspoints(CrosspointsPaths paths, Iterator<Vertex> iterator,
-                            boolean withPath);
+    String writeCrosspoints(CrosspointsPaths paths, Iterator<?> vertices,
+                            Iterator<?> edges, boolean withPath);
 
-    String writeSimilars(SimilarsMap similars, Iterator<Vertex> vertices);
+    String writeSimilars(SimilarsMap similars, Iterator<?> vertices);
 
-    String writeWeightedPath(NodeWithWeight path, Iterator<Vertex> vertices);
+    String writeWeightedPath(NodeWithWeight path, Iterator<?> vertices,
+                             Iterator<?> edges);
 
-    String writeWeightedPaths(WeightedPaths paths, Iterator<Vertex> vertices);
+    String writeWeightedPaths(WeightedPaths paths, Iterator<?> vertices,
+                              Iterator<?> edges);
 
     String writeNodesWithPath(String name, List<Id> nodes, long size,
                               Collection<HugeTraverser.Path> paths,
-                              Iterator<Vertex> vertices);
+                              Iterator<?> vertices, Iterator<?> edges);
 }

--- a/hugegraph-core/src/main/java/org/apache/hugegraph/traversal/algorithm/CollectionPathsTraverser.java
+++ b/hugegraph-core/src/main/java/org/apache/hugegraph/traversal/algorithm/CollectionPathsTraverser.java
@@ -18,7 +18,6 @@
 package org.apache.hugegraph.traversal.algorithm;
 
 import java.util.Collection;
-import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -282,23 +281,20 @@ public class CollectionPathsTraverser extends HugeTraverser {
     }
 
     public static class WrappedPathCollection {
-        private final Collection<Path> paths;
-        private Set<Edge> edges = Collections.emptySet();
 
-        public WrappedPathCollection(Collection<Path> paths) {
-            this.paths = paths;
-        }
+        private final Collection<Path> paths;
+        private final Set<Edge> edges;
 
         public WrappedPathCollection(Collection<Path> paths, Set<Edge> edges) {
             this.paths = paths;
             this.edges = edges;
         }
 
-        public Collection<Path> getPaths() {
+        public Collection<Path> paths() {
             return paths;
         }
 
-        public Set<Edge> getEdges() {
+        public Set<Edge> edges() {
             return edges;
         }
     }

--- a/hugegraph-core/src/main/java/org/apache/hugegraph/traversal/algorithm/CollectionPathsTraverser.java
+++ b/hugegraph-core/src/main/java/org/apache/hugegraph/traversal/algorithm/CollectionPathsTraverser.java
@@ -18,18 +18,21 @@
 package org.apache.hugegraph.traversal.algorithm;
 
 import java.util.Collection;
+import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import org.apache.hugegraph.HugeGraph;
 import org.apache.hugegraph.backend.id.Id;
+import org.apache.hugegraph.structure.HugeVertex;
 import org.apache.hugegraph.traversal.algorithm.steps.EdgeStep;
 import org.apache.hugegraph.traversal.algorithm.strategy.TraverseStrategy;
+import org.apache.hugegraph.util.E;
+import org.apache.tinkerpop.gremlin.structure.Edge;
 import org.apache.tinkerpop.gremlin.structure.Vertex;
 
-import org.apache.hugegraph.structure.HugeVertex;
-import org.apache.hugegraph.util.E;
 import com.google.common.collect.ImmutableList;
 
 public class CollectionPathsTraverser extends HugeTraverser {
@@ -38,10 +41,10 @@ public class CollectionPathsTraverser extends HugeTraverser {
         super(graph);
     }
 
-    public Collection<Path> paths(Iterator<Vertex> sources,
-                                  Iterator<Vertex> targets,
-                                  EdgeStep step, int depth, boolean nearest,
-                                  long capacity, long limit) {
+    public WrappedPathCollection paths(Iterator<Vertex> sources,
+                                       Iterator<Vertex> targets,
+                                       EdgeStep step, int depth, boolean nearest,
+                                       long capacity, long limit) {
         checkCapacity(capacity);
         checkLimit(limit);
 
@@ -63,31 +66,33 @@ public class CollectionPathsTraverser extends HugeTraverser {
                      "but got: %s", MAX_VERTICES, sourceList.size());
         checkPositive(depth, "max depth");
 
+        boolean concurrent = depth >= this.concurrentDepth();
         TraverseStrategy strategy = TraverseStrategy.create(
-                                    depth >= this.concurrentDepth(),
-                                    this.graph());
+                concurrent, this.graph());
         Traverser traverser;
         if (nearest) {
             traverser = new NearestTraverser(this, strategy,
                                              sourceList, targetList, step,
-                                             depth, capacity, limit);
+                                             depth, capacity, limit, concurrent);
         } else {
             traverser = new Traverser(this, strategy,
                                       sourceList, targetList, step,
-                                      depth, capacity, limit);
+                                      depth, capacity, limit, concurrent);
         }
 
         do {
             // Forward
             traverser.forward();
             if (traverser.finished()) {
-                return traverser.paths();
+                Collection<Path> paths = traverser.paths();
+                return new WrappedPathCollection(paths, traverser.edgeRecord.getEdges(paths));
             }
 
             // Backward
             traverser.backward();
             if (traverser.finished()) {
-                return traverser.paths();
+                Collection<Path> paths = traverser.paths();
+                return new WrappedPathCollection(paths, traverser.edgeRecord.getEdges(paths));
             }
         } while (true);
     }
@@ -98,8 +103,9 @@ public class CollectionPathsTraverser extends HugeTraverser {
 
         public Traverser(HugeTraverser traverser, TraverseStrategy strategy,
                          Collection<Id> sources, Collection<Id> targets,
-                         EdgeStep step, int depth, long capacity, long limit) {
-            super(traverser, strategy, sources, targets, capacity, limit);
+                         EdgeStep step, int depth, long capacity, long limit,
+                         boolean concurrent) {
+            super(traverser, strategy, sources, targets, capacity, limit, concurrent);
             this.step = step;
             this.totalSteps = depth;
         }
@@ -180,15 +186,15 @@ public class CollectionPathsTraverser extends HugeTraverser {
         }
     }
 
-    private class NearestTraverser extends Traverser {
+    private static class NearestTraverser extends Traverser {
 
         public NearestTraverser(HugeTraverser traverser,
                                 TraverseStrategy strategy,
                                 Collection<Id> sources, Collection<Id> targets,
                                 EdgeStep step, int depth, long capacity,
-                                long limit) {
+                                long limit, boolean concurrent) {
             super(traverser, strategy, sources, targets, step,
-                  depth, capacity, limit);
+                  depth, capacity, limit, concurrent);
         }
 
         @Override
@@ -272,6 +278,28 @@ public class CollectionPathsTraverser extends HugeTraverser {
         @Override
         protected int accessedNodes() {
             return this.sourcesAll.size() + this.targetsAll.size();
+        }
+    }
+
+    public static class WrappedPathCollection {
+        private final Collection<Path> paths;
+        private Set<Edge> edges = Collections.emptySet();
+
+        public WrappedPathCollection(Collection<Path> paths) {
+            this.paths = paths;
+        }
+
+        public WrappedPathCollection(Collection<Path> paths, Set<Edge> edges) {
+            this.paths = paths;
+            this.edges = edges;
+        }
+
+        public Collection<Path> getPaths() {
+            return paths;
+        }
+
+        public Set<Edge> getEdges() {
+            return edges;
         }
     }
 }

--- a/hugegraph-core/src/main/java/org/apache/hugegraph/traversal/algorithm/CollectionPathsTraverser.java
+++ b/hugegraph-core/src/main/java/org/apache/hugegraph/traversal/algorithm/CollectionPathsTraverser.java
@@ -84,14 +84,14 @@ public class CollectionPathsTraverser extends HugeTraverser {
             traverser.forward();
             if (traverser.finished()) {
                 Collection<Path> paths = traverser.paths();
-                return new WrappedPathCollection(paths, traverser.edgeRecord.getEdges(paths));
+                return new WrappedPathCollection(paths, traverser.edgeResults.getEdges(paths));
             }
 
             // Backward
             traverser.backward();
             if (traverser.finished()) {
                 Collection<Path> paths = traverser.paths();
-                return new WrappedPathCollection(paths, traverser.edgeRecord.getEdges(paths));
+                return new WrappedPathCollection(paths, traverser.edgeResults.getEdges(paths));
             }
         } while (true);
     }

--- a/hugegraph-core/src/main/java/org/apache/hugegraph/traversal/algorithm/CustomizePathsTraverser.java
+++ b/hugegraph-core/src/main/java/org/apache/hugegraph/traversal/algorithm/CustomizePathsTraverser.java
@@ -38,11 +38,12 @@ import com.google.common.collect.ImmutableMap;
 import jakarta.ws.rs.core.MultivaluedMap;
 
 public class CustomizePathsTraverser extends HugeTraverser {
-    private final EdgeRecord edgeRecord;
+
+    private final EdgeRecord edgeResults;
 
     public CustomizePathsTraverser(HugeGraph graph) {
         super(graph);
-        this.edgeRecord = new EdgeRecord(false);
+        this.edgeResults = new EdgeRecord(false);
     }
 
     public static List<Path> topNPath(List<Path> paths,
@@ -108,7 +109,7 @@ public class CustomizePathsTraverser extends HugeTraverser {
                     this.edgeIterCounter.addAndGet(1L);
                     Id target = edge.id().otherVertexId();
 
-                    this.edgeRecord.addEdge(entry.getKey(), target, edge);
+                    this.edgeResults.addEdge(entry.getKey(), target, edge);
 
                     for (Node n : entry.getValue()) {
                         // If have loop, skip target
@@ -171,8 +172,8 @@ public class CustomizePathsTraverser extends HugeTraverser {
         return paths;
     }
 
-    public EdgeRecord getEdgeRecord() {
-        return edgeRecord;
+    public EdgeRecord edgeResults() {
+        return edgeResults;
     }
 
     public static class WeightNode extends Node {

--- a/hugegraph-core/src/main/java/org/apache/hugegraph/traversal/algorithm/CustomizedCrosspointsTraverser.java
+++ b/hugegraph-core/src/main/java/org/apache/hugegraph/traversal/algorithm/CustomizedCrosspointsTraverser.java
@@ -24,93 +24,29 @@ import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-import jakarta.ws.rs.core.MultivaluedMap;
-
 import org.apache.hugegraph.HugeGraph;
 import org.apache.hugegraph.backend.id.Id;
+import org.apache.hugegraph.structure.HugeEdge;
+import org.apache.hugegraph.structure.HugeVertex;
 import org.apache.hugegraph.traversal.algorithm.steps.EdgeStep;
 import org.apache.hugegraph.type.define.Directions;
+import org.apache.hugegraph.util.CollectionUtil;
+import org.apache.hugegraph.util.E;
 import org.apache.tinkerpop.gremlin.structure.Edge;
 import org.apache.tinkerpop.gremlin.structure.Vertex;
 
-import org.apache.hugegraph.structure.HugeEdge;
-import org.apache.hugegraph.structure.HugeVertex;
-import org.apache.hugegraph.util.CollectionUtil;
-import org.apache.hugegraph.util.E;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 
+import jakarta.ws.rs.core.MultivaluedMap;
+
 public class CustomizedCrosspointsTraverser extends HugeTraverser {
+
+    private final EdgeRecord edgeRecord;
 
     public CustomizedCrosspointsTraverser(HugeGraph graph) {
         super(graph);
-    }
-
-    public CrosspointsPaths crosspointsPaths(Iterator<Vertex> vertices,
-                                             List<PathPattern> pathPatterns,
-                                             long capacity, long limit) {
-        E.checkArgument(vertices.hasNext(),
-                        "The source vertices can't be empty");
-        E.checkArgument(!pathPatterns.isEmpty(),
-                        "The steps pattern can't be empty");
-        checkCapacity(capacity);
-        checkLimit(limit);
-        MultivaluedMap<Id, Node> initialSources = newMultivalueMap();
-        List<HugeVertex> verticesList = newList();
-        while (vertices.hasNext()) {
-            HugeVertex vertex = (HugeVertex) vertices.next();
-            verticesList.add(vertex);
-            Node node = new Node(vertex.id(), null);
-            initialSources.add(vertex.id(), node);
-        }
-        List<Path> paths = newList();
-
-        for (PathPattern pathPattern : pathPatterns) {
-            MultivaluedMap<Id, Node> sources = initialSources;
-            int stepNum = pathPattern.size();
-            long access = 0;
-            MultivaluedMap<Id, Node> newVertices = null;
-            for (Step step : pathPattern.steps()) {
-                stepNum--;
-                newVertices = newMultivalueMap();
-                Iterator<Edge> edges;
-
-                // Traversal vertices of previous level
-                for (Map.Entry<Id, List<Node>> entry : sources.entrySet()) {
-                    List<Node> adjacency = newList();
-                    edges = this.edgesOfVertex(entry.getKey(), step.edgeStep);
-                    while (edges.hasNext()) {
-                        HugeEdge edge = (HugeEdge) edges.next();
-                        Id target = edge.id().otherVertexId();
-                        for (Node n : entry.getValue()) {
-                            // If have loop, skip target
-                            if (n.contains(target)) {
-                                continue;
-                            }
-                            Node newNode = new Node(target, n);
-                            adjacency.add(newNode);
-
-                            checkCapacity(capacity, ++access,
-                                          "customized crosspoints");
-                        }
-                    }
-
-                    // Add current node's adjacent nodes
-                    for (Node node : adjacency) {
-                        newVertices.add(node.id(), node);
-                    }
-                }
-                // Re-init sources
-                sources = newVertices;
-            }
-            assert stepNum == 0;
-            for (List<Node> nodes : newVertices.values()) {
-                for (Node n : nodes) {
-                    paths.add(new Path(n.path()));
-                }
-            }
-        }
-        return intersectionPaths(verticesList, paths, limit);
+        this.edgeRecord = new EdgeRecord(false);
     }
 
     private static CrosspointsPaths intersectionPaths(List<HugeVertex> sources,
@@ -162,9 +98,90 @@ public class CustomizedCrosspointsTraverser extends HugeTraverser {
         return new CrosspointsPaths(newSet(intersection), results);
     }
 
+    public EdgeRecord getEdgeRecord() {
+        return edgeRecord;
+    }
+
+    public CrosspointsPaths crosspointsPaths(Iterator<Vertex> vertices,
+                                             List<PathPattern> pathPatterns,
+                                             long capacity, long limit) {
+        E.checkArgument(vertices.hasNext(),
+                        "The source vertices can't be empty");
+        E.checkArgument(!pathPatterns.isEmpty(),
+                        "The steps pattern can't be empty");
+        checkCapacity(capacity);
+        checkLimit(limit);
+        MultivaluedMap<Id, Node> initialSources = newMultivalueMap();
+        List<HugeVertex> verticesList = newList();
+        while (vertices.hasNext()) {
+            HugeVertex vertex = (HugeVertex) vertices.next();
+            verticesList.add(vertex);
+            Node node = new Node(vertex.id(), null);
+            initialSources.add(vertex.id(), node);
+        }
+        List<Path> paths = newList();
+        long edgeCount = 0L;
+        long vertexCount = 0L;
+
+        for (PathPattern pathPattern : pathPatterns) {
+            MultivaluedMap<Id, Node> sources = initialSources;
+            int stepNum = pathPattern.size();
+            long access = 0;
+            MultivaluedMap<Id, Node> newVertices = null;
+            for (Step step : pathPattern.steps()) {
+                stepNum--;
+                newVertices = newMultivalueMap();
+                Iterator<Edge> edges;
+
+                // Traversal vertices of previous level
+                for (Map.Entry<Id, List<Node>> entry : sources.entrySet()) {
+                    List<Node> adjacency = newList();
+                    edges = this.edgesOfVertex(entry.getKey(), step.edgeStep);
+                    vertexCount += 1;
+                    while (edges.hasNext()) {
+                        HugeEdge edge = (HugeEdge) edges.next();
+                        edgeCount += 1;
+                        Id target = edge.id().otherVertexId();
+
+                        this.edgeRecord.addEdge(entry.getKey(), target, edge);
+
+                        for (Node n : entry.getValue()) {
+                            // If have loop, skip target
+                            if (n.contains(target)) {
+                                continue;
+                            }
+                            Node newNode = new Node(target, n);
+                            adjacency.add(newNode);
+
+                            checkCapacity(capacity, ++access,
+                                          "customized crosspoints");
+                        }
+                    }
+
+                    // Add current node's adjacent nodes
+                    for (Node node : adjacency) {
+                        newVertices.add(node.id(), node);
+                    }
+                }
+                // Re-init sources
+                sources = newVertices;
+            }
+            assert stepNum == 0;
+            assert newVertices != null;
+            for (List<Node> nodes : newVertices.values()) {
+                for (Node n : nodes) {
+                    paths.add(new Path(n.path()));
+                }
+            }
+        }
+        this.vertexIterCounter.addAndGet(vertexCount);
+        this.edgeIterCounter.addAndGet(edgeCount);
+        return intersectionPaths(verticesList, paths, limit);
+    }
+
     public static class PathPattern {
 
-        private List<Step> steps;
+        private final List<Step> steps;
 
         public PathPattern() {
             this.steps = newList();
@@ -201,8 +218,8 @@ public class CustomizedCrosspointsTraverser extends HugeTraverser {
                 ImmutableSet.of(), ImmutableList.of()
         );
 
-        private Set<Id> crosspoints;
-        private List<Path> paths;
+        private final Set<Id> crosspoints;
+        private final List<Path> paths;
 
         public CrosspointsPaths(Set<Id> crosspoints, List<Path> paths) {
             this.crosspoints = crosspoints;

--- a/hugegraph-core/src/main/java/org/apache/hugegraph/traversal/algorithm/CustomizedCrosspointsTraverser.java
+++ b/hugegraph-core/src/main/java/org/apache/hugegraph/traversal/algorithm/CustomizedCrosspointsTraverser.java
@@ -42,11 +42,11 @@ import jakarta.ws.rs.core.MultivaluedMap;
 
 public class CustomizedCrosspointsTraverser extends HugeTraverser {
 
-    private final EdgeRecord edgeRecord;
+    private final EdgeRecord edgeResults;
 
     public CustomizedCrosspointsTraverser(HugeGraph graph) {
         super(graph);
-        this.edgeRecord = new EdgeRecord(false);
+        this.edgeResults = new EdgeRecord(false);
     }
 
     private static CrosspointsPaths intersectionPaths(List<HugeVertex> sources,
@@ -98,8 +98,8 @@ public class CustomizedCrosspointsTraverser extends HugeTraverser {
         return new CrosspointsPaths(newSet(intersection), results);
     }
 
-    public EdgeRecord getEdgeRecord() {
-        return edgeRecord;
+    public EdgeRecord edgeResults() {
+        return edgeResults;
     }
 
     public CrosspointsPaths crosspointsPaths(Iterator<Vertex> vertices,
@@ -143,7 +143,7 @@ public class CustomizedCrosspointsTraverser extends HugeTraverser {
                         edgeCount += 1;
                         Id target = edge.id().otherVertexId();
 
-                        this.edgeRecord.addEdge(entry.getKey(), target, edge);
+                        this.edgeResults.addEdge(entry.getKey(), target, edge);
 
                         for (Node n : entry.getValue()) {
                             // If have loop, skip target

--- a/hugegraph-core/src/main/java/org/apache/hugegraph/traversal/algorithm/HugeTraverser.java
+++ b/hugegraph-core/src/main/java/org/apache/hugegraph/traversal/algorithm/HugeTraverser.java
@@ -19,15 +19,16 @@ package org.apache.hugegraph.traversal.algorithm;
 
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
-
-import jakarta.ws.rs.core.MultivaluedHashMap;
-import jakarta.ws.rs.core.MultivaluedMap;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.stream.Collectors;
 
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.hugegraph.HugeException;
@@ -39,39 +40,38 @@ import org.apache.hugegraph.backend.query.Query;
 import org.apache.hugegraph.backend.query.QueryResults;
 import org.apache.hugegraph.backend.tx.GraphTransaction;
 import org.apache.hugegraph.config.CoreOptions;
-import org.apache.hugegraph.schema.SchemaLabel;
-import org.apache.hugegraph.traversal.algorithm.steps.EdgeStep;
-import org.apache.hugegraph.type.HugeType;
-import org.apache.hugegraph.type.define.CollectionType;
-import org.apache.hugegraph.type.define.Directions;
-import org.apache.hugegraph.type.define.HugeKeys;
-import org.apache.hugegraph.util.collection.CollectionFactory;
-import org.apache.tinkerpop.gremlin.structure.Edge;
-import org.slf4j.Logger;
-
 import org.apache.hugegraph.exception.NotFoundException;
 import org.apache.hugegraph.iterator.ExtendableIterator;
 import org.apache.hugegraph.iterator.FilterIterator;
 import org.apache.hugegraph.iterator.LimitIterator;
 import org.apache.hugegraph.iterator.MapperIterator;
 import org.apache.hugegraph.perf.PerfUtil.Watched;
+import org.apache.hugegraph.schema.SchemaLabel;
 import org.apache.hugegraph.structure.HugeEdge;
+import org.apache.hugegraph.traversal.algorithm.steps.EdgeStep;
 import org.apache.hugegraph.traversal.optimize.TraversalUtil;
+import org.apache.hugegraph.type.HugeType;
+import org.apache.hugegraph.type.define.CollectionType;
+import org.apache.hugegraph.type.define.Directions;
+import org.apache.hugegraph.type.define.HugeKeys;
 import org.apache.hugegraph.util.CollectionUtil;
 import org.apache.hugegraph.util.E;
 import org.apache.hugegraph.util.InsertionOrderUtil;
 import org.apache.hugegraph.util.Log;
+import org.apache.hugegraph.util.collection.CollectionFactory;
+import org.apache.hugegraph.util.collection.ObjectIntMapping;
+import org.apache.hugegraph.util.collection.ObjectIntMappingFactory;
+import org.apache.tinkerpop.gremlin.structure.Edge;
+import org.slf4j.Logger;
+
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 
+import jakarta.ws.rs.core.MultivaluedHashMap;
+import jakarta.ws.rs.core.MultivaluedMap;
+
 public class HugeTraverser {
-
-    protected static final Logger LOG = Log.logger(HugeTraverser.class);
-
-    private HugeGraph graph;
-
-    private static CollectionFactory collectionFactory;
 
     public static final String DEFAULT_CAPACITY = "10000000";
     public static final String DEFAULT_ELEMENTS_LIMIT = "10000000";
@@ -82,233 +82,21 @@ public class HugeTraverser {
     public static final String DEFAULT_SAMPLE = "100";
     public static final String DEFAULT_WEIGHT = "0";
     public static final int DEFAULT_MAX_DEPTH = 5000;
-
-    protected static final int MAX_VERTICES = 10;
-
     // Empirical value of scan limit, with which results can be returned in 3s
     public static final String DEFAULT_PAGE_LIMIT = "100000";
-
     public static final long NO_LIMIT = -1L;
+    protected static final Logger LOG = Log.logger(HugeTraverser.class);
+    protected static final int MAX_VERTICES = 10;
+    private static CollectionFactory collectionFactory;
+    private final HugeGraph graph;
+    // for apimeasure
+    public AtomicLong edgeIterCounter = new AtomicLong(0);
+    public AtomicLong vertexIterCounter = new AtomicLong(0);
 
     public HugeTraverser(HugeGraph graph) {
         this.graph = graph;
         if (collectionFactory == null) {
             collectionFactory = new CollectionFactory(this.collectionType());
-        }
-    }
-
-    public HugeGraph graph() {
-        return this.graph;
-    }
-
-    protected int concurrentDepth() {
-        return this.graph.option(CoreOptions.OLTP_CONCURRENT_DEPTH);
-    }
-
-    private CollectionType collectionType() {
-        return this.graph.option(CoreOptions.OLTP_COLLECTION_TYPE);
-    }
-
-    protected Set<Id> adjacentVertices(Id sourceV, Set<Id> vertices,
-                                       Directions dir, Id label,
-                                       Set<Id> excluded, long degree,
-                                       long limit) {
-        if (limit == 0) {
-            return ImmutableSet.of();
-        }
-
-        Set<Id> neighbors = newIdSet();
-        for (Id source : vertices) {
-            Iterator<Edge> edges = this.edgesOfVertex(source, dir,
-                                                      label, degree);
-            while (edges.hasNext()) {
-                HugeEdge e = (HugeEdge) edges.next();
-                Id target = e.id().otherVertexId();
-                boolean matchExcluded = (excluded != null &&
-                                         excluded.contains(target));
-                if (matchExcluded || neighbors.contains(target) ||
-                    sourceV.equals(target)) {
-                    continue;
-                }
-                neighbors.add(target);
-                if (limit != NO_LIMIT && neighbors.size() >= limit) {
-                    return neighbors;
-                }
-            }
-        }
-        return neighbors;
-    }
-
-    protected Iterator<Id> adjacentVertices(Id source, Directions dir,
-                                            Id label, long limit) {
-        Iterator<Edge> edges = this.edgesOfVertex(source, dir, label, limit);
-        return new MapperIterator<>(edges, e -> {
-            HugeEdge edge = (HugeEdge) e;
-            return edge.id().otherVertexId();
-        });
-    }
-
-    protected Set<Id> adjacentVertices(Id source, EdgeStep step) {
-        Set<Id> neighbors = newSet();
-        Iterator<Edge> edges = this.edgesOfVertex(source, step);
-        while (edges.hasNext()) {
-            neighbors.add(((HugeEdge) edges.next()).id().otherVertexId());
-        }
-        return neighbors;
-    }
-
-    @Watched
-    protected Iterator<Edge> edgesOfVertex(Id source, Directions dir,
-                                           Id label, long limit) {
-        Id[] labels = {};
-        if (label != null) {
-            labels = new Id[]{label};
-        }
-
-        Query query = GraphTransaction.constructEdgesQuery(source, dir, labels);
-        if (limit != NO_LIMIT) {
-            query.limit(limit);
-        }
-        return this.graph.edges(query);
-    }
-
-    @Watched
-    protected Iterator<Edge> edgesOfVertex(Id source, Directions dir,
-                                           Map<Id, String> labels, long limit) {
-        if (labels == null || labels.isEmpty()) {
-            return this.edgesOfVertex(source, dir, (Id) null, limit);
-        }
-        ExtendableIterator<Edge> results = new ExtendableIterator<>();
-        for (Id label : labels.keySet()) {
-            E.checkNotNull(label, "edge label");
-            results.extend(this.edgesOfVertex(source, dir, label, limit));
-        }
-
-        if (limit == NO_LIMIT) {
-            return results;
-        }
-
-        long[] count = new long[1];
-        return new LimitIterator<>(results, e -> {
-            return count[0]++ >= limit;
-        });
-    }
-
-    protected Iterator<Edge> edgesOfVertex(Id source, EdgeStep edgeStep) {
-        if (edgeStep.properties() == null || edgeStep.properties().isEmpty()) {
-            Iterator<Edge> edges = this.edgesOfVertex(source,
-                                                      edgeStep.direction(),
-                                                      edgeStep.labels(),
-                                                      edgeStep.limit());
-            return edgeStep.skipSuperNodeIfNeeded(edges);
-        }
-        return this.edgesOfVertex(source, edgeStep, false);
-    }
-
-    protected Iterator<Edge> edgesOfVertexWithSK(Id source, EdgeStep edgeStep) {
-        assert edgeStep.properties() != null && !edgeStep.properties().isEmpty();
-        return this.edgesOfVertex(source, edgeStep, true);
-    }
-
-    private Iterator<Edge> edgesOfVertex(Id source, EdgeStep edgeStep,
-                                         boolean mustAllSK) {
-        Id[] edgeLabels = edgeStep.edgeLabels();
-        Query query = GraphTransaction.constructEdgesQuery(source,
-                                                           edgeStep.direction(),
-                                                           edgeLabels);
-        ConditionQuery filter = null;
-        if (mustAllSK) {
-            this.fillFilterBySortKeys(query, edgeLabels, edgeStep.properties());
-        } else {
-            filter = (ConditionQuery) query.copy();
-            this.fillFilterByProperties(filter, edgeStep.properties());
-        }
-        query.capacity(Query.NO_CAPACITY);
-        if (edgeStep.limit() != NO_LIMIT) {
-            query.limit(edgeStep.limit());
-        }
-        Iterator<Edge> edges = this.graph().edges(query);
-        if (filter != null) {
-            ConditionQuery finalFilter = filter;
-            edges = new FilterIterator<>(edges, (e) -> {
-                return finalFilter.test((HugeEdge) e);
-            });
-        }
-        return edgeStep.skipSuperNodeIfNeeded(edges);
-    }
-
-    private void fillFilterBySortKeys(Query query, Id[] edgeLabels,
-                                      Map<Id, Object> properties) {
-        if (properties == null || properties.isEmpty()) {
-            return;
-        }
-
-        E.checkArgument(edgeLabels.length == 1,
-                        "The properties filter condition can be set " +
-                        "only if just set one edge label");
-
-        this.fillFilterByProperties(query, properties);
-
-        ConditionQuery condQuery = (ConditionQuery) query;
-        if (!GraphTransaction.matchFullEdgeSortKeys(condQuery, this.graph())) {
-            Id label = condQuery.condition(HugeKeys.LABEL);
-            E.checkArgument(false, "The properties %s does not match " +
-                            "sort keys of edge label '%s'",
-                            this.graph().mapPkId2Name(properties.keySet()),
-                            this.graph().edgeLabel(label).name());
-        }
-    }
-
-    private void fillFilterByProperties(Query query,
-                                        Map<Id, Object> properties) {
-        if (properties == null || properties.isEmpty()) {
-            return;
-        }
-
-        ConditionQuery condQuery = (ConditionQuery) query;
-        TraversalUtil.fillConditionQuery(condQuery, properties, this.graph);
-    }
-
-    protected long edgesCount(Id source, EdgeStep edgeStep) {
-        Id[] edgeLabels = edgeStep.edgeLabels();
-        Query query = GraphTransaction.constructEdgesQuery(source,
-                                                           edgeStep.direction(),
-                                                           edgeLabels);
-        this.fillFilterBySortKeys(query, edgeLabels, edgeStep.properties());
-        query.aggregate(Aggregate.AggregateFunc.COUNT, null);
-        query.capacity(Query.NO_CAPACITY);
-        query.limit(Query.NO_LIMIT);
-        long count = graph().queryNumber(query).longValue();
-        if (edgeStep.degree() == NO_LIMIT || count < edgeStep.degree()) {
-            return count;
-        } else if (edgeStep.skipDegree() != 0L &&
-                   count >= edgeStep.skipDegree()) {
-            return 0L;
-        } else {
-            return edgeStep.degree();
-        }
-    }
-
-    protected Object getVertexLabelId(Object label) {
-        if (label == null) {
-            return null;
-        }
-        return SchemaLabel.getLabelId(this.graph, HugeType.VERTEX, label);
-    }
-
-    protected Id getEdgeLabelId(Object label) {
-        if (label == null) {
-            return null;
-        }
-        return SchemaLabel.getLabelId(this.graph, HugeType.EDGE, label);
-    }
-
-    protected void checkVertexExist(Id vertexId, String name) {
-        try {
-            this.graph.vertex(vertexId);
-        } catch (NotFoundException e) {
-            throw new IllegalArgumentException(String.format(
-                      "The %s with id '%s' does not exist", name, vertexId), e);
         }
     }
 
@@ -377,9 +165,9 @@ public class HugeTraverser {
     }
 
     public static <K, V extends Comparable<? super V>> Map<K, V> topN(
-                                                                 Map<K, V> map,
-                                                                 boolean sorted,
-                                                                 long limit) {
+            Map<K, V> map,
+            boolean sorted,
+            long limit) {
         if (sorted) {
             map = CollectionUtil.sortByValue(map, false);
         }
@@ -484,6 +272,247 @@ public class HugeTraverser {
         return path;
     }
 
+    public HugeGraph graph() {
+        return this.graph;
+    }
+
+    protected int concurrentDepth() {
+        return this.graph.option(CoreOptions.OLTP_CONCURRENT_DEPTH);
+    }
+
+    private CollectionType collectionType() {
+        return this.graph.option(CoreOptions.OLTP_COLLECTION_TYPE);
+    }
+
+    protected Set<Id> adjacentVertices(Id sourceV, Set<Id> vertices,
+                                       Directions dir, Id label,
+                                       Set<Id> excluded, long degree,
+                                       long limit) {
+        if (limit == 0) {
+            return ImmutableSet.of();
+        }
+
+        Set<Id> neighbors = newIdSet();
+        for (Id source : vertices) {
+            Iterator<Edge> edges = this.edgesOfVertex(source, dir,
+                                                      label, degree);
+            while (edges.hasNext()) {
+                HugeEdge e = (HugeEdge) edges.next();
+                Id target = e.id().otherVertexId();
+                boolean matchExcluded = (excluded != null &&
+                                         excluded.contains(target));
+                if (matchExcluded || neighbors.contains(target) ||
+                    sourceV.equals(target)) {
+                    continue;
+                }
+                neighbors.add(target);
+                if (limit != NO_LIMIT && neighbors.size() >= limit) {
+                    return neighbors;
+                }
+            }
+        }
+        return neighbors;
+    }
+
+    protected Iterator<Id> adjacentVertices(Id source, Directions dir,
+                                            Id label, long limit) {
+        Iterator<Edge> edges = this.edgesOfVertex(source, dir, label, limit);
+        return new MapperIterator<>(edges, e -> {
+            HugeEdge edge = (HugeEdge) e;
+            return edge.id().otherVertexId();
+        });
+    }
+
+    protected Set<Id> adjacentVertices(Id source, EdgeStep step) {
+        Set<Id> neighbors = newSet();
+        Iterator<Edge> edges = this.edgesOfVertex(source, step);
+        while (edges.hasNext()) {
+            neighbors.add(((HugeEdge) edges.next()).id().otherVertexId());
+        }
+        return neighbors;
+    }
+
+    protected Iterator<Id> adjacentVertices(Id source, Directions dir,
+                                            List<Id> labels, long limit) {
+        Iterator<Edge> edges = this.edgesOfVertex(source, dir, labels, limit);
+        return new MapperIterator<>(edges, e -> {
+            HugeEdge edge = (HugeEdge) e;
+            return edge.id().otherVertexId();
+        });
+    }
+
+    @Watched
+    protected Iterator<Edge> edgesOfVertex(Id source, Directions dir,
+                                           Id label, long limit) {
+        Id[] labels = {};
+        if (label != null) {
+            labels = new Id[]{label};
+        }
+
+        Query query = GraphTransaction.constructEdgesQuery(source, dir, labels);
+        if (limit != NO_LIMIT) {
+            query.limit(limit);
+        }
+        return this.graph.edges(query);
+    }
+
+    @Watched
+    protected Iterator<Edge> edgesOfVertex(Id source, Directions dir,
+                                           Map<Id, String> labels, long limit) {
+        if (labels == null || labels.isEmpty()) {
+            return this.edgesOfVertex(source, dir, (Id) null, limit);
+        }
+        ExtendableIterator<Edge> results = new ExtendableIterator<>();
+        for (Id label : labels.keySet()) {
+            E.checkNotNull(label, "edge label");
+            results.extend(this.edgesOfVertex(source, dir, label, limit));
+        }
+
+        if (limit == NO_LIMIT) {
+            return results;
+        }
+
+        long[] count = new long[1];
+        return new LimitIterator<>(results, e -> count[0]++ >= limit);
+    }
+
+    protected Iterator<Edge> edgesOfVertex(Id source, Directions dir,
+                                           List<Id> labels, long limit) {
+        if (labels == null || labels.isEmpty()) {
+            return this.edgesOfVertex(source, dir, (Id) null, limit);
+        }
+        ExtendableIterator<Edge> results = new ExtendableIterator<>();
+        for (Id label : labels) {
+            E.checkNotNull(label, "edge label");
+            results.extend(this.edgesOfVertex(source, dir, label, limit));
+        }
+
+        if (limit == NO_LIMIT) {
+            return results;
+        }
+
+        long[] count = new long[1];
+        return new LimitIterator<>(results, e -> count[0]++ >= limit);
+    }
+
+    protected Iterator<Edge> edgesOfVertex(Id source, EdgeStep edgeStep) {
+        if (edgeStep.properties() == null || edgeStep.properties().isEmpty()) {
+            Iterator<Edge> edges = this.edgesOfVertex(source,
+                                                      edgeStep.direction(),
+                                                      edgeStep.labels(),
+                                                      edgeStep.limit());
+            return edgeStep.skipSuperNodeIfNeeded(edges);
+        }
+        return this.edgesOfVertex(source, edgeStep, false);
+    }
+
+    protected Iterator<Edge> edgesOfVertexWithSK(Id source, EdgeStep edgeStep) {
+        assert edgeStep.properties() != null && !edgeStep.properties().isEmpty();
+        return this.edgesOfVertex(source, edgeStep, true);
+    }
+
+    private Iterator<Edge> edgesOfVertex(Id source, EdgeStep edgeStep,
+                                         boolean mustAllSK) {
+        Id[] edgeLabels = edgeStep.edgeLabels();
+        Query query = GraphTransaction.constructEdgesQuery(source,
+                                                           edgeStep.direction(),
+                                                           edgeLabels);
+        ConditionQuery filter = null;
+        if (mustAllSK) {
+            this.fillFilterBySortKeys(query, edgeLabels, edgeStep.properties());
+        } else {
+            filter = (ConditionQuery) query.copy();
+            this.fillFilterByProperties(filter, edgeStep.properties());
+        }
+        query.capacity(Query.NO_CAPACITY);
+        if (edgeStep.limit() != NO_LIMIT) {
+            query.limit(edgeStep.limit());
+        }
+        Iterator<Edge> edges = this.graph().edges(query);
+        if (filter != null) {
+            ConditionQuery finalFilter = filter;
+            edges = new FilterIterator<>(edges, (e) -> {
+                return finalFilter.test((HugeEdge) e);
+            });
+        }
+        return edgeStep.skipSuperNodeIfNeeded(edges);
+    }
+
+    private void fillFilterBySortKeys(Query query, Id[] edgeLabels,
+                                      Map<Id, Object> properties) {
+        if (properties == null || properties.isEmpty()) {
+            return;
+        }
+
+        E.checkArgument(edgeLabels.length == 1,
+                        "The properties filter condition can be set " +
+                        "only if just set one edge label");
+
+        this.fillFilterByProperties(query, properties);
+
+        ConditionQuery condQuery = (ConditionQuery) query;
+        if (!GraphTransaction.matchFullEdgeSortKeys(condQuery, this.graph())) {
+            Id label = condQuery.condition(HugeKeys.LABEL);
+            E.checkArgument(false, "The properties %s does not match " +
+                                   "sort keys of edge label '%s'",
+                            this.graph().mapPkId2Name(properties.keySet()),
+                            this.graph().edgeLabel(label).name());
+        }
+    }
+
+    private void fillFilterByProperties(Query query,
+                                        Map<Id, Object> properties) {
+        if (properties == null || properties.isEmpty()) {
+            return;
+        }
+
+        ConditionQuery condQuery = (ConditionQuery) query;
+        TraversalUtil.fillConditionQuery(condQuery, properties, this.graph);
+    }
+
+    protected long edgesCount(Id source, EdgeStep edgeStep) {
+        Id[] edgeLabels = edgeStep.edgeLabels();
+        Query query = GraphTransaction.constructEdgesQuery(source,
+                                                           edgeStep.direction(),
+                                                           edgeLabels);
+        this.fillFilterBySortKeys(query, edgeLabels, edgeStep.properties());
+        query.aggregate(Aggregate.AggregateFunc.COUNT, null);
+        query.capacity(Query.NO_CAPACITY);
+        query.limit(Query.NO_LIMIT);
+        long count = graph().queryNumber(query).longValue();
+        if (edgeStep.degree() == NO_LIMIT || count < edgeStep.degree()) {
+            return count;
+        } else if (edgeStep.skipDegree() != 0L &&
+                   count >= edgeStep.skipDegree()) {
+            return 0L;
+        } else {
+            return edgeStep.degree();
+        }
+    }
+
+    protected Object getVertexLabelId(Object label) {
+        if (label == null) {
+            return null;
+        }
+        return SchemaLabel.getLabelId(this.graph, HugeType.VERTEX, label);
+    }
+
+    protected Id getEdgeLabelId(Object label) {
+        if (label == null) {
+            return null;
+        }
+        return SchemaLabel.getLabelId(this.graph, HugeType.EDGE, label);
+    }
+
+    protected void checkVertexExist(Id vertexId, String name) {
+        try {
+            this.graph.vertex(vertexId);
+        } catch (NotFoundException e) {
+            throw new IllegalArgumentException(String.format(
+                    "The %s with id '%s' does not exist", name, vertexId), e);
+        }
+    }
+
     public static class Node {
 
         private final Id id;
@@ -560,6 +589,7 @@ public class HugeTraverser {
 
         private final Id crosspoint;
         private final List<Id> vertices;
+        private Set<Edge> edges = Collections.emptySet();
 
         public Path(List<Id> vertices) {
             this(null, vertices);
@@ -568,6 +598,19 @@ public class HugeTraverser {
         public Path(Id crosspoint, List<Id> vertices) {
             this.crosspoint = crosspoint;
             this.vertices = vertices;
+        }
+
+        public Path(List<Id> vertices, Set<Edge> edges) {
+            this(null, vertices);
+            this.edges = edges;
+        }
+
+        public Set<Edge> getEdges() {
+            return edges;
+        }
+
+        public void setEdges(Set<Edge> edges) {
+            this.edges = edges;
         }
 
         public Id crosspoint() {
@@ -615,6 +658,7 @@ public class HugeTraverser {
          * Compares the specified object with this path for equality.
          * Returns <tt>true</tt> if and only if both have same vertices list
          * without regard of crosspoint.
+         *
          * @param other the object to be compared for equality with this path
          * @return <tt>true</tt> if the specified object is equal to this path
          */
@@ -638,12 +682,31 @@ public class HugeTraverser {
 
         private final Set<Path> paths;
 
+        private Set<Edge> edges = Collections.emptySet();
+
+        public PathSet(Set<Path> paths, Set<Edge> edges) {
+            this(paths);
+            this.edges = edges;
+        }
+
         public PathSet() {
             this(newSet());
         }
 
         private PathSet(Set<Path> paths) {
             this.paths = paths;
+        }
+
+        public Set<Path> getPaths() {
+            return this.paths;
+        }
+
+        public Set<Edge> getEdges() {
+            return edges;
+        }
+
+        public void setEdges(Set<Edge> edges) {
+            this.edges = edges;
         }
 
         @Override
@@ -729,7 +792,7 @@ public class HugeTraverser {
         }
 
         public void append(Id current) {
-            for (Iterator<Path> iter = paths.iterator(); iter.hasNext();) {
+            for (Iterator<Path> iter = paths.iterator(); iter.hasNext(); ) {
                 Path path = iter.next();
                 if (path.vertices().contains(current)) {
                     iter.remove();
@@ -738,5 +801,81 @@ public class HugeTraverser {
                 path.addToLast(current);
             }
         }
+    }
+
+    public static class EdgeRecord {
+        private final Map<Long, Edge> edgeMap;
+        private final ObjectIntMapping<Id> idMapping;
+
+        public EdgeRecord(boolean concurrent) {
+            this.edgeMap = new HashMap<>();
+            this.idMapping = ObjectIntMappingFactory.newObjectIntMapping(concurrent);
+        }
+
+        private static Long makeVertexPairIndex(int source, int target) {
+            return ((long) source & 0xFFFFFFFFL) |
+                   (((long) target << 32) & 0xFFFFFFFF00000000L);
+        }
+
+        public static Set<Id> getEdgeIds(Set<Edge> edges) {
+            return edges.stream().map(edge -> ((HugeEdge) edge).id()).collect(Collectors.toSet());
+        }
+
+        private int code(Id id) {
+            if (id.number()) {
+                long l = id.asLong();
+                if (0 <= l && l <= Integer.MAX_VALUE) {
+                    return (int) l;
+                }
+            }
+            int code = this.idMapping.object2Code(id);
+            assert code > 0;
+            return -code;
+        }
+
+        public void addEdge(Id source, Id target, Edge edge) {
+            Long index = makeVertexPairIndex(this.code(source), this.code(target));
+            this.edgeMap.put(index, edge);
+        }
+
+        private Edge getEdge(Id source, Id target) {
+            Long index = makeVertexPairIndex(this.code(source), this.code(target));
+            return this.edgeMap.get(index);
+        }
+
+        public Set<Edge> getEdges(HugeTraverser.Path path) {
+            if (path == null || path.vertices().isEmpty()) {
+                return new HashSet<>();
+            }
+            Iterator<Id> vertexIter = path.vertices().iterator();
+            return getEdges(vertexIter);
+        }
+
+        public Set<Edge> getEdges(Collection<HugeTraverser.Path> paths) {
+            Set<Edge> edgeIds = new HashSet<>();
+            for (HugeTraverser.Path path : paths) {
+                edgeIds.addAll(getEdges(path));
+            }
+            return edgeIds;
+        }
+
+        public Set<Edge> getEdges(Iterator<Id> vertexIter) {
+            Set<Edge> edges = new HashSet<>();
+            Id first = vertexIter.next();
+            Id second;
+            while (vertexIter.hasNext()) {
+                second = vertexIter.next();
+                Edge edge = getEdge(first, second);
+                if (edge == null) {
+                    edge = getEdge(second, first);
+                }
+                if (edge != null) {
+                    edges.add(edge);
+                }
+                first = second;
+            }
+            return edges;
+        }
+
     }
 }

--- a/hugegraph-core/src/main/java/org/apache/hugegraph/traversal/algorithm/KneighborTraverser.java
+++ b/hugegraph-core/src/main/java/org/apache/hugegraph/traversal/algorithm/KneighborTraverser.java
@@ -23,13 +23,12 @@ import java.util.function.Consumer;
 
 import org.apache.hugegraph.HugeGraph;
 import org.apache.hugegraph.backend.id.Id;
+import org.apache.hugegraph.structure.HugeEdge;
 import org.apache.hugegraph.traversal.algorithm.records.KneighborRecords;
 import org.apache.hugegraph.traversal.algorithm.steps.EdgeStep;
 import org.apache.hugegraph.type.define.Directions;
-import org.apache.tinkerpop.gremlin.structure.Edge;
-
-import org.apache.hugegraph.structure.HugeEdge;
 import org.apache.hugegraph.util.E;
+import org.apache.tinkerpop.gremlin.structure.Edge;
 
 public class KneighborTraverser extends OltpTraverser {
 
@@ -53,12 +52,15 @@ public class KneighborTraverser extends OltpTraverser {
         Set<Id> all = newSet();
 
         latest.add(sourceV);
+        this.vertexIterCounter.addAndGet(1L);
 
         while (depth-- > 0) {
             long remaining = limit == NO_LIMIT ? NO_LIMIT : limit - all.size();
             latest = this.adjacentVertices(sourceV, latest, dir, labelId,
                                            all, degree, remaining);
             all.addAll(latest);
+            this.vertexIterCounter.addAndGet(1L);
+            this.edgeIterCounter.addAndGet(latest.size());
             if (reachLimit(limit, all.size())) {
                 break;
             }
@@ -84,9 +86,15 @@ public class KneighborTraverser extends OltpTraverser {
                 return;
             }
             Iterator<Edge> edges = edgesOfVertex(v, step);
+            this.vertexIterCounter.addAndGet(1L);
             while (!this.reachLimit(limit, records.size()) && edges.hasNext()) {
-                Id target = ((HugeEdge) edges.next()).id().otherVertexId();
+                HugeEdge edge = (HugeEdge) edges.next();
+                Id target = edge.id().otherVertexId();
                 records.addPath(v, target);
+
+                records.getEdgeIdRecord().addEdge(v, target, edge);
+
+                this.edgeIterCounter.addAndGet(1L);
             }
         };
 

--- a/hugegraph-core/src/main/java/org/apache/hugegraph/traversal/algorithm/KneighborTraverser.java
+++ b/hugegraph-core/src/main/java/org/apache/hugegraph/traversal/algorithm/KneighborTraverser.java
@@ -92,7 +92,7 @@ public class KneighborTraverser extends OltpTraverser {
                 Id target = edge.id().otherVertexId();
                 records.addPath(v, target);
 
-                records.getEdgeIdRecord().addEdge(v, target, edge);
+                records.edgeResults().addEdge(v, target, edge);
 
                 this.edgeIterCounter.addAndGet(1L);
             }

--- a/hugegraph-core/src/main/java/org/apache/hugegraph/traversal/algorithm/KoutTraverser.java
+++ b/hugegraph-core/src/main/java/org/apache/hugegraph/traversal/algorithm/KoutTraverser.java
@@ -24,13 +24,12 @@ import java.util.function.Consumer;
 import org.apache.hugegraph.HugeException;
 import org.apache.hugegraph.HugeGraph;
 import org.apache.hugegraph.backend.id.Id;
+import org.apache.hugegraph.structure.HugeEdge;
 import org.apache.hugegraph.traversal.algorithm.records.KoutRecords;
 import org.apache.hugegraph.traversal.algorithm.steps.EdgeStep;
 import org.apache.hugegraph.type.define.Directions;
-import org.apache.tinkerpop.gremlin.structure.Edge;
-
-import org.apache.hugegraph.structure.HugeEdge;
 import org.apache.hugegraph.util.E;
+import org.apache.tinkerpop.gremlin.structure.Edge;
 
 public class KoutTraverser extends OltpTraverser {
 
@@ -66,6 +65,7 @@ public class KoutTraverser extends OltpTraverser {
 
         long remaining = capacity == NO_LIMIT ?
                          NO_LIMIT : capacity - latest.size();
+        this.vertexIterCounter.addAndGet(1L);
         while (depth-- > 0) {
             // Just get limit nodes in last layer if limit < remaining capacity
             if (depth == 0 && limit != NO_LIMIT &&
@@ -80,14 +80,16 @@ public class KoutTraverser extends OltpTraverser {
                 latest = this.adjacentVertices(sourceV, latest, dir, labelId,
                                                null, degree, remaining);
             }
+            this.vertexIterCounter.addAndGet(1L);
+            this.edgeIterCounter.addAndGet(latest.size());
             if (capacity != NO_LIMIT) {
                 // Update 'remaining' value to record remaining capacity
                 remaining -= latest.size();
 
                 if (remaining <= 0 && depth > 0) {
                     throw new HugeException(
-                              "Reach capacity '%s' while remaining depth '%s'",
-                              capacity, depth);
+                            "Reach capacity '%s' while remaining depth '%s'",
+                            capacity, depth);
                 }
             }
         }
@@ -114,11 +116,17 @@ public class KoutTraverser extends OltpTraverser {
                 return;
             }
             Iterator<Edge> edges = edgesOfVertex(v, step);
+            this.vertexIterCounter.addAndGet(1L);
             while (!this.reachLimit(limit, depth[0], records.size()) &&
                    edges.hasNext()) {
-                Id target = ((HugeEdge) edges.next()).id().otherVertexId();
+                HugeEdge edge = (HugeEdge) edges.next();
+                Id target = edge.id().otherVertexId();
                 records.addPath(v, target);
                 this.checkCapacity(capacity, records.accessed(), depth[0]);
+
+                records.getEdgeIdRecord().addEdge(v, target, edge);
+
+                this.edgeIterCounter.addAndGet(1L);
             }
         };
 
@@ -136,8 +144,8 @@ public class KoutTraverser extends OltpTraverser {
         }
         if (accessed >= capacity && depth > 0) {
             throw new HugeException(
-                      "Reach capacity '%s' while remaining depth '%s'",
-                      capacity, depth);
+                    "Reach capacity '%s' while remaining depth '%s'",
+                    capacity, depth);
         }
     }
 

--- a/hugegraph-core/src/main/java/org/apache/hugegraph/traversal/algorithm/KoutTraverser.java
+++ b/hugegraph-core/src/main/java/org/apache/hugegraph/traversal/algorithm/KoutTraverser.java
@@ -124,7 +124,7 @@ public class KoutTraverser extends OltpTraverser {
                 records.addPath(v, target);
                 this.checkCapacity(capacity, records.accessed(), depth[0]);
 
-                records.getEdgeIdRecord().addEdge(v, target, edge);
+                records.edgeResults().addEdge(v, target, edge);
 
                 this.edgeIterCounter.addAndGet(1L);
             }

--- a/hugegraph-core/src/main/java/org/apache/hugegraph/traversal/algorithm/MultiNodeShortestPathTraverser.java
+++ b/hugegraph-core/src/main/java/org/apache/hugegraph/traversal/algorithm/MultiNodeShortestPathTraverser.java
@@ -132,6 +132,7 @@ public class MultiNodeShortestPathTraverser extends OltpTraverser {
     }
 
     public static class WrappedListPath {
+
         private final List<Path> paths;
         private final Set<Edge> edges;
 
@@ -140,11 +141,11 @@ public class MultiNodeShortestPathTraverser extends OltpTraverser {
             this.edges = edges;
         }
 
-        public List<Path> getPaths() {
+        public List<Path> paths() {
             return paths;
         }
 
-        public Set<Edge> getEdges() {
+        public Set<Edge> edges() {
             return edges;
         }
     }

--- a/hugegraph-core/src/main/java/org/apache/hugegraph/traversal/algorithm/MultiNodeShortestPathTraverser.java
+++ b/hugegraph-core/src/main/java/org/apache/hugegraph/traversal/algorithm/MultiNodeShortestPathTraverser.java
@@ -19,83 +19,25 @@ package org.apache.hugegraph.traversal.algorithm;
 
 import java.util.Iterator;
 import java.util.List;
+import java.util.Set;
 import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.CopyOnWriteArraySet;
 import java.util.function.Consumer;
 
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.hugegraph.HugeGraph;
 import org.apache.hugegraph.backend.id.Id;
+import org.apache.hugegraph.structure.HugeVertex;
 import org.apache.hugegraph.traversal.algorithm.steps.EdgeStep;
+import org.apache.hugegraph.util.E;
+import org.apache.tinkerpop.gremlin.structure.Edge;
 import org.apache.tinkerpop.gremlin.structure.Vertex;
 import org.apache.tinkerpop.gremlin.util.iterator.IteratorUtils;
-
-import org.apache.hugegraph.structure.HugeVertex;
-import org.apache.hugegraph.util.E;
 
 public class MultiNodeShortestPathTraverser extends OltpTraverser {
 
     public MultiNodeShortestPathTraverser(HugeGraph graph) {
         super(graph);
-    }
-
-    public List<Path> multiNodeShortestPath(Iterator<Vertex> vertices,
-                                            EdgeStep step, int maxDepth,
-                                            long capacity) {
-        List<Vertex> vertexList = IteratorUtils.list(vertices);
-        int vertexCount = vertexList.size();
-        E.checkState(vertexCount >= 2 && vertexCount <= MAX_VERTICES,
-                     "The number of vertices of multiple node shortest path " +
-                     "must in [2, %s], but got: %s",
-                     MAX_VERTICES, vertexList.size());
-        List<Pair<Id, Id>> pairs = newList();
-        cmn(vertexList, vertexCount, 2, 0, null, r -> {
-            Id source = ((HugeVertex) r.get(0)).id();
-            Id target = ((HugeVertex) r.get(1)).id();
-            Pair<Id, Id> pair = Pair.of(source, target);
-            pairs.add(pair);
-        });
-
-        if (maxDepth >= this.concurrentDepth() && vertexCount > 10) {
-            return this.multiNodeShortestPathConcurrent(pairs, step,
-                                                        maxDepth, capacity);
-        } else {
-            return this.multiNodeShortestPathSingle(pairs, step,
-                                                    maxDepth, capacity);
-        }
-    }
-
-    public List<Path> multiNodeShortestPathConcurrent(List<Pair<Id, Id>> pairs,
-                                                      EdgeStep step,
-                                                      int maxDepth,
-                                                      long capacity) {
-        List<Path> results = new CopyOnWriteArrayList<>();
-        ShortestPathTraverser traverser =
-                              new ShortestPathTraverser(this.graph());
-        this.traversePairs(pairs.iterator(), pair -> {
-            Path path = traverser.shortestPath(pair.getLeft(), pair.getRight(),
-                                               step, maxDepth, capacity);
-            if (!Path.EMPTY.equals(path)) {
-                results.add(path);
-            }
-        });
-
-        return results;
-    }
-
-    public List<Path> multiNodeShortestPathSingle(List<Pair<Id, Id>> pairs,
-                                                  EdgeStep step, int maxDepth,
-                                                  long capacity) {
-        List<Path> results = newList();
-        ShortestPathTraverser traverser =
-                              new ShortestPathTraverser(this.graph());
-        for (Pair<Id, Id> pair : pairs) {
-            Path path = traverser.shortestPath(pair.getLeft(), pair.getRight(),
-                                               step, maxDepth, capacity);
-            if (!Path.EMPTY.equals(path)) {
-                results.add(path);
-            }
-        }
-        return results;
     }
 
     private static <T> void cmn(List<T> all, int m, int n, int current,
@@ -121,5 +63,89 @@ public class MultiNodeShortestPathTraverser extends OltpTraverser {
         // Not select current item, continue to select C(m-1, n)
         result.remove(index);
         cmn(all, m - 1, n, current, result, consumer);
+    }
+
+    public WrappedListPath multiNodeShortestPath(Iterator<Vertex> vertices,
+                                                 EdgeStep step, int maxDepth,
+                                                 long capacity) {
+        List<Vertex> vertexList = IteratorUtils.list(vertices);
+        int vertexCount = vertexList.size();
+        E.checkState(vertexCount >= 2 && vertexCount <= MAX_VERTICES,
+                     "The number of vertices of multiple node shortest path " +
+                     "must in [2, %s], but got: %s",
+                     MAX_VERTICES, vertexList.size());
+        List<Pair<Id, Id>> pairs = newList();
+        cmn(vertexList, vertexCount, 2, 0, null, r -> {
+            Id source = ((HugeVertex) r.get(0)).id();
+            Id target = ((HugeVertex) r.get(1)).id();
+            Pair<Id, Id> pair = Pair.of(source, target);
+            pairs.add(pair);
+        });
+
+        if (maxDepth >= this.concurrentDepth() && vertexCount > 10) {
+            return this.multiNodeShortestPathConcurrent(pairs, step, maxDepth, capacity);
+        } else {
+            return this.multiNodeShortestPathSingle(pairs, step, maxDepth, capacity);
+        }
+    }
+
+    public WrappedListPath multiNodeShortestPathConcurrent(List<Pair<Id, Id>> pairs,
+                                                           EdgeStep step, int maxDepth,
+                                                           long capacity) {
+        List<Path> paths = new CopyOnWriteArrayList<>();
+        Set<Edge> edges = new CopyOnWriteArraySet<>();
+        ShortestPathTraverser traverser =
+                new ShortestPathTraverser(this.graph());
+        this.traversePairs(pairs.iterator(), pair -> {
+            Path path = traverser.shortestPath(pair.getLeft(), pair.getRight(),
+                                               step, maxDepth, capacity);
+            if (!Path.EMPTY.equals(path)) {
+                paths.add(path);
+            }
+            edges.addAll(path.getEdges());
+        });
+        this.vertexIterCounter.addAndGet(traverser.vertexIterCounter.get());
+        this.edgeIterCounter.addAndGet(traverser.edgeIterCounter.get());
+
+        return new WrappedListPath(paths, edges);
+    }
+
+    public WrappedListPath multiNodeShortestPathSingle(List<Pair<Id, Id>> pairs,
+                                                       EdgeStep step, int maxDepth,
+                                                       long capacity) {
+        List<Path> paths = newList();
+        Set<Edge> edges = newSet();
+        ShortestPathTraverser traverser =
+                new ShortestPathTraverser(this.graph());
+        for (Pair<Id, Id> pair : pairs) {
+            Path path = traverser.shortestPath(pair.getLeft(), pair.getRight(),
+                                               step, maxDepth, capacity);
+            if (!Path.EMPTY.equals(path)) {
+                paths.add(path);
+            }
+            edges.addAll(path.getEdges());
+        }
+        this.vertexIterCounter.addAndGet(traverser.vertexIterCounter.get());
+        this.edgeIterCounter.addAndGet(traverser.edgeIterCounter.get());
+
+        return new WrappedListPath(paths, edges);
+    }
+
+    public static class WrappedListPath {
+        private final List<Path> paths;
+        private final Set<Edge> edges;
+
+        public WrappedListPath(List<Path> paths, Set<Edge> edges) {
+            this.paths = paths;
+            this.edges = edges;
+        }
+
+        public List<Path> getPaths() {
+            return paths;
+        }
+
+        public Set<Edge> getEdges() {
+            return edges;
+        }
     }
 }

--- a/hugegraph-core/src/main/java/org/apache/hugegraph/traversal/algorithm/PathTraverser.java
+++ b/hugegraph-core/src/main/java/org/apache/hugegraph/traversal/algorithm/PathTraverser.java
@@ -28,6 +28,7 @@ import java.util.function.BiConsumer;
 
 import org.apache.hugegraph.backend.id.Id;
 import org.apache.hugegraph.structure.HugeEdge;
+import org.apache.hugegraph.traversal.algorithm.HugeTraverser.EdgeRecord;
 import org.apache.hugegraph.traversal.algorithm.steps.EdgeStep;
 import org.apache.hugegraph.traversal.algorithm.strategy.TraverseStrategy;
 import org.apache.tinkerpop.gremlin.structure.Edge;
@@ -50,7 +51,7 @@ public abstract class PathTraverser {
     protected Set<HugeTraverser.Path> paths;
 
     protected TraverseStrategy traverseStrategy;
-    protected HugeTraverser.EdgeRecord edgeRecord;
+    protected EdgeRecord edgeResults;
 
     public PathTraverser(HugeTraverser traverser, TraverseStrategy strategy,
                          Collection<Id> sources, Collection<Id> targets,
@@ -79,7 +80,7 @@ public abstract class PathTraverser {
 
         this.paths = this.newPathSet();
 
-        this.edgeRecord = new HugeTraverser.EdgeRecord(concurrent);
+        this.edgeResults = new EdgeRecord(concurrent);
     }
 
     public void forward() {
@@ -148,7 +149,7 @@ public abstract class PathTraverser {
             Id target = edge.id().otherVertexId();
             this.traverser.edgeIterCounter.addAndGet(1L);
 
-            this.edgeRecord.addEdge(v, target, edge);
+            this.edgeResults.addEdge(v, target, edge);
 
             this.processOne(v, target, forward);
         }

--- a/hugegraph-core/src/main/java/org/apache/hugegraph/traversal/algorithm/SameNeighborTraverser.java
+++ b/hugegraph-core/src/main/java/org/apache/hugegraph/traversal/algorithm/SameNeighborTraverser.java
@@ -17,15 +17,17 @@
 
 package org.apache.hugegraph.traversal.algorithm;
 
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 
 import org.apache.hugegraph.HugeGraph;
 import org.apache.hugegraph.backend.id.Id;
 import org.apache.hugegraph.type.define.Directions;
-import org.apache.tinkerpop.gremlin.util.iterator.IteratorUtils;
-
 import org.apache.hugegraph.util.CollectionUtil;
 import org.apache.hugegraph.util.E;
+import org.apache.tinkerpop.gremlin.util.iterator.IteratorUtils;
 
 public class SameNeighborTraverser extends HugeTraverser {
 
@@ -46,13 +48,58 @@ public class SameNeighborTraverser extends HugeTraverser {
         Id labelId = this.getEdgeLabelId(label);
 
         Set<Id> sourceNeighbors = IteratorUtils.set(this.adjacentVertices(
-                                  vertex, direction, labelId, degree));
+                vertex, direction, labelId, degree));
         Set<Id> targetNeighbors = IteratorUtils.set(this.adjacentVertices(
-                                  other, direction, labelId, degree));
+                other, direction, labelId, degree));
         Set<Id> sameNeighbors = (Set<Id>) CollectionUtil.intersect(
-                                sourceNeighbors, targetNeighbors);
+                sourceNeighbors, targetNeighbors);
+
+        this.vertexIterCounter.addAndGet(2L);
+        this.edgeIterCounter.addAndGet(sourceNeighbors.size());
+        this.edgeIterCounter.addAndGet(targetNeighbors.size());
+
         if (limit != NO_LIMIT) {
             int end = Math.min(sameNeighbors.size(), limit);
+            sameNeighbors = CollectionUtil.subSet(sameNeighbors, 0, end);
+        }
+        return sameNeighbors;
+    }
+
+    public Set<Id> sameNeighbors(List<Id> vertexIds, Directions direction,
+                                 List<String> labels, long degree, long limit) {
+        E.checkNotNull(vertexIds, "vertex ids");
+        E.checkArgument(vertexIds.size() >= 2, "vertex_list size can't " +
+                                               "be less than 2");
+        for (Id id : vertexIds) {
+            this.checkVertexExist(id, "vertex");
+        }
+        E.checkNotNull(direction, "direction");
+        checkDegree(degree);
+        checkLimit(limit);
+
+        List<Id> labelsId = new ArrayList<>();
+        if (labels != null) {
+            for (String label : labels) {
+                labelsId.add(this.getEdgeLabelId(label));
+            }
+        }
+
+        Set<Id> sameNeighbors = new HashSet<>();
+        for (int i = 0; i < vertexIds.size(); i++) {
+            Set<Id> vertexNeighbors = IteratorUtils.set(this.adjacentVertices(
+                    vertexIds.get(i), direction, labelsId, degree));
+            if (i == 0) {
+                sameNeighbors = vertexNeighbors;
+            } else {
+                sameNeighbors = (Set<Id>) CollectionUtil.intersect(
+                        sameNeighbors, vertexNeighbors);
+            }
+            this.vertexIterCounter.addAndGet(1L);
+            this.edgeIterCounter.addAndGet(vertexNeighbors.size());
+        }
+
+        if (limit != NO_LIMIT) {
+            int end = Math.min(sameNeighbors.size(), (int) limit);
             sameNeighbors = CollectionUtil.subSet(sameNeighbors, 0, end);
         }
         return sameNeighbors;

--- a/hugegraph-core/src/main/java/org/apache/hugegraph/traversal/algorithm/SameNeighborTraverser.java
+++ b/hugegraph-core/src/main/java/org/apache/hugegraph/traversal/algorithm/SameNeighborTraverser.java
@@ -66,7 +66,7 @@ public class SameNeighborTraverser extends HugeTraverser {
     }
 
     public Set<Id> sameNeighbors(List<Id> vertexIds, Directions direction,
-                                 List<String> labels, long degree, long limit) {
+                                 List<String> labels, long degree, int limit) {
         E.checkNotNull(vertexIds, "vertex ids");
         E.checkArgument(vertexIds.size() >= 2, "vertex_list size can't " +
                                                "be less than 2");
@@ -99,7 +99,7 @@ public class SameNeighborTraverser extends HugeTraverser {
         }
 
         if (limit != NO_LIMIT) {
-            int end = Math.min(sameNeighbors.size(), (int) limit);
+            int end = Math.min(sameNeighbors.size(), limit);
             sameNeighbors = CollectionUtil.subSet(sameNeighbors, 0, end);
         }
         return sameNeighbors;

--- a/hugegraph-core/src/main/java/org/apache/hugegraph/traversal/algorithm/TemplatePathsTraverser.java
+++ b/hugegraph-core/src/main/java/org/apache/hugegraph/traversal/algorithm/TemplatePathsTraverser.java
@@ -18,7 +18,6 @@
 package org.apache.hugegraph.traversal.algorithm;
 
 import java.util.Collection;
-import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -282,23 +281,20 @@ public class TemplatePathsTraverser extends HugeTraverser {
     }
 
     public static class WrappedPathSet {
-        private final Set<Path> paths;
-        private Set<Edge> edges = Collections.emptySet();
 
-        public WrappedPathSet(Set<Path> paths) {
-            this.paths = paths;
-        }
+        private final Set<Path> paths;
+        private final Set<Edge> edges;
 
         public WrappedPathSet(Set<Path> paths, Set<Edge> edges) {
             this.paths = paths;
             this.edges = edges;
         }
 
-        public Set<Path> getPaths() {
+        public Set<Path> paths() {
             return paths;
         }
 
-        public Set<Edge> getEdges() {
+        public Set<Edge> edges() {
             return edges;
         }
     }

--- a/hugegraph-core/src/main/java/org/apache/hugegraph/traversal/algorithm/TemplatePathsTraverser.java
+++ b/hugegraph-core/src/main/java/org/apache/hugegraph/traversal/algorithm/TemplatePathsTraverser.java
@@ -18,6 +18,7 @@
 package org.apache.hugegraph.traversal.algorithm;
 
 import java.util.Collection;
+import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -25,13 +26,13 @@ import java.util.Set;
 
 import org.apache.hugegraph.HugeGraph;
 import org.apache.hugegraph.backend.id.Id;
+import org.apache.hugegraph.structure.HugeVertex;
 import org.apache.hugegraph.traversal.algorithm.steps.EdgeStep;
 import org.apache.hugegraph.traversal.algorithm.steps.RepeatEdgeStep;
 import org.apache.hugegraph.traversal.algorithm.strategy.TraverseStrategy;
-import org.apache.tinkerpop.gremlin.structure.Vertex;
-
-import org.apache.hugegraph.structure.HugeVertex;
 import org.apache.hugegraph.util.E;
+import org.apache.tinkerpop.gremlin.structure.Edge;
+import org.apache.tinkerpop.gremlin.structure.Vertex;
 
 public class TemplatePathsTraverser extends HugeTraverser {
 
@@ -39,11 +40,11 @@ public class TemplatePathsTraverser extends HugeTraverser {
         super(graph);
     }
 
-    public Set<Path> templatePaths(Iterator<Vertex> sources,
-                                   Iterator<Vertex> targets,
-                                   List<RepeatEdgeStep> steps,
-                                   boolean withRing,
-                                   long capacity, long limit) {
+    public WrappedPathSet templatePaths(Iterator<Vertex> sources,
+                                        Iterator<Vertex> targets,
+                                        List<RepeatEdgeStep> steps,
+                                        boolean withRing, long capacity,
+                                        long limit) {
         checkCapacity(capacity);
         checkLimit(limit);
 
@@ -68,23 +69,26 @@ public class TemplatePathsTraverser extends HugeTraverser {
         for (RepeatEdgeStep step : steps) {
             totalSteps += step.maxTimes();
         }
+
+        boolean concurrent = totalSteps >= this.concurrentDepth();
         TraverseStrategy strategy = TraverseStrategy.create(
-                                    totalSteps >= this.concurrentDepth(),
-                                    this.graph());
+                concurrent, this.graph());
         Traverser traverser = new Traverser(this, strategy,
                                             sourceList, targetList, steps,
-                                            withRing, capacity, limit);
+                                            withRing, capacity, limit, concurrent);
         do {
             // Forward
             traverser.forward();
             if (traverser.finished()) {
-                return traverser.paths();
+                Set<Path> paths = traverser.paths();
+                return new WrappedPathSet(paths, traverser.edgeRecord.getEdges(paths));
             }
 
             // Backward
             traverser.backward();
             if (traverser.finished()) {
-                return traverser.paths();
+                Set<Path> paths = traverser.paths();
+                return new WrappedPathSet(paths, traverser.edgeRecord.getEdges(paths));
             }
         } while (true);
     }
@@ -98,14 +102,14 @@ public class TemplatePathsTraverser extends HugeTraverser {
         protected int sourceIndex;
         protected int targetIndex;
 
-        protected boolean sourceFinishOneStep = false;
-        protected boolean targetFinishOneStep = false;
+        protected boolean sourceFinishOneStep;
+        protected boolean targetFinishOneStep;
 
         public Traverser(HugeTraverser traverser, TraverseStrategy strategy,
                          Collection<Id> sources, Collection<Id> targets,
                          List<RepeatEdgeStep> steps, boolean withRing,
-                         long capacity, long limit) {
-            super(traverser, strategy, sources, targets, capacity, limit);
+                         long capacity, long limit, boolean concurrent) {
+            super(traverser, strategy, sources, targets, capacity, limit, concurrent);
 
             this.steps = steps;
             this.withRing = withRing;
@@ -135,7 +139,7 @@ public class TemplatePathsTraverser extends HugeTraverser {
         public void afterTraverse(EdgeStep step, boolean forward) {
 
             Map<Id, List<Node>> all = forward ? this.sourcesAll :
-                                                this.targetsAll;
+                                      this.targetsAll;
             this.addNewVerticesToAll(all);
             this.reInitCurrentStepIfNeeded(step, forward);
             this.stepCount++;
@@ -274,6 +278,28 @@ public class TemplatePathsTraverser extends HugeTraverser {
         public boolean lastSuperStep() {
             return this.targetIndex == this.sourceIndex ||
                    this.targetIndex == this.sourceIndex + 1;
+        }
+    }
+
+    public static class WrappedPathSet {
+        private final Set<Path> paths;
+        private Set<Edge> edges = Collections.emptySet();
+
+        public WrappedPathSet(Set<Path> paths) {
+            this.paths = paths;
+        }
+
+        public WrappedPathSet(Set<Path> paths, Set<Edge> edges) {
+            this.paths = paths;
+            this.edges = edges;
+        }
+
+        public Set<Path> getPaths() {
+            return paths;
+        }
+
+        public Set<Edge> getEdges() {
+            return edges;
         }
     }
 }

--- a/hugegraph-core/src/main/java/org/apache/hugegraph/traversal/algorithm/TemplatePathsTraverser.java
+++ b/hugegraph-core/src/main/java/org/apache/hugegraph/traversal/algorithm/TemplatePathsTraverser.java
@@ -80,14 +80,14 @@ public class TemplatePathsTraverser extends HugeTraverser {
             traverser.forward();
             if (traverser.finished()) {
                 Set<Path> paths = traverser.paths();
-                return new WrappedPathSet(paths, traverser.edgeRecord.getEdges(paths));
+                return new WrappedPathSet(paths, traverser.edgeResults.getEdges(paths));
             }
 
             // Backward
             traverser.backward();
             if (traverser.finished()) {
                 Set<Path> paths = traverser.paths();
-                return new WrappedPathSet(paths, traverser.edgeRecord.getEdges(paths));
+                return new WrappedPathSet(paths, traverser.edgeResults.getEdges(paths));
             }
         } while (true);
     }

--- a/hugegraph-core/src/main/java/org/apache/hugegraph/traversal/algorithm/records/ShortestPathRecords.java
+++ b/hugegraph-core/src/main/java/org/apache/hugegraph/traversal/algorithm/records/ShortestPathRecords.java
@@ -23,14 +23,14 @@ import java.util.Stack;
 import java.util.function.Function;
 
 import org.apache.hugegraph.backend.id.Id;
+import org.apache.hugegraph.traversal.algorithm.HugeTraverser.Path;
+import org.apache.hugegraph.traversal.algorithm.HugeTraverser.PathSet;
 import org.apache.hugegraph.traversal.algorithm.records.record.Int2IntRecord;
 import org.apache.hugegraph.traversal.algorithm.records.record.Record;
 import org.apache.hugegraph.traversal.algorithm.records.record.RecordType;
 import org.apache.hugegraph.util.collection.CollectionFactory;
 import org.apache.hugegraph.util.collection.IntMap;
 import org.apache.hugegraph.util.collection.IntSet;
-import org.apache.hugegraph.traversal.algorithm.HugeTraverser.Path;
-import org.apache.hugegraph.traversal.algorithm.HugeTraverser.PathSet;
 
 public class ShortestPathRecords extends DoubleWayMultiPathsRecords {
 

--- a/hugegraph-core/src/main/java/org/apache/hugegraph/traversal/algorithm/records/SingleWayMultiPathsRecords.java
+++ b/hugegraph-core/src/main/java/org/apache/hugegraph/traversal/algorithm/records/SingleWayMultiPathsRecords.java
@@ -26,7 +26,7 @@ import java.util.function.Function;
 import org.apache.hugegraph.HugeException;
 import org.apache.hugegraph.backend.id.Id;
 import org.apache.hugegraph.perf.PerfUtil.Watched;
-import org.apache.hugegraph.traversal.algorithm.HugeTraverser;
+import org.apache.hugegraph.traversal.algorithm.HugeTraverser.EdgeRecord;
 import org.apache.hugegraph.traversal.algorithm.HugeTraverser.Path;
 import org.apache.hugegraph.traversal.algorithm.HugeTraverser.PathSet;
 import org.apache.hugegraph.traversal.algorithm.records.record.Int2IntRecord;
@@ -45,7 +45,7 @@ public abstract class SingleWayMultiPathsRecords extends AbstractRecords {
     private final int sourceCode;
     private final boolean nearest;
     private final IntSet accessedVertices;
-    private final HugeTraverser.EdgeRecord edgeRecord;
+    private final EdgeRecord edgeResults;
     private IntIterator parentRecordKeys;
 
     public SingleWayMultiPathsRecords(RecordType type, boolean concurrent,
@@ -59,7 +59,7 @@ public abstract class SingleWayMultiPathsRecords extends AbstractRecords {
         firstRecord.addPath(this.sourceCode, 0);
         this.records = new Stack<>();
         this.records.push(firstRecord);
-        this.edgeRecord = new HugeTraverser.EdgeRecord(concurrent);
+        this.edgeResults = new EdgeRecord(concurrent);
 
         this.accessedVertices = CollectionFactory.newIntSet();
     }
@@ -178,8 +178,8 @@ public abstract class SingleWayMultiPathsRecords extends AbstractRecords {
         return this.records;
     }
 
-    public HugeTraverser.EdgeRecord getEdgeIdRecord() {
-        return edgeRecord;
+    public EdgeRecord edgeResults() {
+        return edgeResults;
     }
 
     public abstract int size();

--- a/hugegraph-core/src/main/java/org/apache/hugegraph/traversal/algorithm/records/SingleWayMultiPathsRecords.java
+++ b/hugegraph-core/src/main/java/org/apache/hugegraph/traversal/algorithm/records/SingleWayMultiPathsRecords.java
@@ -25,17 +25,18 @@ import java.util.function.Function;
 
 import org.apache.hugegraph.HugeException;
 import org.apache.hugegraph.backend.id.Id;
-import org.apache.hugegraph.type.define.CollectionType;
-import org.apache.hugegraph.util.collection.CollectionFactory;
-import org.apache.hugegraph.util.collection.IntIterator;
-import org.apache.hugegraph.util.collection.IntMap;
-import org.apache.hugegraph.util.collection.IntSet;
 import org.apache.hugegraph.perf.PerfUtil.Watched;
+import org.apache.hugegraph.traversal.algorithm.HugeTraverser;
 import org.apache.hugegraph.traversal.algorithm.HugeTraverser.Path;
 import org.apache.hugegraph.traversal.algorithm.HugeTraverser.PathSet;
 import org.apache.hugegraph.traversal.algorithm.records.record.Int2IntRecord;
 import org.apache.hugegraph.traversal.algorithm.records.record.Record;
 import org.apache.hugegraph.traversal.algorithm.records.record.RecordType;
+import org.apache.hugegraph.type.define.CollectionType;
+import org.apache.hugegraph.util.collection.CollectionFactory;
+import org.apache.hugegraph.util.collection.IntIterator;
+import org.apache.hugegraph.util.collection.IntMap;
+import org.apache.hugegraph.util.collection.IntSet;
 
 public abstract class SingleWayMultiPathsRecords extends AbstractRecords {
 
@@ -44,7 +45,7 @@ public abstract class SingleWayMultiPathsRecords extends AbstractRecords {
     private final int sourceCode;
     private final boolean nearest;
     private final IntSet accessedVertices;
-
+    private final HugeTraverser.EdgeRecord edgeRecord;
     private IntIterator parentRecordKeys;
 
     public SingleWayMultiPathsRecords(RecordType type, boolean concurrent,
@@ -58,6 +59,7 @@ public abstract class SingleWayMultiPathsRecords extends AbstractRecords {
         firstRecord.addPath(this.sourceCode, 0);
         this.records = new Stack<>();
         this.records.push(firstRecord);
+        this.edgeRecord = new HugeTraverser.EdgeRecord(concurrent);
 
         this.accessedVertices = CollectionFactory.newIntSet();
     }
@@ -174,6 +176,10 @@ public abstract class SingleWayMultiPathsRecords extends AbstractRecords {
 
     protected final Stack<Record> records() {
         return this.records;
+    }
+
+    public HugeTraverser.EdgeRecord getEdgeIdRecord() {
+        return edgeRecord;
     }
 
     public abstract int size();

--- a/hugegraph-test/src/main/java/org/apache/hugegraph/api/traversers/JaccardSimilarityApiTest.java
+++ b/hugegraph-test/src/main/java/org/apache/hugegraph/api/traversers/JaccardSimilarityApiTest.java
@@ -19,13 +19,14 @@ package org.apache.hugegraph.api.traversers;
 
 import java.util.Map;
 
-import jakarta.ws.rs.core.Response;
+import org.apache.hugegraph.api.BaseApiTest;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
-import org.apache.hugegraph.api.BaseApiTest;
 import com.google.common.collect.ImmutableMap;
+
+import jakarta.ws.rs.core.Response;
 
 public class JaccardSimilarityApiTest extends BaseApiTest {
 
@@ -72,9 +73,10 @@ public class JaccardSimilarityApiTest extends BaseApiTest {
                                        "\"top\": 3}", markoId);
         Response r = client().post(PATH, reqBody);
         String content = assertResponseStatus(200, r);
-        Double rippleJaccardSimilarity = assertJsonContains(content, rippleId);
-        Double peterJaccardSimilarity = assertJsonContains(content, peterId);
-        Double jsonJaccardSimilarity = assertJsonContains(content, jsonId);
+        Map<?, ?> jaccardSimilarity = assertJsonContains(content, "jaccard_similarity");
+        Double rippleJaccardSimilarity = assertMapContains(jaccardSimilarity, rippleId);
+        Double peterJaccardSimilarity = assertMapContains(jaccardSimilarity, peterId);
+        Double jsonJaccardSimilarity = assertMapContains(jaccardSimilarity, jsonId);
         Assert.assertEquals(0.3333, rippleJaccardSimilarity.doubleValue(),
                             0.0001);
         Assert.assertEquals(0.25, peterJaccardSimilarity.doubleValue(), 0.0001);


### PR DESCRIPTION
<!-- 
  Thank you very much for contributing to Apache HugeGraph, we are happy that you want to help us improve it!

  Here are some tips for you:
    1. If this is your first time, please read the [contributing guidelines](https://github.com/apache/hugegraph/blob/master/CONTRIBUTING.md)

    2. If a PR fix/close an issue, type the message "close xxx" (xxx is the link of related 
issue) in the content, GitHub will auto link it (Required)

    3. Name the PR title in "Google Commit Format", start with "feat | fix | perf | refactor | doc | chore", 
      such like: "feat(core): support the PageRank algorithm" or "fix: wrong break in the compute loop" (module is optional)
      skip it if you are unsure about which is the best component.

    4. One PR address one issue, better not to mix up multiple issues.

    5. Put an `x` in the `[ ]` to mark the item as CHECKED. `[x]` (or click it directly after 
published)
-->

## Purpose of the PR

- Add statistics infomation in oltp api response, including the number of vertices and edges traversed at runtime, as well as the time the api takes to execute
- Support full infomation about vertices and edges in oltp api response

<!--
Please explain more context in this section, clarify why the changes are needed. 
e.g:
- If you propose a new API, clarify the use case for a new API.
- If you fix a bug, you can clarify why it is a bug, and should be associated with an issue.
-->

## Main Changes

<!-- Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. These change logs are helpful for better ant faster reviews.)

For example:

- If you introduce a new feature, please show detailed design here or add the link of design documentation.
- If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
- If there is a discussion in the mailing list, please add the link. -->

### Statistics information:

* add vertexIterCounter and edgeIterCounter in HugeTraverser.java to track traversed vertices and edges at run time

* modify all oltp apis to add statistics information in response

* modify Serializer.java and JsonSerializer.java to support statistics infomation serialization

* [design document](https://hugegraph.feishu.cn/wiki/JhxTwzvnrip57nkWksbcFNgUnea)

### Full information about vertices and edges:

* add 'with_vertex' and 'with_edge' parameter option in oltp apis

* modify oltp apis to support vertex and edge information in api response

* add EdgeRecord in HugeTraverser.java to record edges at run time and generate the edge information returned in api response

* modify Path and PathSet in HugeTraverser.java to support full edge information storage

* modify all traversers to support track of edge information at run time

* modify Serializer.java and JsonSerializer.java to support full infomation serialization about vertices and edges

* [design document](https://hugegraph.feishu.cn/wiki/VxXvwakvzixarbkMGqpchMZwnnc)

### Implementation overview

* **N: No Need**

* **✓: Supported**

|                                 | statistics | with_vertex | with_edge |
| ------------------------------- | ---------- | ----------- | --------- |
| Kout Get                        | **✓**      | **N**       | **N**     |
| Kout Post                       | **✓**      | **✓**       | **✓**     |
| Kneighbor Get                   | **✓**      | **N**       | **N**     |
| Kneighbor Post                  | **✓**      | **✓**       | **✓**     |
| Sameneighbors Get               | **✓**      | **N**       | **N**     |
| Sameneighbors Post              | **✓**      | **✓**       | **N**     |
| Jaccard Similarity Get          | **✓**      | **N**       | **N**     |
| Jaccard Similarity Post         | **✓**      | **N**       | **N**     |
| Shortest Path Get               | **✓**      | **✓**       | **✓**     |
| All Shortest Paths Get          | **✓**      | **✓**       | **✓**     |
| Weighted Shortest Path Get      | **✓**      | **✓**       | **✓**     |
| Single Source Shortest Path Get | **✓**      | **✓**       | **✓**     |
| Multi Node Shortest Path Post   | **✓**      | **✓**       | **✓**     |
| Paths Get                       | **✓**      | **N**       | **N**     |
| Paths Post                      | **✓**      | **✓**       | **✓**     |
| Customized Paths Post           | **✓**      | **✓**       | **✓**     |
| Template Paths Post             | **✓**      | **✓**       | **✓**     |
| Crosspoints Get                 | **✓**      | **N**       | **N**     |
| Customized Crosspoints Post     | **✓**      | **✓**       | **✓**     |
| Rings Get                       | **✓**      | **✓**       | **✓**     |
| Rays Get                        | **✓**      | **✓**       | **✓**     |
| Fusiform Similarity Post        | **✓**      | **N**       | **N**     |

![measure full-info](https://github.com/apache/incubator-hugegraph/assets/77946882/fe51be13-2174-4a66-96a4-8cf760476c8b)


## Verifying these changes

<!-- Please pick the proper options below -->

- [ ] Trivial rework / code cleanup without any test coverage. (No Need)
- [ ] Already covered by existing tests, such as *(please modify tests here)*.
- [x] Need tests and can be verified as follows:
    - Postman Test: the tests of `Kout Post` and `Single Source Shortest Path Get` are shown below

### Initialize the Graph
* Initialze the graph according to the [link](https://hugegraph.apache.org/docs/clients/restful-api/traverser/#32-detailed-explanation-of-traverser-api-1)


### Kout Post

* Method & Url
```
POST http://localhost:8080/graphs/{graph}/traversers/kout
```

#### with_vertex=false, with_edge=false
* Request Body
```json
{
  "source": "1:marko",
  "step": {
    "direction": "BOTH",
    "labels": ["knows", "created"],
    "properties": {
      "weight": "P.gt(0.1)"
    },
    "max_degree": 10000,
    "skip_degree": 100000
  },
  "max_depth": 1,
  "nearest": true,
  "limit": 10000,
  "with_vertex": false,
  "with_path": true,
  "with_edge": false
}
```

* Response Status
```
200
```

* Response Body
```json
{
    "kout": [
        "1:vadas",
        "1:josh",
        "2:lop"
    ],
    "size": 3,
    "paths": [
        {
            "objects": [
                "1:marko",
                "2:lop"
            ]
        },
        {
            "objects": [
                "1:marko",
                "1:josh"
            ]
        },
        {
            "objects": [
                "1:marko",
                "1:vadas"
            ]
        }
    ],
    "vertices": [
        "1:marko",
        "1:josh",
        "1:vadas",
        "2:lop"
    ],
    "edges": [
        "S1:marko>1>20160110>S1:vadas",
        "S1:marko>2>>S2:lop",
        "S1:marko>1>20130220>S1:josh"
    ],
    "measure": {
        "edge_iterations": 3,
        "vertice_iterations": 1,
        "cost": 72
    }
}
```

<img width="1494" alt="image" src="https://github.com/apache/incubator-hugegraph/assets/77946882/2c6e7ca8-afc6-42ef-a6db-d957b2f90879">

#### with_vertex=true, with_edge=true
* Request Body
```json
{
  "source": "1:marko",
  "step": {
    "direction": "BOTH",
    "labels": ["knows", "created"],
    "properties": {
      "weight": "P.gt(0.1)"
    },
    "max_degree": 10000,
    "skip_degree": 100000
  },
  "max_depth": 1,
  "nearest": true,
  "limit": 10000,
  "with_vertex": true,
  "with_path": true,
  "with_edge": true
}
```

* Response Status
```
200
```

* Response Body
```json
{
    "kneighbor": [
        "1:vadas",
        "1:josh",
        "2:lop",
        "1:peter",
        "2:ripple"
    ],
    "size": 5,
    "paths": [
        {
            "objects": [
                "1:marko",
                "2:lop"
            ]
        },
        {
            "objects": [
                "1:marko",
                "2:lop",
                "1:peter"
            ]
        },
        {
            "objects": [
                "1:marko",
                "1:josh"
            ]
        },
        {
            "objects": [
                "1:marko",
                "1:vadas"
            ]
        },
        {
            "objects": [
                "1:marko",
                "1:josh",
                "2:ripple"
            ]
        }
    ],
    "vertices": [
        {
            "id": "2:ripple",
            "label": "software",
            "type": "vertex",
            "properties": {
                "name": "ripple",
                "lang": "java",
                "price": 199
            }
        },
        {
            "id": "1:marko",
            "label": "person",
            "type": "vertex",
            "properties": {
                "name": "marko",
                "age": 29,
                "city": "Beijing"
            }
        },
        {
            "id": "1:josh",
            "label": "person",
            "type": "vertex",
            "properties": {
                "name": "josh",
                "age": 32,
                "city": "Beijing"
            }
        },
        {
            "id": "1:vadas",
            "label": "person",
            "type": "vertex",
            "properties": {
                "name": "vadas",
                "age": 27,
                "city": "Hongkong"
            }
        },
        {
            "id": "1:peter",
            "label": "person",
            "type": "vertex",
            "properties": {
                "name": "peter",
                "age": 35,
                "city": "Shanghai"
            }
        },
        {
            "id": "2:lop",
            "label": "software",
            "type": "vertex",
            "properties": {
                "name": "lop",
                "lang": "java",
                "price": 328
            }
        }
    ],
    "edges": [
        {
            "id": "S1:josh>2>>S2:ripple",
            "label": "created",
            "type": "edge",
            "outV": "1:josh",
            "outVLabel": "person",
            "inV": "2:ripple",
            "inVLabel": "software",
            "properties": {
                "weight": 1.0,
                "date": "20171210"
            }
        },
        {
            "id": "S1:marko>1>20160110>S1:vadas",
            "label": "knows",
            "type": "edge",
            "outV": "1:marko",
            "outVLabel": "person",
            "inV": "1:vadas",
            "inVLabel": "person",
            "properties": {
                "weight": 0.5,
                "date": "20160110"
            }
        },
        {
            "id": "S1:marko>2>>S2:lop",
            "label": "created",
            "type": "edge",
            "outV": "1:marko",
            "outVLabel": "person",
            "inV": "2:lop",
            "inVLabel": "software",
            "properties": {
                "weight": 0.4,
                "date": "20171210"
            }
        },
        {
            "id": "S1:marko>1>20130220>S1:josh",
            "label": "knows",
            "type": "edge",
            "outV": "1:marko",
            "outVLabel": "person",
            "inV": "1:josh",
            "inVLabel": "person",
            "properties": {
                "weight": 1.0,
                "date": "20130220"
            }
        },
        {
            "id": "S1:peter>2>>S2:lop",
            "label": "created",
            "type": "edge",
            "outV": "1:peter",
            "outVLabel": "person",
            "inV": "2:lop",
            "inVLabel": "software",
            "properties": {
                "weight": 0.2,
                "date": "20170324"
            }
        }
    ],
    "measure": {
        "edge_iterations": 12,
        "vertice_iterations": 12,
        "cost": 34
    }
}
```

<img width="1486" alt="image" src="https://github.com/apache/incubator-hugegraph/assets/77946882/85eec8e9-7e80-450c-9be6-06792dd4133c">


### Single Source Shortest Path Get

* Method & Url
```
http://localhost:8080/graphs/hugegraph/traversers/singlesourceshortestpath?source="1:marko"&with_vertex=false&with_edge=false&weight=weight
```

* Response Status
```
200
```

* Response Body
```json
{
    "paths": {
        "1:peter": {
            "weight": 0.6000000000000001,
            "vertices": [
                "1:marko",
                "2:lop",
                "1:peter"
            ]
        },
        "2:lop": {
            "weight": 0.4,
            "vertices": [
                "1:marko",
                "2:lop"
            ]
        },
        "1:josh": {
            "weight": 0.8,
            "vertices": [
                "1:marko",
                "2:lop",
                "1:josh"
            ]
        },
        "2:ripple": {
            "weight": 1.8,
            "vertices": [
                "1:marko",
                "2:lop",
                "1:josh",
                "2:ripple"
            ]
        },
        "1:vadas": {
            "weight": 0.5,
            "vertices": [
                "1:marko",
                "1:vadas"
            ]
        }
    },
    "vertices": [
        "1:peter",
        "2:lop",
        "1:josh",
        "2:ripple",
        "1:marko",
        "1:vadas"
    ],
    "edges": [
        "S1:josh>2>>S2:ripple",
        "S1:marko>1>20160110>S1:vadas",
        "S1:josh>2>>S2:lop",
        "S1:marko>2>>S2:lop",
        "S1:peter>2>>S2:lop"
    ],
    "measure": {
        "edge_iterations": 12,
        "vertice_iterations": 6,
        "cost": 16
    }
}
```

<img width="1483" alt="image" src="https://github.com/apache/incubator-hugegraph/assets/77946882/e49b4dee-b795-4c75-bb37-7b2c104fa1c4">


* Method & Url
```
http://localhost:8080/graphs/hugegraph/traversers/singlesourceshortestpath?source="1:marko"&with_vertex=true&with_edge=true&weight=weight
```

* Response Status
```
200
```

* Response Body
```json
{
    "paths": {
        "1:peter": {
            "weight": 0.6000000000000001,
            "vertices": [
                "1:marko",
                "2:lop",
                "1:peter"
            ]
        },
        "2:lop": {
            "weight": 0.4,
            "vertices": [
                "1:marko",
                "2:lop"
            ]
        },
        "1:josh": {
            "weight": 0.8,
            "vertices": [
                "1:marko",
                "2:lop",
                "1:josh"
            ]
        },
        "2:ripple": {
            "weight": 1.8,
            "vertices": [
                "1:marko",
                "2:lop",
                "1:josh",
                "2:ripple"
            ]
        },
        "1:vadas": {
            "weight": 0.5,
            "vertices": [
                "1:marko",
                "1:vadas"
            ]
        }
    },
    "vertices": [
        {
            "id": "1:peter",
            "label": "person",
            "type": "vertex",
            "properties": {
                "name": "peter",
                "age": 35,
                "city": "Shanghai"
            }
        },
        {
            "id": "2:lop",
            "label": "software",
            "type": "vertex",
            "properties": {
                "name": "lop",
                "lang": "java",
                "price": 328
            }
        },
        {
            "id": "1:josh",
            "label": "person",
            "type": "vertex",
            "properties": {
                "name": "josh",
                "age": 32,
                "city": "Beijing"
            }
        },
        {
            "id": "2:ripple",
            "label": "software",
            "type": "vertex",
            "properties": {
                "name": "ripple",
                "lang": "java",
                "price": 199
            }
        },
        {
            "id": "1:marko",
            "label": "person",
            "type": "vertex",
            "properties": {
                "name": "marko",
                "age": 29,
                "city": "Beijing"
            }
        },
        {
            "id": "1:vadas",
            "label": "person",
            "type": "vertex",
            "properties": {
                "name": "vadas",
                "age": 27,
                "city": "Hongkong"
            }
        }
    ],
    "edges": [
        {
            "id": "S1:josh>2>>S2:ripple",
            "label": "created",
            "type": "edge",
            "outV": "1:josh",
            "outVLabel": "person",
            "inV": "2:ripple",
            "inVLabel": "software",
            "properties": {
                "weight": 1.0,
                "date": "20171210"
            }
        },
        {
            "id": "S1:marko>1>20160110>S1:vadas",
            "label": "knows",
            "type": "edge",
            "outV": "1:marko",
            "outVLabel": "person",
            "inV": "1:vadas",
            "inVLabel": "person",
            "properties": {
                "weight": 0.5,
                "date": "20160110"
            }
        },
        {
            "id": "S1:josh>2>>S2:lop",
            "label": "created",
            "type": "edge",
            "outV": "1:josh",
            "outVLabel": "person",
            "inV": "2:lop",
            "inVLabel": "software",
            "properties": {
                "weight": 0.4,
                "date": "20091111"
            }
        },
        {
            "id": "S1:marko>2>>S2:lop",
            "label": "created",
            "type": "edge",
            "outV": "1:marko",
            "outVLabel": "person",
            "inV": "2:lop",
            "inVLabel": "software",
            "properties": {
                "weight": 0.4,
                "date": "20171210"
            }
        },
        {
            "id": "S1:peter>2>>S2:lop",
            "label": "created",
            "type": "edge",
            "outV": "1:peter",
            "outVLabel": "person",
            "inV": "2:lop",
            "inVLabel": "software",
            "properties": {
                "weight": 0.2,
                "date": "20170324"
            }
        }
    ],
    "measure": {
        "edge_iterations": 12,
        "vertice_iterations": 12,
        "cost": 2
    }
}
```

<img width="1480" alt="image" src="https://github.com/apache/incubator-hugegraph/assets/77946882/1cc33945-cf66-4e4b-99fe-5acae05c4710">


## Does this PR potentially affect the following parts?

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ]  Nope
- [ ]  Dependencies (add/update license info) <!-- Don't forget to add/update the info in "LICENSE" & "NOTICE" files (both in root & dist module) -->
- [ ]  Modify configurations
- [x]  The public API
- [ ]  Other affects (typed here)

## Documentation Status

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [x]  `Doc - TODO` <!-- Your PR changes impact docs and you will update later -->
- [ ]  `Doc - Done` <!-- Related docs have been already added or updated -->
- [ ]  `Doc - No Need` <!-- Your PR changes don't impact/need docs -->
