### PR TITLE
feat(api-core): support label & property filtering for both edge and vertex & support kout dfs mode

### DIFF
--- a/hugegraph-api/src/main/java/org/apache/hugegraph/api/traversers/KneighborAPI.java
+++ b/hugegraph-api/src/main/java/org/apache/hugegraph/api/traversers/KneighborAPI.java
@@ -37,7 +37,7 @@ import org.apache.hugegraph.structure.HugeVertex;
 import org.apache.hugegraph.traversal.algorithm.HugeTraverser;
 import org.apache.hugegraph.traversal.algorithm.KneighborTraverser;
 import org.apache.hugegraph.traversal.algorithm.records.KneighborRecords;
-import org.apache.hugegraph.traversal.algorithm.steps.EdgeStep;
+import org.apache.hugegraph.traversal.algorithm.steps.Steps;
 import org.apache.hugegraph.type.define.Directions;
 import org.apache.hugegraph.util.E;
 import org.apache.hugegraph.util.Log;
@@ -120,7 +120,7 @@ public class KneighborAPI extends TraverserAPI {
         E.checkArgumentNotNull(request, "The request body can't be null");
         E.checkArgumentNotNull(request.source,
                                "The source of request can't be null");
-        E.checkArgument(request.step != null,
+        E.checkArgument(request.steps != null,
                         "The steps of request can't be null");
         if (request.countOnly) {
             E.checkArgument(!request.withVertex && !request.withPath && !request.withEdge,
@@ -128,9 +128,9 @@ public class KneighborAPI extends TraverserAPI {
         }
 
         LOG.debug("Graph [{}] get customized kneighbor from source vertex " +
-                  "'{}', with step '{}', limit '{}', count_only '{}', " +
+                  "'{}', with steps '{}', limit '{}', count_only '{}', " +
                   "with_vertex '{}', with_path '{}' and with_edge '{}'",
-                  graph, request.source, request.step, request.limit,
+                  graph, request.source, request.steps, request.limit,
                   request.countOnly, request.withVertex, request.withPath,
                   request.withEdge);
 
@@ -139,11 +139,11 @@ public class KneighborAPI extends TraverserAPI {
         HugeGraph g = graph(manager, graph);
         Id sourceId = HugeVertex.getIdValue(request.source);
 
-        EdgeStep step = step(g, request.step);
+        Steps steps = steps(g, request.steps);
 
         KneighborRecords results;
         try (KneighborTraverser traverser = new KneighborTraverser(g)) {
-            results = traverser.customizedKneighbor(sourceId, step,
+            results = traverser.customizedKneighbor(sourceId, steps,
                                                     request.maxDepth,
                                                     request.limit);
             measure.addIterCount(traverser.vertexIterCounter.get(),
@@ -202,8 +202,8 @@ public class KneighborAPI extends TraverserAPI {
 
         @JsonProperty("source")
         public Object source;
-        @JsonProperty("step")
-        public TraverserAPI.Step step;
+        @JsonProperty("steps")
+        public TraverserAPI.VESteps steps;
         @JsonProperty("max_depth")
         public int maxDepth;
         @JsonProperty("limit")
@@ -219,9 +219,9 @@ public class KneighborAPI extends TraverserAPI {
 
         @Override
         public String toString() {
-            return String.format("PathRequest{source=%s,step=%s,maxDepth=%s" +
+            return String.format("PathRequest{source=%s,steps=%s,maxDepth=%s" +
                                  "limit=%s,countOnly=%s,withVertex=%s," +
-                                 "withPath=%s,withEdge=%s}", this.source, this.step,
+                                 "withPath=%s,withEdge=%s}", this.source, this.steps,
                                  this.maxDepth, this.limit, this.countOnly,
                                  this.withVertex, this.withPath, this.withEdge);
         }

--- a/hugegraph-api/src/main/java/org/apache/hugegraph/api/traversers/KoutAPI.java
+++ b/hugegraph-api/src/main/java/org/apache/hugegraph/api/traversers/KoutAPI.java
@@ -38,7 +38,7 @@ import org.apache.hugegraph.structure.HugeVertex;
 import org.apache.hugegraph.traversal.algorithm.HugeTraverser;
 import org.apache.hugegraph.traversal.algorithm.KoutTraverser;
 import org.apache.hugegraph.traversal.algorithm.records.KoutRecords;
-import org.apache.hugegraph.traversal.algorithm.steps.EdgeStep;
+import org.apache.hugegraph.traversal.algorithm.steps.Steps;
 import org.apache.hugegraph.type.define.Directions;
 import org.apache.hugegraph.util.E;
 import org.apache.hugegraph.util.Log;
@@ -126,18 +126,19 @@ public class KoutAPI extends TraverserAPI {
         E.checkArgumentNotNull(request, "The request body can't be null");
         E.checkArgumentNotNull(request.source,
                                "The source of request can't be null");
-        E.checkArgument(request.step != null,
+        E.checkArgument(request.steps != null,
                         "The steps of request can't be null");
         if (request.countOnly) {
             E.checkArgument(!request.withVertex && !request.withPath && !request.withEdge,
                             "Can't return vertex, edge or path when count only");
         }
+        HugeTraverser.checkAlgorithm(request.algorithm);
 
         LOG.debug("Graph [{}] get customized kout from source vertex '{}', " +
-                  "with step '{}', max_depth '{}', nearest '{}', " +
+                  "with steps '{}', max_depth '{}', nearest '{}', " +
                   "count_only '{}', capacity '{}', limit '{}', " +
                   "with_vertex '{}', with_path '{}' and with_edge '{}'",
-                  graph, request.source, request.step, request.maxDepth,
+                  graph, request.source, request.steps, request.maxDepth,
                   request.nearest, request.countOnly, request.capacity,
                   request.limit, request.withVertex, request.withPath,
                   request.withEdge);
@@ -147,14 +148,22 @@ public class KoutAPI extends TraverserAPI {
         HugeGraph g = graph(manager, graph);
         Id sourceId = HugeVertex.getIdValue(request.source);
 
-        EdgeStep step = step(g, request.step);
+        Steps steps = steps(g, request.steps);
         KoutRecords results;
         try (KoutTraverser traverser = new KoutTraverser(g)) {
-            results = traverser.customizedKout(sourceId, step,
-                                               request.maxDepth,
-                                               request.nearest,
-                                               request.capacity,
-                                               request.limit);
+            if (HugeTraverser.isDFSAlgorithm(request.algorithm)) {
+                results = traverser.DFSKout(sourceId, steps,
+                                            request.maxDepth,
+                                            request.nearest,
+                                            request.capacity,
+                                            request.limit);
+            } else {
+                results = traverser.customizedKout(sourceId, steps,
+                                                   request.maxDepth,
+                                                   request.nearest,
+                                                   request.capacity,
+                                                   request.limit);
+            }
             measure.addIterCount(traverser.vertexIterCounter.get(),
                                  traverser.edgeIterCounter.get());
         }
@@ -172,7 +181,7 @@ public class KoutAPI extends TraverserAPI {
 
         if (request.countOnly) {
             return manager.serializer(g, measure.measures())
-                          .writeNodesWithPath("kneighbor", neighbors, size, paths,
+                          .writeNodesWithPath("kout", neighbors, size, paths,
                                               QueryResults.emptyIterator(),
                                               QueryResults.emptyIterator());
         }
@@ -210,8 +219,8 @@ public class KoutAPI extends TraverserAPI {
 
         @JsonProperty("source")
         public Object source;
-        @JsonProperty("step")
-        public TraverserAPI.Step step;
+        @JsonProperty("steps")
+        public TraverserAPI.VESteps steps;
         @JsonProperty("max_depth")
         public int maxDepth;
         @JsonProperty("nearest")
@@ -229,15 +238,19 @@ public class KoutAPI extends TraverserAPI {
         @JsonProperty("with_edge")
         public boolean withEdge = false;
 
+        @JsonProperty("algorithm")
+        public String algorithm = HugeTraverser.ALGORITHM_BFS;
+
         @Override
         public String toString() {
-            return String.format("KoutRequest{source=%s,step=%s,maxDepth=%s" +
+            return String.format("KoutRequest{source=%s,steps=%s,maxDepth=%s" +
                                  "nearest=%s,countOnly=%s,capacity=%s," +
                                  "limit=%s,withVertex=%s,withPath=%s," +
-                                 "withEdge=%s}", this.source, this.step,
-                                 this.maxDepth, this.nearest, this.countOnly,
-                                 this.capacity, this.limit, this.withVertex,
-                                 this.withPath, this.withEdge);
+                                 "withEdge=%s,algorithm=%s}", this.source,
+                                 this.steps, this.maxDepth, this.nearest,
+                                 this.countOnly, this.capacity, this.limit,
+                                 this.withVertex, this.withPath, this.withEdge,
+                                 this.algorithm);
         }
     }
 }

--- a/hugegraph-api/src/main/java/org/apache/hugegraph/api/traversers/KoutAPI.java
+++ b/hugegraph-api/src/main/java/org/apache/hugegraph/api/traversers/KoutAPI.java
@@ -152,7 +152,7 @@ public class KoutAPI extends TraverserAPI {
         KoutRecords results;
         try (KoutTraverser traverser = new KoutTraverser(g)) {
             if (HugeTraverser.isDFSAlgorithm(request.algorithm)) {
-                results = traverser.DFSKout(sourceId, steps,
+                results = traverser.dfsKout(sourceId, steps,
                                             request.maxDepth,
                                             request.nearest,
                                             request.capacity,

--- a/hugegraph-api/src/main/java/org/apache/hugegraph/api/traversers/KoutAPI.java
+++ b/hugegraph-api/src/main/java/org/apache/hugegraph/api/traversers/KoutAPI.java
@@ -132,7 +132,7 @@ public class KoutAPI extends TraverserAPI {
             E.checkArgument(!request.withVertex && !request.withPath && !request.withEdge,
                             "Can't return vertex, edge or path when count only");
         }
-        HugeTraverser.checkAlgorithm(request.algorithm);
+        HugeTraverser.checkTraverseMode(request.algorithm);
 
         LOG.debug("Graph [{}] get customized kout from source vertex '{}', " +
                   "with steps '{}', max_depth '{}', nearest '{}', " +
@@ -239,7 +239,7 @@ public class KoutAPI extends TraverserAPI {
         public boolean withEdge = false;
 
         @JsonProperty("algorithm")
-        public String algorithm = HugeTraverser.ALGORITHM_BFS;
+        public String algorithm = HugeTraverser.TRAVERSE_MODE_BFS;
 
         @Override
         public String toString() {

--- a/hugegraph-api/src/main/java/org/apache/hugegraph/api/traversers/KoutAPI.java
+++ b/hugegraph-api/src/main/java/org/apache/hugegraph/api/traversers/KoutAPI.java
@@ -132,7 +132,7 @@ public class KoutAPI extends TraverserAPI {
             E.checkArgument(!request.withVertex && !request.withPath && !request.withEdge,
                             "Can't return vertex, edge or path when count only");
         }
-        HugeTraverser.checkTraverseMode(request.algorithm);
+        HugeTraverser.checkTraverseMode(request.traverse_mode);
 
         LOG.debug("Graph [{}] get customized kout from source vertex '{}', " +
                   "with steps '{}', max_depth '{}', nearest '{}', " +
@@ -151,7 +151,7 @@ public class KoutAPI extends TraverserAPI {
         Steps steps = steps(g, request.steps);
         KoutRecords results;
         try (KoutTraverser traverser = new KoutTraverser(g)) {
-            if (HugeTraverser.isTraverseModeDFS(request.algorithm)) {
+            if (HugeTraverser.isTraverseModeDFS(request.traverse_mode)) {
                 results = traverser.dfsKout(sourceId, steps,
                                             request.maxDepth,
                                             request.nearest,
@@ -237,19 +237,19 @@ public class KoutAPI extends TraverserAPI {
         public boolean withPath = false;
         @JsonProperty("with_edge")
         public boolean withEdge = false;
-        @JsonProperty("algorithm")
-        public String algorithm = HugeTraverser.TRAVERSE_MODE_BFS;
+        @JsonProperty("traverse_mode")
+        public String traverse_mode = HugeTraverser.TRAVERSE_MODE_BFS;
 
         @Override
         public String toString() {
             return String.format("KoutRequest{source=%s,steps=%s,maxDepth=%s" +
                                  "nearest=%s,countOnly=%s,capacity=%s," +
                                  "limit=%s,withVertex=%s,withPath=%s," +
-                                 "withEdge=%s,algorithm=%s}", this.source,
+                                 "withEdge=%s,traverse_mode=%s}", this.source,
                                  this.steps, this.maxDepth, this.nearest,
                                  this.countOnly, this.capacity, this.limit,
                                  this.withVertex, this.withPath, this.withEdge,
-                                 this.algorithm);
+                                 this.traverse_mode);
         }
     }
 }

--- a/hugegraph-api/src/main/java/org/apache/hugegraph/api/traversers/KoutAPI.java
+++ b/hugegraph-api/src/main/java/org/apache/hugegraph/api/traversers/KoutAPI.java
@@ -151,7 +151,7 @@ public class KoutAPI extends TraverserAPI {
         Steps steps = steps(g, request.steps);
         KoutRecords results;
         try (KoutTraverser traverser = new KoutTraverser(g)) {
-            if (HugeTraverser.isDFSAlgorithm(request.algorithm)) {
+            if (HugeTraverser.isTraverseModeDFS(request.algorithm)) {
                 results = traverser.dfsKout(sourceId, steps,
                                             request.maxDepth,
                                             request.nearest,

--- a/hugegraph-api/src/main/java/org/apache/hugegraph/api/traversers/KoutAPI.java
+++ b/hugegraph-api/src/main/java/org/apache/hugegraph/api/traversers/KoutAPI.java
@@ -237,7 +237,6 @@ public class KoutAPI extends TraverserAPI {
         public boolean withPath = false;
         @JsonProperty("with_edge")
         public boolean withEdge = false;
-
         @JsonProperty("algorithm")
         public String algorithm = HugeTraverser.TRAVERSE_MODE_BFS;
 

--- a/hugegraph-api/src/main/java/org/apache/hugegraph/api/traversers/KoutAPI.java
+++ b/hugegraph-api/src/main/java/org/apache/hugegraph/api/traversers/KoutAPI.java
@@ -132,7 +132,7 @@ public class KoutAPI extends TraverserAPI {
             E.checkArgument(!request.withVertex && !request.withPath && !request.withEdge,
                             "Can't return vertex, edge or path when count only");
         }
-        HugeTraverser.checkTraverseMode(request.traverse_mode);
+        HugeTraverser.checkTraverseMode(request.traverseMode);
 
         LOG.debug("Graph [{}] get customized kout from source vertex '{}', " +
                   "with steps '{}', max_depth '{}', nearest '{}', " +
@@ -151,7 +151,7 @@ public class KoutAPI extends TraverserAPI {
         Steps steps = steps(g, request.steps);
         KoutRecords results;
         try (KoutTraverser traverser = new KoutTraverser(g)) {
-            if (HugeTraverser.isTraverseModeDFS(request.traverse_mode)) {
+            if (HugeTraverser.isTraverseModeDFS(request.traverseMode)) {
                 results = traverser.dfsKout(sourceId, steps,
                                             request.maxDepth,
                                             request.nearest,
@@ -238,18 +238,18 @@ public class KoutAPI extends TraverserAPI {
         @JsonProperty("with_edge")
         public boolean withEdge = false;
         @JsonProperty("traverse_mode")
-        public String traverse_mode = HugeTraverser.TRAVERSE_MODE_BFS;
+        public String traverseMode = HugeTraverser.TRAVERSE_MODE_BFS;
 
         @Override
         public String toString() {
             return String.format("KoutRequest{source=%s,steps=%s,maxDepth=%s" +
                                  "nearest=%s,countOnly=%s,capacity=%s," +
                                  "limit=%s,withVertex=%s,withPath=%s," +
-                                 "withEdge=%s,traverse_mode=%s}", this.source,
+                                 "withEdge=%s,traverseMode=%s}", this.source,
                                  this.steps, this.maxDepth, this.nearest,
                                  this.countOnly, this.capacity, this.limit,
                                  this.withVertex, this.withPath, this.withEdge,
-                                 this.traverse_mode);
+                                 this.traverseMode);
         }
     }
 }

--- a/hugegraph-api/src/main/java/org/apache/hugegraph/api/traversers/TraverserAPI.java
+++ b/hugegraph-api/src/main/java/org/apache/hugegraph/api/traversers/TraverserAPI.java
@@ -19,13 +19,16 @@ package org.apache.hugegraph.api.traversers;
 
 import static org.apache.hugegraph.traversal.algorithm.HugeTraverser.DEFAULT_MAX_DEGREE;
 
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
 import org.apache.hugegraph.HugeGraph;
 import org.apache.hugegraph.api.API;
 import org.apache.hugegraph.traversal.algorithm.steps.EdgeStep;
+import org.apache.hugegraph.traversal.algorithm.steps.Steps;
 import org.apache.hugegraph.type.define.Directions;
+
 import com.fasterxml.jackson.annotation.JsonAlias;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
@@ -34,6 +37,25 @@ public class TraverserAPI extends API {
     protected static EdgeStep step(HugeGraph graph, Step step) {
         return new EdgeStep(graph, step.direction, step.labels, step.properties,
                             step.maxDegree, step.skipDegree);
+    }
+
+    protected static Steps steps(HugeGraph graph, VESteps steps) {
+        Map<String, Map<String, Object>> vSteps = new HashMap<>();
+        if (steps.vSteps != null) {
+            for (VEStepEntity vStep : steps.vSteps) {
+                vSteps.put(vStep.label, vStep.properties);
+            }
+        }
+
+        Map<String, Map<String, Object>> eSteps = new HashMap<>();
+        if (steps.eSteps != null) {
+            for (VEStepEntity eStep : steps.eSteps) {
+                eSteps.put(eStep.label, eStep.properties);
+            }
+        }
+
+        return new Steps(graph, steps.direction, vSteps, eSteps,
+                         steps.maxDegree, steps.skipDegree);
     }
 
     protected static class Step {
@@ -56,6 +78,44 @@ public class TraverserAPI extends API {
                                  "maxDegree=%s,skipDegree=%s}",
                                  this.direction, this.labels, this.properties,
                                  this.maxDegree, this.skipDegree);
+        }
+    }
+
+    protected static class VEStepEntity {
+
+        @JsonProperty("label")
+        public String label;
+
+        @JsonProperty("properties")
+        public Map<String, Object> properties;
+
+        @Override
+        public String toString() {
+            return String.format("VEStepEntity{label=%s,properties=%s}",
+                                 this.label, this.properties);
+        }
+    }
+
+    protected static class VESteps {
+
+        @JsonProperty("direction")
+        public Directions direction;
+        @JsonAlias("degree")
+        @JsonProperty("max_degree")
+        public long maxDegree = Long.parseLong(DEFAULT_MAX_DEGREE);
+        @JsonProperty("skip_degree")
+        public long skipDegree = 0L;
+        @JsonProperty("vertex_steps")
+        public List<VEStepEntity> vSteps;
+        @JsonProperty("edge_steps")
+        public List<VEStepEntity> eSteps;
+
+        @Override
+        public String toString() {
+            return String.format("Steps{direction=%s,maxDegree=%s," +
+                                 "skipDegree=%s,vSteps=%s,eSteps=%s}",
+                                 this.direction, this.maxDegree,
+                                 this.skipDegree, this.vSteps, this.eSteps);
         }
     }
 }

--- a/hugegraph-core/src/main/java/org/apache/hugegraph/backend/query/Query.java
+++ b/hugegraph-core/src/main/java/org/apache/hugegraph/backend/query/Query.java
@@ -50,7 +50,7 @@ public class Query implements Cloneable {
     public static final long NO_CAPACITY = -1L;
     public static final long DEFAULT_CAPACITY = 800000L; // HugeGraph-777
 
-    private static final ThreadLocal<Long> CAPACITY_CONTEXT = new ThreadLocal<>();
+    protected static final ThreadLocal<Long> CAPACITY_CONTEXT = new ThreadLocal<>();
 
     protected static final Query NONE = new Query(HugeType.UNKNOWN);
 
@@ -99,6 +99,25 @@ public class Query implements Cloneable {
         this.showExpired = false;
         this.olap = false;
         this.olapPks = EMPTY_OLAP_PKS;
+    }
+
+    public static long defaultCapacity(long capacity) {
+        Long old = CAPACITY_CONTEXT.get();
+        CAPACITY_CONTEXT.set(capacity);
+        return old != null ? old : DEFAULT_CAPACITY;
+    }
+
+    public static long defaultCapacity() {
+        Long capacity = CAPACITY_CONTEXT.get();
+        return capacity != null ? capacity : DEFAULT_CAPACITY;
+    }
+
+    public static void checkForceCapacity(long count) throws LimitExceedException {
+        if (count > Query.DEFAULT_CAPACITY) {
+            throw new LimitExceedException(
+                    "Too many records(must <= %s) for one query",
+                    Query.DEFAULT_CAPACITY);
+        }
     }
 
     public void copyBasic(Query query) {
@@ -306,6 +325,7 @@ public class Query implements Cloneable {
     /**
      * Set or update the offset and limit by a range [start, end)
      * NOTE: it will use the min range one: max start and min end
+     *
      * @param start the range start, include it
      * @param end   the range end, exclude it
      */
@@ -401,8 +421,8 @@ public class Query implements Cloneable {
                 query = query.substring(0, MAX_CHARS) + "...";
             }
             throw new LimitExceedException(
-                      "Too many records(must <= %s) for the query: %s",
-                      this.capacity, query);
+                    "Too many records(must <= %s) for the query: %s",
+                    this.capacity, query);
         }
     }
 
@@ -558,25 +578,6 @@ public class Query implements Cloneable {
 
         sb.append('`');
         return sb.toString();
-    }
-
-    public static long defaultCapacity(long capacity) {
-        Long old = CAPACITY_CONTEXT.get();
-        CAPACITY_CONTEXT.set(capacity);
-        return old != null ? old : DEFAULT_CAPACITY;
-    }
-
-    public static long defaultCapacity() {
-        Long capacity = CAPACITY_CONTEXT.get();
-        return capacity != null ? capacity : DEFAULT_CAPACITY;
-    }
-
-    public static void checkForceCapacity(long count) throws LimitExceedException {
-        if (count > Query.DEFAULT_CAPACITY) {
-            throw new LimitExceedException(
-                      "Too many records(must <= %s) for one query",
-                      Query.DEFAULT_CAPACITY);
-        }
     }
 
     public enum Order {

--- a/hugegraph-core/src/main/java/org/apache/hugegraph/backend/query/Query.java
+++ b/hugegraph-core/src/main/java/org/apache/hugegraph/backend/query/Query.java
@@ -50,7 +50,7 @@ public class Query implements Cloneable {
     public static final long NO_CAPACITY = -1L;
     public static final long DEFAULT_CAPACITY = 800000L; // HugeGraph-777
 
-    protected static final ThreadLocal<Long> CAPACITY_CONTEXT = new ThreadLocal<>();
+    private static final ThreadLocal<Long> CAPACITY_CONTEXT = new ThreadLocal<>();
 
     protected static final Query NONE = new Query(HugeType.UNKNOWN);
 
@@ -99,25 +99,6 @@ public class Query implements Cloneable {
         this.showExpired = false;
         this.olap = false;
         this.olapPks = EMPTY_OLAP_PKS;
-    }
-
-    public static long defaultCapacity(long capacity) {
-        Long old = CAPACITY_CONTEXT.get();
-        CAPACITY_CONTEXT.set(capacity);
-        return old != null ? old : DEFAULT_CAPACITY;
-    }
-
-    public static long defaultCapacity() {
-        Long capacity = CAPACITY_CONTEXT.get();
-        return capacity != null ? capacity : DEFAULT_CAPACITY;
-    }
-
-    public static void checkForceCapacity(long count) throws LimitExceedException {
-        if (count > Query.DEFAULT_CAPACITY) {
-            throw new LimitExceedException(
-                    "Too many records(must <= %s) for one query",
-                    Query.DEFAULT_CAPACITY);
-        }
     }
 
     public void copyBasic(Query query) {
@@ -578,6 +559,25 @@ public class Query implements Cloneable {
 
         sb.append('`');
         return sb.toString();
+    }
+
+    public static long defaultCapacity(long capacity) {
+        Long old = CAPACITY_CONTEXT.get();
+        CAPACITY_CONTEXT.set(capacity);
+        return old != null ? old : DEFAULT_CAPACITY;
+    }
+
+    public static long defaultCapacity() {
+        Long capacity = CAPACITY_CONTEXT.get();
+        return capacity != null ? capacity : DEFAULT_CAPACITY;
+    }
+
+    public static void checkForceCapacity(long count) throws LimitExceedException {
+        if (count > Query.DEFAULT_CAPACITY) {
+            throw new LimitExceedException(
+                    "Too many records(must <= %s) for one query",
+                    Query.DEFAULT_CAPACITY);
+        }
     }
 
     public enum Order {

--- a/hugegraph-core/src/main/java/org/apache/hugegraph/backend/query/Query.java
+++ b/hugegraph-core/src/main/java/org/apache/hugegraph/backend/query/Query.java
@@ -402,8 +402,8 @@ public class Query implements Cloneable {
                 query = query.substring(0, MAX_CHARS) + "...";
             }
             throw new LimitExceedException(
-                    "Too many records(must <= %s) for the query: %s",
-                    this.capacity, query);
+                      "Too many records(must <= %s) for the query: %s",
+                      this.capacity, query);
         }
     }
 
@@ -575,8 +575,8 @@ public class Query implements Cloneable {
     public static void checkForceCapacity(long count) throws LimitExceedException {
         if (count > Query.DEFAULT_CAPACITY) {
             throw new LimitExceedException(
-                    "Too many records(must <= %s) for one query",
-                    Query.DEFAULT_CAPACITY);
+                      "Too many records(must <= %s) for one query",
+                      Query.DEFAULT_CAPACITY);
         }
     }
 

--- a/hugegraph-core/src/main/java/org/apache/hugegraph/backend/tx/GraphTransaction.java
+++ b/hugegraph-core/src/main/java/org/apache/hugegraph/backend/tx/GraphTransaction.java
@@ -1729,9 +1729,12 @@ public class GraphTransaction extends IndexableTransaction {
                 return false;
             }
             // Process results that query from left index or primary-key
-            // Only index query will come here
-            return query.resultType().isVertex() != elem.type().isVertex() ||
-                   rightResultFromIndexQuery(query, elem);
+            if (query.resultType().isVertex() == elem.type().isVertex() &&
+                !rightResultFromIndexQuery(query, elem)) {
+                // Only index query will come here
+                return false;
+            }
+            return true;
         });
     }
 

--- a/hugegraph-core/src/main/java/org/apache/hugegraph/backend/tx/GraphTransaction.java
+++ b/hugegraph-core/src/main/java/org/apache/hugegraph/backend/tx/GraphTransaction.java
@@ -1218,8 +1218,8 @@ public class GraphTransaction extends IndexableTransaction {
         // Edge direction
         if (direction == Directions.BOTH) {
             query.query(Condition.or(
-                    Condition.eq(HugeKeys.DIRECTION, Directions.OUT),
-                    Condition.eq(HugeKeys.DIRECTION, Directions.IN)));
+                        Condition.eq(HugeKeys.DIRECTION, Directions.OUT),
+                        Condition.eq(HugeKeys.DIRECTION, Directions.IN)));
         } else {
             assert direction == Directions.OUT || direction == Directions.IN;
             query.eq(HugeKeys.DIRECTION, direction);
@@ -1380,8 +1380,8 @@ public class GraphTransaction extends IndexableTransaction {
 
         if (matched != total) {
             throw new HugeException(
-                    "Not supported querying edges by %s, expect %s",
-                    query.conditions(), EdgeId.KEYS[count]);
+                      "Not supported querying edges by %s, expect %s",
+                      query.conditions(), EdgeId.KEYS[count]);
         }
     }
 
@@ -1614,7 +1614,7 @@ public class GraphTransaction extends IndexableTransaction {
             HugeGraph graph = this.graph();
 
             E.checkArgument(false, "All non-null property keys %s of " +
-                                            "vertex label '%s' must be set, missed keys %s",
+                            "vertex label '%s' must be set, missed keys %s",
                             graph.mapPkId2Name(nonNullKeys), vertexLabel.name(),
                             graph.mapPkId2Name(missed));
         }

--- a/hugegraph-core/src/main/java/org/apache/hugegraph/backend/tx/GraphTransaction.java
+++ b/hugegraph-core/src/main/java/org/apache/hugegraph/backend/tx/GraphTransaction.java
@@ -104,23 +104,7 @@ public class GraphTransaction extends IndexableTransaction {
     public static final int COMMIT_BATCH = (int) Query.COMMIT_BATCH;
 
     private final GraphIndexTransaction indexTx;
-
-    private Map<Id, HugeVertex> addedVertices;
-    private Map<Id, HugeVertex> removedVertices;
-
-    private Map<Id, HugeEdge> addedEdges;
-    private Map<Id, HugeEdge> removedEdges;
-
-    private Set<HugeProperty<?>> addedProps;
-    private Set<HugeProperty<?>> removedProps;
-
-    // These are used to rollback state
-    private Map<Id, HugeVertex> updatedVertices;
-    private Map<Id, HugeEdge> updatedEdges;
-    private Set<HugeProperty<?>> updatedOldestProps; // Oldest props
-
     private final LockUtil.LocksTable locksTable;
-
     private final boolean checkCustomVertexExist;
     private final boolean checkAdjacentVertexExist;
     private final boolean lazyLoadAdjacentVertex;
@@ -130,9 +114,18 @@ public class GraphTransaction extends IndexableTransaction {
     private final int commitPartOfAdjacentEdges;
     private final int batchSize;
     private final int pageSize;
-
     private final int verticesCapacity;
     private final int edgesCapacity;
+    private Map<Id, HugeVertex> addedVertices;
+    private Map<Id, HugeVertex> removedVertices;
+    private Map<Id, HugeEdge> addedEdges;
+    private Map<Id, HugeEdge> removedEdges;
+    private Set<HugeProperty<?>> addedProps;
+    private Set<HugeProperty<?>> removedProps;
+    // These are used to rollback state
+    private Map<Id, HugeVertex> updatedVertices;
+    private Map<Id, HugeEdge> updatedEdges;
+    private Set<HugeProperty<?>> updatedOldestProps; // Oldest props
 
     public GraphTransaction(HugeGraphParams graph, BackendStore store) {
         super(graph, store);
@@ -144,19 +137,19 @@ public class GraphTransaction extends IndexableTransaction {
 
         final HugeConfig conf = graph.configuration();
         this.checkCustomVertexExist =
-             conf.get(CoreOptions.VERTEX_CHECK_CUSTOMIZED_ID_EXIST);
+                conf.get(CoreOptions.VERTEX_CHECK_CUSTOMIZED_ID_EXIST);
         this.checkAdjacentVertexExist =
-             conf.get(CoreOptions.VERTEX_ADJACENT_VERTEX_EXIST);
+                conf.get(CoreOptions.VERTEX_ADJACENT_VERTEX_EXIST);
         this.lazyLoadAdjacentVertex =
-             conf.get(CoreOptions.VERTEX_ADJACENT_VERTEX_LAZY);
+                conf.get(CoreOptions.VERTEX_ADJACENT_VERTEX_LAZY);
         this.removeLeftIndexOnOverwrite =
-             conf.get(CoreOptions.VERTEX_REMOVE_LEFT_INDEX);
+                conf.get(CoreOptions.VERTEX_REMOVE_LEFT_INDEX);
         this.commitPartOfAdjacentEdges =
-             conf.get(CoreOptions.VERTEX_PART_EDGE_COMMIT_SIZE);
+                conf.get(CoreOptions.VERTEX_PART_EDGE_COMMIT_SIZE);
         this.ignoreInvalidEntry =
-             conf.get(CoreOptions.QUERY_IGNORE_INVALID_DATA);
+                conf.get(CoreOptions.QUERY_IGNORE_INVALID_DATA);
         this.optimizeAggrByIndex =
-             conf.get(CoreOptions.QUERY_OPTIMIZE_AGGR_BY_INDEX);
+                conf.get(CoreOptions.QUERY_OPTIMIZE_AGGR_BY_INDEX);
         this.batchSize = conf.get(CoreOptions.QUERY_BATCH_SIZE);
         this.pageSize = conf.get(CoreOptions.QUERY_PAGE_SIZE);
 
@@ -169,6 +162,199 @@ public class GraphTransaction extends IndexableTransaction {
                         this.commitPartOfAdjacentEdges,
                         CoreOptions.EDGE_TX_CAPACITY.name(),
                         this.edgesCapacity);
+    }
+
+    /**
+     * Construct one edge condition query based on source vertex, direction and
+     * edge labels
+     *
+     * @param sourceVertex source vertex of edge
+     * @param direction    only be "IN", "OUT" or "BOTH"
+     * @param edgeLabels   edge labels of queried edges
+     * @return constructed condition query
+     */
+    @Watched
+    public static ConditionQuery constructEdgesQuery(Id sourceVertex,
+                                                     Directions direction,
+                                                     Id... edgeLabels) {
+        E.checkState(sourceVertex != null,
+                     "The edge query must contain source vertex");
+        E.checkState(direction != null,
+                     "The edge query must contain direction");
+
+        ConditionQuery query = new ConditionQuery(HugeType.EDGE);
+
+        // Edge source vertex
+        query.eq(HugeKeys.OWNER_VERTEX, sourceVertex);
+
+        // Edge direction
+        if (direction == Directions.BOTH) {
+            query.query(Condition.or(
+                    Condition.eq(HugeKeys.DIRECTION, Directions.OUT),
+                    Condition.eq(HugeKeys.DIRECTION, Directions.IN)));
+        } else {
+            assert direction == Directions.OUT || direction == Directions.IN;
+            query.eq(HugeKeys.DIRECTION, direction);
+        }
+
+        // Edge labels
+        if (edgeLabels.length == 1) {
+            query.eq(HugeKeys.LABEL, edgeLabels[0]);
+        } else if (edgeLabels.length > 1) {
+            query.query(Condition.in(HugeKeys.LABEL,
+                                     Arrays.asList(edgeLabels)));
+        }
+
+        return query;
+    }
+
+    public static ConditionQuery constructEdgesQuery(Id sourceVertex,
+                                                     Directions direction,
+                                                     List<Id> edgeLabels) {
+        E.checkState(sourceVertex != null,
+                     "The edge query must contain source vertex");
+        E.checkState(direction != null,
+                     "The edge query must contain direction");
+
+        ConditionQuery query = new ConditionQuery(HugeType.EDGE);
+
+        // Edge source vertex
+        query.eq(HugeKeys.OWNER_VERTEX, sourceVertex);
+
+        // Edge direction
+        if (direction == Directions.BOTH) {
+            query.query(Condition.or(
+                    Condition.eq(HugeKeys.DIRECTION, Directions.OUT),
+                    Condition.eq(HugeKeys.DIRECTION, Directions.IN)));
+        } else {
+            assert direction == Directions.OUT || direction == Directions.IN;
+            query.eq(HugeKeys.DIRECTION, direction);
+        }
+
+        // Edge labels
+        if (edgeLabels.size() == 1) {
+            query.eq(HugeKeys.LABEL, edgeLabels.get(0));
+        } else if (edgeLabels.size() > 1) {
+            query.query(Condition.in(HugeKeys.LABEL, edgeLabels));
+        }
+
+        return query;
+    }
+
+    public static boolean matchFullEdgeSortKeys(ConditionQuery query,
+                                                HugeGraph graph) {
+        // All queryKeys in sortKeys
+        return matchEdgeSortKeys(query, true, graph);
+    }
+
+    public static boolean matchPartialEdgeSortKeys(ConditionQuery query,
+                                                   HugeGraph graph) {
+        // Partial queryKeys in sortKeys
+        return matchEdgeSortKeys(query, false, graph);
+    }
+
+    private static boolean matchEdgeSortKeys(ConditionQuery query,
+                                             boolean matchAll,
+                                             HugeGraph graph) {
+        assert query.resultType().isEdge();
+        Id label = query.condition(HugeKeys.LABEL);
+        if (label == null) {
+            return false;
+        }
+        List<Id> sortKeys = graph.edgeLabel(label).sortKeys();
+        if (sortKeys.isEmpty()) {
+            return false;
+        }
+        Set<Id> queryKeys = query.userpropKeys();
+        for (int i = sortKeys.size(); i > 0; i--) {
+            List<Id> subFields = sortKeys.subList(0, i);
+            if (queryKeys.containsAll(subFields)) {
+                if (queryKeys.size() == subFields.size() || !matchAll) {
+                    /*
+                     * Return true if:
+                     * matchAll=true and all queryKeys are in sortKeys
+                     *  or
+                     * partial queryKeys are in sortKeys
+                     */
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+    private static void verifyVerticesConditionQuery(ConditionQuery query) {
+        assert query.resultType().isVertex();
+
+        int total = query.conditionsSize();
+        if (total == 1) {
+            /*
+             * Supported query:
+             *  1.query just by vertex label
+             *  2.query just by PROPERTIES (like containsKey,containsValue)
+             *  3.query with scan
+             */
+            if (query.containsCondition(HugeKeys.LABEL) ||
+                query.containsCondition(HugeKeys.PROPERTIES) ||
+                query.containsScanRelation()) {
+                return;
+            }
+        }
+
+        int matched = 0;
+        if (query.containsCondition(HugeKeys.PROPERTIES)) {
+            matched++;
+            if (query.containsCondition(HugeKeys.LABEL)) {
+                matched++;
+            }
+        }
+
+        if (matched != total) {
+            throw new HugeException("Not supported querying vertices by %s",
+                                    query.conditions());
+        }
+    }
+
+    private static void verifyEdgesConditionQuery(ConditionQuery query) {
+        assert query.resultType().isEdge();
+
+        int total = query.conditionsSize();
+        if (total == 1) {
+            /*
+             * Supported query:
+             *  1.query just by edge label
+             *  2.query just by PROPERTIES (like containsKey,containsValue)
+             *  3.query with scan
+             */
+            if (query.containsCondition(HugeKeys.LABEL) ||
+                query.containsCondition(HugeKeys.PROPERTIES) ||
+                query.containsScanRelation()) {
+                return;
+            }
+        }
+
+        int matched = 0;
+        for (HugeKeys key : EdgeId.KEYS) {
+            Object value = query.condition(key);
+            if (value == null) {
+                break;
+            }
+            matched++;
+        }
+        int count = matched;
+
+        if (query.containsCondition(HugeKeys.PROPERTIES)) {
+            matched++;
+            if (count < 3 && query.containsCondition(HugeKeys.LABEL)) {
+                matched++;
+            }
+        }
+
+        if (matched != total) {
+            throw new HugeException(
+                    "Not supported querying edges by %s, expect %s",
+                    query.conditions(), EdgeId.KEYS[count]);
+        }
     }
 
     @Override
@@ -444,7 +630,7 @@ public class GraphTransaction extends IndexableTransaction {
                     // Eliminate the property(OUT and IN owner edge)
                     this.doEliminate(this.serializer.writeEdgeProperty(prop));
                     this.doEliminate(this.serializer.writeEdgeProperty(
-                                     prop.switchEdgeOwner()));
+                            prop.switchEdgeOwner()));
                 } else {
                     // Override edge(it will be in addedEdges & updatedEdges)
                     this.addEdge(prop.element());
@@ -473,7 +659,7 @@ public class GraphTransaction extends IndexableTransaction {
                     // Append new property(OUT and IN owner edge)
                     this.doAppend(this.serializer.writeEdgeProperty(prop));
                     this.doAppend(this.serializer.writeEdgeProperty(
-                                  prop.switchEdgeOwner()));
+                            prop.switchEdgeOwner()));
                 } else {
                     // Override edge (it will be in addedEdges & updatedEdges)
                     this.addEdge(prop.element());
@@ -535,7 +721,7 @@ public class GraphTransaction extends IndexableTransaction {
         QueryList<BackendEntry> queries = this.optimizeQueries(query, super::query);
         LOG.debug("{}", queries);
         return queries.empty() ? QueryResults.empty() :
-                                 queries.fetch(this.pageSize);
+               queries.fetch(this.pageSize);
     }
 
     @Override
@@ -690,7 +876,7 @@ public class GraphTransaction extends IndexableTransaction {
         // Override vertices in local `addedVertices`
         this.addedVertices.remove(vertex.id());
         // Force load vertex to ensure all properties are loaded (refer to #2181)
-        if (vertex.schemaLabel().indexLabels().size() > 0)  {
+        if (vertex.schemaLabel().indexLabels().size() > 0) {
             vertex.forceLoad();
         }
         // Collect the removed vertex
@@ -776,7 +962,7 @@ public class GraphTransaction extends IndexableTransaction {
             if (vertex == null) {
                 if (checkMustExist) {
                     throw new NotFoundException(
-                              "Vertex '%s' does not exist", id);
+                            "Vertex '%s' does not exist", id);
                 } else if (adjacentVertex) {
                     assert !checkMustExist;
                     // Return undefined if adjacentVertex but !checkMustExist
@@ -937,7 +1123,7 @@ public class GraphTransaction extends IndexableTransaction {
                  * local vertex and duplicated id.
                  */
                 Iterator<HugeEdge> it = this.queryEdgesFromBackend(query);
-                @SuppressWarnings({ "unchecked", "rawtypes" })
+                @SuppressWarnings({"unchecked", "rawtypes"})
                 Iterator<Edge> r = (Iterator) it;
                 return r;
             }
@@ -1018,9 +1204,7 @@ public class GraphTransaction extends IndexableTransaction {
             if (vertex == null) {
                 return null;
             }
-            if (query.idsSize() == 1) {
-                assert vertex.getEdges().size() == 1;
-            }
+            assert query.idsSize() != 1 || vertex.getEdges().size() == 1;
             /*
              * Copy to avoid ConcurrentModificationException when removing edge
              * because HugeEdge.remove() will update edges in owner vertex
@@ -1192,167 +1376,6 @@ public class GraphTransaction extends IndexableTransaction {
         });
     }
 
-    /**
-     * Construct one edge condition query based on source vertex, direction and
-     * edge labels
-     * @param sourceVertex source vertex of edge
-     * @param direction only be "IN", "OUT" or "BOTH"
-     * @param edgeLabels edge labels of queried edges
-     * @return constructed condition query
-     */
-    @Watched
-    public static ConditionQuery constructEdgesQuery(Id sourceVertex,
-                                                     Directions direction,
-                                                     Id... edgeLabels) {
-        E.checkState(sourceVertex != null,
-                     "The edge query must contain source vertex");
-        E.checkState(direction != null,
-                     "The edge query must contain direction");
-
-        ConditionQuery query = new ConditionQuery(HugeType.EDGE);
-
-        // Edge source vertex
-        query.eq(HugeKeys.OWNER_VERTEX, sourceVertex);
-
-        // Edge direction
-        if (direction == Directions.BOTH) {
-            query.query(Condition.or(
-                        Condition.eq(HugeKeys.DIRECTION, Directions.OUT),
-                        Condition.eq(HugeKeys.DIRECTION, Directions.IN)));
-        } else {
-            assert direction == Directions.OUT || direction == Directions.IN;
-            query.eq(HugeKeys.DIRECTION, direction);
-        }
-
-        // Edge labels
-        if (edgeLabels.length == 1) {
-            query.eq(HugeKeys.LABEL, edgeLabels[0]);
-        } else if (edgeLabels.length > 1) {
-            query.query(Condition.in(HugeKeys.LABEL,
-                                     Arrays.asList(edgeLabels)));
-        } else {
-            assert edgeLabels.length == 0;
-        }
-
-        return query;
-    }
-
-    public static boolean matchFullEdgeSortKeys(ConditionQuery query,
-                                                HugeGraph graph) {
-        // All queryKeys in sortKeys
-        return matchEdgeSortKeys(query, true, graph);
-    }
-
-    public static boolean matchPartialEdgeSortKeys(ConditionQuery query,
-                                                   HugeGraph graph) {
-        // Partial queryKeys in sortKeys
-        return matchEdgeSortKeys(query, false, graph);
-    }
-
-    private static boolean matchEdgeSortKeys(ConditionQuery query,
-                                             boolean matchAll,
-                                             HugeGraph graph) {
-        assert query.resultType().isEdge();
-        Id label = query.condition(HugeKeys.LABEL);
-        if (label == null) {
-            return false;
-        }
-        List<Id> sortKeys = graph.edgeLabel(label).sortKeys();
-        if (sortKeys.isEmpty()) {
-            return false;
-        }
-        Set<Id> queryKeys = query.userpropKeys();
-        for (int i = sortKeys.size(); i > 0; i--) {
-            List<Id> subFields = sortKeys.subList(0, i);
-            if (queryKeys.containsAll(subFields)) {
-                if (queryKeys.size() == subFields.size() || !matchAll) {
-                    /*
-                     * Return true if:
-                     * matchAll=true and all queryKeys are in sortKeys
-                     *  or
-                     * partial queryKeys are in sortKeys
-                     */
-                    return true;
-                }
-            }
-        }
-        return false;
-    }
-
-    private static void verifyVerticesConditionQuery(ConditionQuery query) {
-        assert query.resultType().isVertex();
-
-        int total = query.conditionsSize();
-        if (total == 1) {
-            /*
-             * Supported query:
-             *  1.query just by vertex label
-             *  2.query just by PROPERTIES (like containsKey,containsValue)
-             *  3.query with scan
-             */
-            if (query.containsCondition(HugeKeys.LABEL) ||
-                query.containsCondition(HugeKeys.PROPERTIES) ||
-                query.containsScanRelation()) {
-                return;
-            }
-        }
-
-        int matched = 0;
-        if (query.containsCondition(HugeKeys.PROPERTIES)) {
-            matched++;
-            if (query.containsCondition(HugeKeys.LABEL)) {
-                matched++;
-            }
-        }
-
-        if (matched != total) {
-            throw new HugeException("Not supported querying vertices by %s",
-                                    query.conditions());
-        }
-    }
-
-    private static void verifyEdgesConditionQuery(ConditionQuery query) {
-        assert query.resultType().isEdge();
-
-        int total = query.conditionsSize();
-        if (total == 1) {
-            /*
-             * Supported query:
-             *  1.query just by edge label
-             *  2.query just by PROPERTIES (like containsKey,containsValue)
-             *  3.query with scan
-             */
-            if (query.containsCondition(HugeKeys.LABEL) ||
-                query.containsCondition(HugeKeys.PROPERTIES) ||
-                query.containsScanRelation()) {
-                return;
-            }
-        }
-
-        int matched = 0;
-        for (HugeKeys key : EdgeId.KEYS) {
-            Object value = query.condition(key);
-            if (value == null) {
-                break;
-            }
-            matched++;
-        }
-        int count = matched;
-
-        if (query.containsCondition(HugeKeys.PROPERTIES)) {
-            matched++;
-            if (count < 3 && query.containsCondition(HugeKeys.LABEL)) {
-                matched++;
-            }
-        }
-
-        if (matched != total) {
-            throw new HugeException(
-                      "Not supported querying edges by %s, expect %s",
-                      query.conditions(), EdgeId.KEYS[count]);
-        }
-    }
-
     private <R> QueryList<R> optimizeQueries(Query query,
                                              QueryResults.Fetcher<R> fetcher) {
         QueryList<R> queries = new QueryList<>(query, fetcher);
@@ -1363,8 +1386,8 @@ public class GraphTransaction extends IndexableTransaction {
         }
 
         boolean supportIn = this.storeFeatures().supportsQueryWithInCondition();
-        for (ConditionQuery cq: ConditionQueryFlatten.flatten(
-                                (ConditionQuery) query, supportIn)) {
+        for (ConditionQuery cq : ConditionQueryFlatten.flatten(
+                (ConditionQuery) query, supportIn)) {
             // Optimize by sysprop
             Query q = this.optimizeQuery(cq);
             /*
@@ -1384,10 +1407,10 @@ public class GraphTransaction extends IndexableTransaction {
     private Query optimizeQuery(ConditionQuery query) {
         if (query.idsSize() > 0) {
             throw new HugeException(
-                      "Not supported querying by id and conditions: %s", query);
+                    "Not supported querying by id and conditions: %s", query);
         }
 
-        Id label = (Id) query.condition(HugeKeys.LABEL);
+        Id label = query.condition(HugeKeys.LABEL);
 
         // Optimize vertex query
         if (label != null && query.resultType().isVertex()) {
@@ -1426,7 +1449,7 @@ public class GraphTransaction extends IndexableTransaction {
             // Serialize sort-values
             List<Id> keys = this.graph().edgeLabel(label).sortKeys();
             List<Condition> conditions =
-                            GraphIndexTransaction.constructShardConditions(
+                    GraphIndexTransaction.constructShardConditions(
                             query, keys, HugeKeys.SORT_VALUES);
             query.query(conditions);
             /*
@@ -1574,14 +1597,14 @@ public class GraphTransaction extends IndexableTransaction {
         // Check whether passed all non-null property
         @SuppressWarnings("unchecked")
         Collection<Id> nonNullKeys = CollectionUtils.subtract(
-                                     vertexLabel.properties(),
-                                     vertexLabel.nullableKeys());
+                vertexLabel.properties(),
+                vertexLabel.nullableKeys());
         if (!keys.containsAll(nonNullKeys)) {
             @SuppressWarnings("unchecked")
             Collection<Id> missed = CollectionUtils.subtract(nonNullKeys, keys);
             HugeGraph graph = this.graph();
             E.checkArgument(false, "All non-null property keys %s of " +
-                            "vertex label '%s' must be set, missed keys %s",
+                                   "vertex label '%s' must be set, missed keys %s",
                             graph.mapPkId2Name(nonNullKeys), vertexLabel.name(),
                             graph.mapPkId2Name(missed));
         }
@@ -1608,11 +1631,11 @@ public class GraphTransaction extends IndexableTransaction {
             HugeVertex newVertex = vertices.get(existedVertex.id());
             if (!existedVertex.label().equals(newVertex.label())) {
                 throw new HugeException(
-                          "The newly added vertex with id:'%s' label:'%s' " +
-                          "is not allowed to insert, because already exist " +
-                          "a vertex with same id and different label:'%s'",
-                          newVertex.id(), newVertex.label(),
-                          existedVertex.label());
+                        "The newly added vertex with id:'%s' label:'%s' " +
+                        "is not allowed to insert, because already exist " +
+                        "a vertex with same id and different label:'%s'",
+                        newVertex.id(), newVertex.label(),
+                        existedVertex.label());
             }
         } finally {
             CloseableIterator.closeIterator(results);
@@ -1676,8 +1699,8 @@ public class GraphTransaction extends IndexableTransaction {
     }
 
     private <T extends HugeElement> Iterator<T> filterUnmatchedRecords(
-                                                Iterator<T> results,
-                                                Query query) {
+            Iterator<T> results,
+            Query query) {
         // Filter unused or incorrect records
         return new FilterIterator<T>(results, elem -> {
             // TODO: Left vertex/edge should to be auto removed via async task
@@ -1696,12 +1719,9 @@ public class GraphTransaction extends IndexableTransaction {
                 return false;
             }
             // Process results that query from left index or primary-key
-            if (query.resultType().isVertex() == elem.type().isVertex() &&
-                !rightResultFromIndexQuery(query, elem)) {
-                // Only index query will come here
-                return false;
-            }
-            return true;
+            // Only index query will come here
+            return query.resultType().isVertex() != elem.type().isVertex() ||
+                   rightResultFromIndexQuery(query, elem);
         });
     }
 
@@ -1753,7 +1773,7 @@ public class GraphTransaction extends IndexableTransaction {
     }
 
     private <T extends HugeElement> Iterator<T> filterExpiredResultFromBackend(
-                                    Query query, Iterator<T> results) {
+            Query query, Iterator<T> results) {
         if (this.store().features().supportsTtl() || query.showExpired()) {
             return results;
         }
@@ -1803,9 +1823,9 @@ public class GraphTransaction extends IndexableTransaction {
             // Filter vertices matched conditions
             return q.test(v) ? v : null;
         };
-        vertices =  this.joinTxRecords(query, vertices, matchTxFunc,
-                                       this.addedVertices, this.removedVertices,
-                                       this.updatedVertices);
+        vertices = this.joinTxRecords(query, vertices, matchTxFunc,
+                                      this.addedVertices, this.removedVertices,
+                                      this.updatedVertices);
         return vertices;
     }
 
@@ -1839,12 +1859,12 @@ public class GraphTransaction extends IndexableTransaction {
     }
 
     private <V extends HugeElement> Iterator<V> joinTxRecords(
-                                    Query query,
-                                    Iterator<V> records,
-                                    BiFunction<Query, V, V> matchFunc,
-                                    Map<Id, V> addedTxRecords,
-                                    Map<Id, V> removedTxRecords,
-                                    Map<Id, V> updatedTxRecords) {
+            Query query,
+            Iterator<V> records,
+            BiFunction<Query, V, V> matchFunc,
+            Map<Id, V> addedTxRecords,
+            Map<Id, V> removedTxRecords,
+            Map<Id, V> updatedTxRecords) {
         this.checkOwnerThread();
         // Return the origin results if there is no change in tx
         if (addedTxRecords.isEmpty() &&
@@ -1890,16 +1910,16 @@ public class GraphTransaction extends IndexableTransaction {
     private void checkTxVerticesCapacity() throws LimitExceedException {
         if (this.verticesInTxSize() >= this.verticesCapacity) {
             throw new LimitExceedException(
-                      "Vertices size has reached tx capacity %d",
-                      this.verticesCapacity);
+                    "Vertices size has reached tx capacity %d",
+                    this.verticesCapacity);
         }
     }
 
     private void checkTxEdgesCapacity() throws LimitExceedException {
         if (this.edgesInTxSize() >= this.edgesCapacity) {
             throw new LimitExceedException(
-                      "Edges size has reached tx capacity %d",
-                      this.edgesCapacity);
+                    "Edges size has reached tx capacity %d",
+                    this.edgesCapacity);
         }
     }
 
@@ -2042,7 +2062,7 @@ public class GraphTransaction extends IndexableTransaction {
         HugeType type = label.type() == HugeType.VERTEX_LABEL ?
                         HugeType.VERTEX : HugeType.EDGE;
         Query query = label.enableLabelIndex() ? new ConditionQuery(type) :
-                                                 new Query(type);
+                      new Query(type);
         query.capacity(Query.NO_CAPACITY);
         query.limit(Query.NO_LIMIT);
         if (this.store().features().supportsQueryByPage()) {

--- a/hugegraph-core/src/main/java/org/apache/hugegraph/traversal/algorithm/HugeTraverser.java
+++ b/hugegraph-core/src/main/java/org/apache/hugegraph/traversal/algorithm/HugeTraverser.java
@@ -536,19 +536,19 @@ public class HugeTraverser {
 
     private Map<Id, ConditionQuery> getElementFilterQuery(
             Map<Id, Steps.StepEntity> idStepEntityMap, HugeType type) {
-        Map<Id, ConditionQuery> vertexConditions = new HashMap<>();
+        Map<Id, ConditionQuery> conditions = new HashMap<>();
         for (Map.Entry<Id, Steps.StepEntity> entry : idStepEntityMap.entrySet()) {
             Steps.StepEntity stepEntity = entry.getValue();
             if (stepEntity.getProperties() != null && !stepEntity.getProperties().isEmpty()) {
                 ConditionQuery cq = new ConditionQuery(type);
                 Map<Id, Object> properties = stepEntity.getProperties();
                 TraversalUtil.fillConditionQuery(cq, properties, this.graph);
-                vertexConditions.put(entry.getKey(), cq);
+                conditions.put(entry.getKey(), cq);
             } else {
-                vertexConditions.put(entry.getKey(), null);
+                conditions.put(entry.getKey(), null);
             }
         }
-        return vertexConditions;
+        return conditions;
     }
 
     private void fillFilterBySortKeys(Query query, Id[] edgeLabels,

--- a/hugegraph-core/src/main/java/org/apache/hugegraph/traversal/algorithm/HugeTraverser.java
+++ b/hugegraph-core/src/main/java/org/apache/hugegraph/traversal/algorithm/HugeTraverser.java
@@ -178,8 +178,8 @@ public class HugeTraverser {
                         TRAVERSE_MODE_BFS, TRAVERSE_MODE_DFS, traverseMode);
     }
 
-    public static boolean isTraverseModeDFS(String traverse_mode) {
-        return traverse_mode.compareToIgnoreCase(TRAVERSE_MODE_DFS) == 0;
+    public static boolean isTraverseModeDFS(String traverseMode) {
+        return traverseMode.compareToIgnoreCase(TRAVERSE_MODE_DFS) == 0;
     }
 
     public static <K, V extends Comparable<? super V>> Map<K, V> topN(

--- a/hugegraph-core/src/main/java/org/apache/hugegraph/traversal/algorithm/HugeTraverser.java
+++ b/hugegraph-core/src/main/java/org/apache/hugegraph/traversal/algorithm/HugeTraverser.java
@@ -1089,6 +1089,7 @@ public class HugeTraverser {
                 this.cachePointer++;
                 this.currentIterator =
                         traverser.edgesOfVertex(this.currentEdge.id().otherVertexId(), steps);
+                this.traverser.vertexIterCounter.addAndGet(1L);
 
             }
             return true;

--- a/hugegraph-core/src/main/java/org/apache/hugegraph/traversal/algorithm/HugeTraverser.java
+++ b/hugegraph-core/src/main/java/org/apache/hugegraph/traversal/algorithm/HugeTraverser.java
@@ -537,6 +537,7 @@ public class HugeTraverser {
     private Map<Id, ConditionQuery> getFilterQueryConditions(
             Map<Id, Steps.StepEntity> idStepEntityMap, HugeType type) {
         Map<Id, ConditionQuery> conditions = new HashMap<>();
+
         for (Map.Entry<Id, Steps.StepEntity> entry : idStepEntityMap.entrySet()) {
             Steps.StepEntity stepEntity = entry.getValue();
             if (stepEntity.properties() != null && !stepEntity.properties().isEmpty()) {
@@ -628,9 +629,7 @@ public class HugeTraverser {
 
     public Iterator<Edge> createNestedIterator(Id sourceV, Steps steps,
                                                int depth, Set<Id> visited, boolean nearest) {
-        E.checkArgument(depth > 0,
-                        "The depth should large than 0 for nested iterator");
-
+        E.checkArgument(depth > 0, "The depth should large than 0 for nested iterator");
         visited.add(sourceV);
 
         // build a chained iterator path with length of depth

--- a/hugegraph-core/src/main/java/org/apache/hugegraph/traversal/algorithm/HugeTraverser.java
+++ b/hugegraph-core/src/main/java/org/apache/hugegraph/traversal/algorithm/HugeTraverser.java
@@ -89,7 +89,7 @@ public class HugeTraverser {
     // Empirical value of scan limit, with which results can be returned in 3s
     public static final String DEFAULT_PAGE_LIMIT = "100000";
     public static final long NO_LIMIT = -1L;
-    // algorithms
+    // kout traverse mode algorithms: bfs and dfs
     public static final String TRAVERSE_MODE_BFS = "breadth_first_search";
     public static final String TRAVERSE_MODE_DFS = "depth_first_search";
     protected static final Logger LOG = Log.logger(HugeTraverser.class);
@@ -178,7 +178,7 @@ public class HugeTraverser {
                         TRAVERSE_MODE_BFS, TRAVERSE_MODE_DFS, traverseMode);
     }
 
-    public static boolean isDFSAlgorithm(String algorithm) {
+    public static boolean isTraverseModeDFS(String algorithm) {
         return algorithm.compareToIgnoreCase(TRAVERSE_MODE_DFS) == 0;
     }
 

--- a/hugegraph-core/src/main/java/org/apache/hugegraph/traversal/algorithm/HugeTraverser.java
+++ b/hugegraph-core/src/main/java/org/apache/hugegraph/traversal/algorithm/HugeTraverser.java
@@ -90,8 +90,8 @@ public class HugeTraverser {
     public static final String DEFAULT_PAGE_LIMIT = "100000";
     public static final long NO_LIMIT = -1L;
     // algorithms
-    public static final String ALGORITHM_BFS = "breadth_first_search";
-    public static final String ALGORITHM_DFS = "depth_first_search";
+    public static final String TRAVERSE_MODE_BFS = "breadth_first_search";
+    public static final String TRAVERSE_MODE_DFS = "depth_first_search";
     protected static final Logger LOG = Log.logger(HugeTraverser.class);
     protected static final int MAX_VERTICES = 10;
     private static CollectionFactory collectionFactory;
@@ -171,15 +171,15 @@ public class HugeTraverser {
         }
     }
 
-    public static void checkAlgorithm(String algorithm) {
-        E.checkArgument(algorithm.compareToIgnoreCase(ALGORITHM_BFS) == 0 ||
-                        algorithm.compareToIgnoreCase(ALGORITHM_DFS) == 0,
-                        "The algorithm must be one of '%s' or '%s', but got '%s'",
-                        ALGORITHM_BFS, ALGORITHM_DFS, algorithm);
+    public static void checkTraverseMode(String traverseMode) {
+        E.checkArgument(traverseMode.compareToIgnoreCase(TRAVERSE_MODE_BFS) == 0 ||
+                        traverseMode.compareToIgnoreCase(TRAVERSE_MODE_DFS) == 0,
+                        "The traverse mode must be one of '%s' or '%s', but got '%s'",
+                        TRAVERSE_MODE_BFS, TRAVERSE_MODE_DFS, traverseMode);
     }
 
     public static boolean isDFSAlgorithm(String algorithm) {
-        return algorithm.compareToIgnoreCase(ALGORITHM_DFS) == 0;
+        return algorithm.compareToIgnoreCase(TRAVERSE_MODE_DFS) == 0;
     }
 
     public static <K, V extends Comparable<? super V>> Map<K, V> topN(

--- a/hugegraph-core/src/main/java/org/apache/hugegraph/traversal/algorithm/HugeTraverser.java
+++ b/hugegraph-core/src/main/java/org/apache/hugegraph/traversal/algorithm/HugeTraverser.java
@@ -1003,7 +1003,5 @@ public class HugeTraverser {
             }
             return edges;
         }
-
     }
-
 }

--- a/hugegraph-core/src/main/java/org/apache/hugegraph/traversal/algorithm/HugeTraverser.java
+++ b/hugegraph-core/src/main/java/org/apache/hugegraph/traversal/algorithm/HugeTraverser.java
@@ -290,10 +290,10 @@ public class HugeTraverser {
         return path;
     }
 
-    public static List<HugeEdge> getPathEdges(Iterator<Edge> iterator, HugeEdge edge) {
+    public static List<HugeEdge> pathEdges(Iterator<Edge> iterator, HugeEdge edge) {
         List<HugeEdge> edges = new ArrayList<>();
         if (iterator instanceof NestedIterator) {
-            edges = ((NestedIterator) iterator).getPathEdges();
+            edges = ((NestedIterator) iterator).pathEdges();
         }
         edges.add(edge);
         return edges;
@@ -539,9 +539,9 @@ public class HugeTraverser {
         Map<Id, ConditionQuery> conditions = new HashMap<>();
         for (Map.Entry<Id, Steps.StepEntity> entry : idStepEntityMap.entrySet()) {
             Steps.StepEntity stepEntity = entry.getValue();
-            if (stepEntity.getProperties() != null && !stepEntity.getProperties().isEmpty()) {
+            if (stepEntity.properties() != null && !stepEntity.properties().isEmpty()) {
                 ConditionQuery cq = new ConditionQuery(type);
-                Map<Id, Object> properties = stepEntity.getProperties();
+                Map<Id, Object> properties = stepEntity.properties();
                 TraversalUtil.fillConditionQuery(cq, properties, this.graph);
                 conditions.put(entry.getKey(), cq);
             } else {
@@ -1121,25 +1121,25 @@ public class HugeTraverser {
             return this.cache.size() > this.cachePointer;
         }
 
-        public List<HugeEdge> getPathEdges() {
+        public List<HugeEdge> pathEdges() {
             List<HugeEdge> edges = new ArrayList<>();
             HugeEdge currentEdge = this.currentEdge;
             if (this.parentIterator instanceof NestedIterator) {
                 NestedIterator parent = (NestedIterator) this.parentIterator;
                 int parentEdgePointer = this.parentEdgePointerMap.get(makeEdgeIndex(currentEdge));
-                edges.addAll(parent.getPathEdges(parentEdgePointer));
+                edges.addAll(parent.pathEdges(parentEdgePointer));
             }
             edges.add(currentEdge);
             return edges;
         }
 
-        private List<HugeEdge> getPathEdges(int edgePointer) {
+        private List<HugeEdge> pathEdges(int edgePointer) {
             List<HugeEdge> edges = new ArrayList<>();
             HugeEdge edge = this.cache.get(edgePointer);
             if (this.parentIterator instanceof NestedIterator) {
                 NestedIterator parent = (NestedIterator) this.parentIterator;
                 int parentEdgePointer = this.parentEdgePointerMap.get(makeEdgeIndex(edge));
-                edges.addAll(parent.getPathEdges(parentEdgePointer));
+                edges.addAll(parent.pathEdges(parentEdgePointer));
             }
             edges.add(edge);
             return edges;

--- a/hugegraph-core/src/main/java/org/apache/hugegraph/traversal/algorithm/HugeTraverser.java
+++ b/hugegraph-core/src/main/java/org/apache/hugegraph/traversal/algorithm/HugeTraverser.java
@@ -89,7 +89,7 @@ public class HugeTraverser {
     // Empirical value of scan limit, with which results can be returned in 3s
     public static final String DEFAULT_PAGE_LIMIT = "100000";
     public static final long NO_LIMIT = -1L;
-    // kout traverse mode algorithms: bfs and dfs
+    // traverse mode of kout algorithm: bfs and dfs
     public static final String TRAVERSE_MODE_BFS = "breadth_first_search";
     public static final String TRAVERSE_MODE_DFS = "depth_first_search";
     protected static final Logger LOG = Log.logger(HugeTraverser.class);
@@ -178,8 +178,8 @@ public class HugeTraverser {
                         TRAVERSE_MODE_BFS, TRAVERSE_MODE_DFS, traverseMode);
     }
 
-    public static boolean isTraverseModeDFS(String algorithm) {
-        return algorithm.compareToIgnoreCase(TRAVERSE_MODE_DFS) == 0;
+    public static boolean isTraverseModeDFS(String traverse_mode) {
+        return traverse_mode.compareToIgnoreCase(TRAVERSE_MODE_DFS) == 0;
     }
 
     public static <K, V extends Comparable<? super V>> Map<K, V> topN(

--- a/hugegraph-core/src/main/java/org/apache/hugegraph/traversal/algorithm/KneighborTraverser.java
+++ b/hugegraph-core/src/main/java/org/apache/hugegraph/traversal/algorithm/KneighborTraverser.java
@@ -25,7 +25,7 @@ import org.apache.hugegraph.HugeGraph;
 import org.apache.hugegraph.backend.id.Id;
 import org.apache.hugegraph.structure.HugeEdge;
 import org.apache.hugegraph.traversal.algorithm.records.KneighborRecords;
-import org.apache.hugegraph.traversal.algorithm.steps.EdgeStep;
+import org.apache.hugegraph.traversal.algorithm.steps.Steps;
 import org.apache.hugegraph.type.define.Directions;
 import org.apache.hugegraph.util.E;
 import org.apache.tinkerpop.gremlin.structure.Edge;
@@ -69,7 +69,7 @@ public class KneighborTraverser extends OltpTraverser {
         return all;
     }
 
-    public KneighborRecords customizedKneighbor(Id source, EdgeStep step,
+    public KneighborRecords customizedKneighbor(Id source, Steps steps,
                                                 int maxDepth, long limit) {
         E.checkNotNull(source, "source vertex id");
         this.checkVertexExist(source, "source vertex");
@@ -85,7 +85,7 @@ public class KneighborTraverser extends OltpTraverser {
             if (this.reachLimit(limit, records.size())) {
                 return;
             }
-            Iterator<Edge> edges = edgesOfVertex(v, step);
+            Iterator<Edge> edges = edgesOfVertex(v, steps);
             this.vertexIterCounter.addAndGet(1L);
             while (!this.reachLimit(limit, records.size()) && edges.hasNext()) {
                 HugeEdge edge = (HugeEdge) edges.next();

--- a/hugegraph-core/src/main/java/org/apache/hugegraph/traversal/algorithm/KoutTraverser.java
+++ b/hugegraph-core/src/main/java/org/apache/hugegraph/traversal/algorithm/KoutTraverser.java
@@ -167,7 +167,6 @@ public class KoutTraverser extends OltpTraverser {
             }
         }
 
-        this.vertexIterCounter.addAndGet(all.size());
         return records;
     }
 

--- a/hugegraph-core/src/main/java/org/apache/hugegraph/traversal/algorithm/KoutTraverser.java
+++ b/hugegraph-core/src/main/java/org/apache/hugegraph/traversal/algorithm/KoutTraverser.java
@@ -138,7 +138,7 @@ public class KoutTraverser extends OltpTraverser {
         return records;
     }
 
-    public KoutRecords DFSKout(Id source, Steps steps,
+    public KoutRecords dfsKout(Id source, Steps steps,
                                int maxDepth, boolean nearest,
                                long capacity, long limit) {
         E.checkNotNull(source, "source vertex id");

--- a/hugegraph-core/src/main/java/org/apache/hugegraph/traversal/algorithm/KoutTraverser.java
+++ b/hugegraph-core/src/main/java/org/apache/hugegraph/traversal/algorithm/KoutTraverser.java
@@ -26,7 +26,7 @@ import org.apache.hugegraph.HugeGraph;
 import org.apache.hugegraph.backend.id.Id;
 import org.apache.hugegraph.structure.HugeEdge;
 import org.apache.hugegraph.traversal.algorithm.records.KoutRecords;
-import org.apache.hugegraph.traversal.algorithm.steps.EdgeStep;
+import org.apache.hugegraph.traversal.algorithm.steps.Steps;
 import org.apache.hugegraph.type.define.Directions;
 import org.apache.hugegraph.util.E;
 import org.apache.tinkerpop.gremlin.structure.Edge;
@@ -97,7 +97,7 @@ public class KoutTraverser extends OltpTraverser {
         return latest;
     }
 
-    public KoutRecords customizedKout(Id source, EdgeStep step,
+    public KoutRecords customizedKout(Id source, Steps steps,
                                       int maxDepth, boolean nearest,
                                       long capacity, long limit) {
         E.checkNotNull(source, "source vertex id");
@@ -109,13 +109,13 @@ public class KoutTraverser extends OltpTraverser {
         depth[0] = maxDepth;
         boolean concurrent = maxDepth >= this.concurrentDepth();
 
-        KoutRecords records = new KoutRecords(concurrent, source, nearest);
+        KoutRecords records = new KoutRecords(concurrent, source, nearest, 0);
 
         Consumer<Id> consumer = v -> {
             if (this.reachLimit(limit, depth[0], records.size())) {
                 return;
             }
-            Iterator<Edge> edges = edgesOfVertex(v, step);
+            Iterator<Edge> edges = edgesOfVertex(v, steps);
             this.vertexIterCounter.addAndGet(1L);
             while (!this.reachLimit(limit, depth[0], records.size()) &&
                    edges.hasNext()) {
@@ -135,6 +135,39 @@ public class KoutTraverser extends OltpTraverser {
             this.traverseIds(records.keys(), consumer, concurrent);
             records.finishOneLayer();
         }
+        return records;
+    }
+
+    public KoutRecords DFSKout(Id source, Steps steps,
+                               int maxDepth, boolean nearest,
+                               long capacity, long limit) {
+        E.checkNotNull(source, "source vertex id");
+        this.checkVertexExist(source, "source vertex");
+        checkPositive(maxDepth, "k-out max_depth");
+        checkCapacity(capacity);
+        checkLimit(limit);
+
+        Set<Id> all = newIdSet();
+        all.add(source);
+
+        KoutRecords records = new KoutRecords(false, source, nearest, maxDepth);
+        Iterator<Edge> iterator = this.createNestedIterator(source, steps, maxDepth, all, nearest);
+        while (iterator.hasNext()) {
+            HugeEdge edge = (HugeEdge) iterator.next();
+            this.edgeIterCounter.addAndGet(1L);
+
+            Id target = edge.id().otherVertexId();
+            if (!nearest || !all.contains(target)) {
+                records.addFullPath(HugeTraverser.getPathEdges(iterator, edge));
+            }
+
+            if (limit != NO_LIMIT && records.size() >= limit ||
+                capacity != NO_LIMIT && all.size() > capacity) {
+                break;
+            }
+        }
+
+        this.vertexIterCounter.addAndGet(all.size());
         return records;
     }
 

--- a/hugegraph-core/src/main/java/org/apache/hugegraph/traversal/algorithm/KoutTraverser.java
+++ b/hugegraph-core/src/main/java/org/apache/hugegraph/traversal/algorithm/KoutTraverser.java
@@ -158,7 +158,7 @@ public class KoutTraverser extends OltpTraverser {
 
             Id target = edge.id().otherVertexId();
             if (!nearest || !all.contains(target)) {
-                records.addFullPath(HugeTraverser.getPathEdges(iterator, edge));
+                records.addFullPath(HugeTraverser.pathEdges(iterator, edge));
             }
 
             if (limit != NO_LIMIT && records.size() >= limit ||

--- a/hugegraph-core/src/main/java/org/apache/hugegraph/traversal/algorithm/iterator/NestedIterator.java
+++ b/hugegraph-core/src/main/java/org/apache/hugegraph/traversal/algorithm/iterator/NestedIterator.java
@@ -1,0 +1,195 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with this
+ * work for additional information regarding copyright ownership. The ASF
+ * licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.hugegraph.traversal.algorithm.iterator;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.apache.hugegraph.backend.id.Id;
+import org.apache.hugegraph.iterator.WrappedIterator;
+import org.apache.hugegraph.structure.HugeEdge;
+import org.apache.hugegraph.traversal.algorithm.HugeTraverser;
+import org.apache.hugegraph.traversal.algorithm.steps.Steps;
+import org.apache.hugegraph.util.collection.ObjectIntMapping;
+import org.apache.hugegraph.util.collection.ObjectIntMappingFactory;
+import org.apache.tinkerpop.gremlin.structure.Edge;
+
+public class NestedIterator extends WrappedIterator<Edge> {
+
+    private final int MAX_CACHED_COUNT = 1000;
+    /*
+     * Set<Id> visited: visited vertex-ids of all parent-tree
+     * used to exclude visited vertex
+     */
+    private final boolean nearest;
+    private final Set<Id> visited;
+    private final int MAX_VISITED_COUNT = 100000;
+
+    // cache for edges, initial capacity to avoid memory fragment
+    private final List<HugeEdge> cache;
+    private final Map<Long, Integer> parentEdgePointerMap;
+
+    private final Iterator<Edge> parentIterator;
+    private final HugeTraverser traverser;
+    private final Steps steps;
+    private final ObjectIntMapping<Id> idMapping;
+    private HugeEdge currentEdge;
+    private int cachePointer;
+    private Iterator<Edge> currentIterator;
+
+    public NestedIterator(HugeTraverser traverser,
+                          Iterator<Edge> parentIterator,
+                          Steps steps,
+                          Set<Id> visited,
+                          boolean nearest) {
+        this.traverser = traverser;
+        this.parentIterator = parentIterator;
+        this.steps = steps;
+        this.visited = visited;
+        this.nearest = nearest;
+
+        this.cache = new ArrayList<>(MAX_CACHED_COUNT);
+        this.parentEdgePointerMap = new HashMap<>();
+
+        this.cachePointer = 0;
+        this.currentEdge = null;
+        this.currentIterator = null;
+
+        this.idMapping = ObjectIntMappingFactory.newObjectIntMapping(false);
+    }
+
+    private static Long makeVertexPairIndex(int source, int target) {
+        return ((long) source & 0xFFFFFFFFL) |
+               (((long) target << 32) & 0xFFFFFFFF00000000L);
+    }
+
+    @Override
+    public boolean hasNext() {
+        if (this.currentIterator == null || !this.currentIterator.hasNext()) {
+            return fetch();
+        }
+        return true;
+    }
+
+    @Override
+    public Edge next() {
+        return this.currentIterator.next();
+    }
+
+    @Override
+    protected Iterator<?> originIterator() {
+        return this.parentIterator;
+    }
+
+    @Override
+    protected boolean fetch() {
+        while (this.currentIterator == null || !this.currentIterator.hasNext()) {
+            if (this.currentIterator != null) {
+                this.currentIterator = null;
+            }
+
+            if (this.cache.size() == this.cachePointer && !this.fillCache()) {
+                return false;
+            }
+
+            this.currentEdge = this.cache.get(this.cachePointer);
+            this.cachePointer++;
+            this.currentIterator =
+                    traverser.edgesOfVertex(this.currentEdge.id().otherVertexId(), steps);
+            this.traverser.vertexIterCounter.addAndGet(1L);
+
+        }
+        return true;
+    }
+
+    private boolean fillCache() {
+        // fill cache from parent
+        while (this.parentIterator.hasNext() && this.cache.size() < MAX_CACHED_COUNT) {
+            HugeEdge edge = (HugeEdge) this.parentIterator.next();
+            Id vertexId = edge.id().otherVertexId();
+
+            this.traverser.edgeIterCounter.addAndGet(1L);
+
+            if (!this.nearest || !this.visited.contains(vertexId)) {
+                // update parent edge cache pointer
+                int parentEdgePointer = -1;
+                if (this.parentIterator instanceof NestedIterator) {
+                    parentEdgePointer = ((NestedIterator) this.parentIterator).currentEdgePointer();
+                }
+
+                this.parentEdgePointerMap.put(makeEdgeIndex(edge), parentEdgePointer);
+
+                this.cache.add(edge);
+                if (this.visited.size() < MAX_VISITED_COUNT) {
+                    this.visited.add(vertexId);
+                }
+            }
+        }
+        return this.cache.size() > this.cachePointer;
+    }
+
+    public List<HugeEdge> pathEdges() {
+        List<HugeEdge> edges = new ArrayList<>();
+        HugeEdge currentEdge = this.currentEdge;
+        if (this.parentIterator instanceof NestedIterator) {
+            NestedIterator parent = (NestedIterator) this.parentIterator;
+            int parentEdgePointer = this.parentEdgePointerMap.get(makeEdgeIndex(currentEdge));
+            edges.addAll(parent.pathEdges(parentEdgePointer));
+        }
+        edges.add(currentEdge);
+        return edges;
+    }
+
+    private List<HugeEdge> pathEdges(int edgePointer) {
+        List<HugeEdge> edges = new ArrayList<>();
+        HugeEdge edge = this.cache.get(edgePointer);
+        if (this.parentIterator instanceof NestedIterator) {
+            NestedIterator parent = (NestedIterator) this.parentIterator;
+            int parentEdgePointer = this.parentEdgePointerMap.get(makeEdgeIndex(edge));
+            edges.addAll(parent.pathEdges(parentEdgePointer));
+        }
+        edges.add(edge);
+        return edges;
+    }
+
+    public int currentEdgePointer() {
+        return this.cachePointer - 1;
+    }
+
+    private Long makeEdgeIndex(HugeEdge edge) {
+        int sourceV = this.code(edge.id().ownerVertexId());
+        int targetV = this.code(edge.id().otherVertexId());
+        return makeVertexPairIndex(sourceV, targetV);
+    }
+
+    private int code(Id id) {
+        if (id.number()) {
+            long l = id.asLong();
+            if (0 <= l && l <= Integer.MAX_VALUE) {
+                return (int) l;
+            }
+        }
+        int code = this.idMapping.object2Code(id);
+        assert code > 0;
+        return -code;
+    }
+}

--- a/hugegraph-core/src/main/java/org/apache/hugegraph/traversal/algorithm/iterator/NestedIterator.java
+++ b/hugegraph-core/src/main/java/org/apache/hugegraph/traversal/algorithm/iterator/NestedIterator.java
@@ -36,7 +36,7 @@ import org.apache.tinkerpop.gremlin.structure.Edge;
 public class NestedIterator extends WrappedIterator<Edge> {
 
     private final int MAX_CACHED_COUNT = 1000;
-    /*
+    /**
      * Set<Id> visited: visited vertex-ids of all parent-tree
      * used to exclude visited vertex
      */

--- a/hugegraph-core/src/main/java/org/apache/hugegraph/traversal/algorithm/records/KoutRecords.java
+++ b/hugegraph-core/src/main/java/org/apache/hugegraph/traversal/algorithm/records/KoutRecords.java
@@ -90,7 +90,7 @@ public class KoutRecords extends SingleWayMultiPathsRecords {
 
             assert (this.code(sourceV) == sourceCode);
 
-            this.getEdgeRecord().addEdge(sourceV, targetV, edge);
+            this.edgeResults().addEdge(sourceV, targetV, edge);
 
             targetCode = this.code(targetV);
             Record record = this.records().elementAt(i + 1);

--- a/hugegraph-core/src/main/java/org/apache/hugegraph/traversal/algorithm/records/KoutRecords.java
+++ b/hugegraph-core/src/main/java/org/apache/hugegraph/traversal/algorithm/records/KoutRecords.java
@@ -23,6 +23,7 @@ import java.util.List;
 import java.util.Stack;
 
 import org.apache.hugegraph.backend.id.Id;
+import org.apache.hugegraph.structure.HugeEdge;
 import org.apache.hugegraph.traversal.algorithm.HugeTraverser.PathSet;
 import org.apache.hugegraph.traversal.algorithm.records.record.Record;
 import org.apache.hugegraph.traversal.algorithm.records.record.RecordType;
@@ -32,8 +33,23 @@ import org.apache.hugegraph.util.collection.IntIterator;
 
 public class KoutRecords extends SingleWayMultiPathsRecords {
 
-    public KoutRecords(boolean concurrent, Id source, boolean nearest) {
+    // Non-zero depth is used for deepFirst traverse mode.
+    // In such case, startOneLayer/finishOneLayer should not be called,
+    // instead, we should use addFullPath
+    private final int depth;
+
+    public KoutRecords(boolean concurrent, Id source, boolean nearest, int depth) {
         super(RecordType.INT, concurrent, source, nearest);
+
+        // add depth(num) records to record each layer
+        this.depth = depth;
+        for (int i = 0; i < depth; i++) {
+            this.records().push(this.newRecord());
+        }
+        assert (this.records().size() == (depth + 1));
+
+        // init top layer's parentRecord
+        this.currentRecord(this.records().peek(), null);
     }
 
     @Override
@@ -60,5 +76,30 @@ public class KoutRecords extends SingleWayMultiPathsRecords {
             paths.add(this.linkPath(records.size() - 1, iterator.next()));
         }
         return paths;
+    }
+
+    public void addFullPath(List<HugeEdge> edges) {
+        assert (depth == edges.size());
+
+        int sourceCode = this.code(edges.get(0).id().ownerVertexId());
+        int targetCode;
+        for (int i = 0; i < edges.size(); i++) {
+            HugeEdge edge = edges.get(i);
+            Id sourceV = edge.id().ownerVertexId();
+            Id targetV = edge.id().otherVertexId();
+
+            assert (this.code(sourceV) == sourceCode);
+
+            this.getEdgeRecord().addEdge(sourceV, targetV, edge);
+
+            targetCode = this.code(targetV);
+            Record record = this.records().elementAt(i + 1);
+            if (this.sourceCode == targetCode) {
+                break;
+            }
+            
+            this.addPathToRecord(sourceCode, targetCode, record);
+            sourceCode = targetCode;
+        }
     }
 }

--- a/hugegraph-core/src/main/java/org/apache/hugegraph/traversal/algorithm/records/SingleWayMultiPathsRecords.java
+++ b/hugegraph-core/src/main/java/org/apache/hugegraph/traversal/algorithm/records/SingleWayMultiPathsRecords.java
@@ -40,9 +40,8 @@ import org.apache.hugegraph.util.collection.IntSet;
 
 public abstract class SingleWayMultiPathsRecords extends AbstractRecords {
 
+    protected final int sourceCode;
     private final Stack<Record> records;
-
-    private final int sourceCode;
     private final boolean nearest;
     private final IntSet accessedVertices;
     private final EdgeRecord edgeResults;
@@ -110,15 +109,16 @@ public abstract class SingleWayMultiPathsRecords extends AbstractRecords {
 
     @Watched
     public void addPath(Id source, Id target) {
-        int sourceCode = this.code(source);
-        int targetCode = this.code(target);
+        this.addPathToRecord(this.code(source), this.code(target), this.currentRecord());
+    }
+
+    public void addPathToRecord(int sourceCode, int targetCode, Record record) {
         if (this.nearest && this.accessedVertices.contains(targetCode) ||
-            !this.nearest && this.currentRecord().containsKey(targetCode) ||
+            !this.nearest && record.containsKey(targetCode) ||
             targetCode == this.sourceCode) {
             return;
         }
-        this.currentRecord().addPath(targetCode, sourceCode);
-
+        record.addPath(targetCode, sourceCode);
         this.accessedVertices.add(targetCode);
     }
 

--- a/hugegraph-core/src/main/java/org/apache/hugegraph/traversal/algorithm/steps/Steps.java
+++ b/hugegraph-core/src/main/java/org/apache/hugegraph/traversal/algorithm/steps/Steps.java
@@ -43,7 +43,6 @@ public class Steps {
     protected final long degree;
     protected final long skipDegree;
 
-
     public Steps(HugeGraph graph, Directions direction,
                  Map<String, Map<String, Object>> vSteps,
                  Map<String, Map<String, Object>> eSteps,
@@ -167,15 +166,15 @@ public class Steps {
             this.properties = properties;
         }
 
-        public Id getId() {
+        public Id id() {
             return id;
         }
 
-        public String getLabel() {
+        public String label() {
             return label;
         }
 
-        public Map<Id, Object> getProperties() {
+        public Map<Id, Object> properties() {
             return properties;
         }
 

--- a/hugegraph-core/src/main/java/org/apache/hugegraph/traversal/algorithm/steps/Steps.java
+++ b/hugegraph-core/src/main/java/org/apache/hugegraph/traversal/algorithm/steps/Steps.java
@@ -1,20 +1,18 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with this
+ * work for additional information regarding copyright ownership. The ASF
+ * licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *  * Licensed to the Apache Software Foundation (ASF) under one or more
- *  * contributor license agreements. See the NOTICE file distributed with this
- *  * work for additional information regarding copyright ownership. The ASF
- *  * licenses this file to You under the Apache License, Version 2.0 (the
- *  * "License"); you may not use this file except in compliance with the License.
- *  * You may obtain a copy of the License at
- *  *
- *  *     http://www.apache.org/licenses/LICENSE-2.0
- *  *
- *  * Unless required by applicable law or agreed to in writing, software
- *  * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- *  * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- *  * License for the specific language governing permissions and limitations
- *  * under the License.
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
  */
 
 package org.apache.hugegraph.traversal.algorithm.steps;

--- a/hugegraph-core/src/main/java/org/apache/hugegraph/traversal/algorithm/steps/Steps.java
+++ b/hugegraph-core/src/main/java/org/apache/hugegraph/traversal/algorithm/steps/Steps.java
@@ -145,19 +145,6 @@ public class Steps {
         return this.vertexSteps.isEmpty();
     }
 
-    public boolean isEdgeStepPropertiesEmpty() {
-        if (this.edgeSteps.isEmpty()) {
-            return true;
-        }
-        for (Map.Entry<Id, StepEntity> entry : this.edgeSteps.entrySet()) {
-            Map<Id, Object> properties = entry.getValue().getProperties();
-            if (properties != null && !properties.isEmpty()) {
-                return false;
-            }
-        }
-        return true;
-    }
-
     @Override
     public String toString() {
         return "Steps{" +

--- a/hugegraph-core/src/main/java/org/apache/hugegraph/traversal/algorithm/steps/Steps.java
+++ b/hugegraph-core/src/main/java/org/apache/hugegraph/traversal/algorithm/steps/Steps.java
@@ -1,0 +1,202 @@
+/*
+ *
+ *  * Licensed to the Apache Software Foundation (ASF) under one or more
+ *  * contributor license agreements. See the NOTICE file distributed with this
+ *  * work for additional information regarding copyright ownership. The ASF
+ *  * licenses this file to You under the Apache License, Version 2.0 (the
+ *  * "License"); you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ *  * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ *  * License for the specific language governing permissions and limitations
+ *  * under the License.
+ *
+ */
+
+package org.apache.hugegraph.traversal.algorithm.steps;
+
+import static org.apache.hugegraph.traversal.algorithm.HugeTraverser.NO_LIMIT;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.hugegraph.HugeGraph;
+import org.apache.hugegraph.backend.id.Id;
+import org.apache.hugegraph.schema.EdgeLabel;
+import org.apache.hugegraph.schema.VertexLabel;
+import org.apache.hugegraph.traversal.algorithm.HugeTraverser;
+import org.apache.hugegraph.traversal.optimize.TraversalUtil;
+import org.apache.hugegraph.type.define.Directions;
+import org.apache.hugegraph.util.E;
+
+public class Steps {
+
+    protected final Map<Id, StepEntity> edgeSteps;
+    protected final Map<Id, StepEntity> vertexSteps;
+    protected final Directions direction;
+    protected final long degree;
+    protected final long skipDegree;
+
+
+    public Steps(HugeGraph graph, Directions direction,
+                 Map<String, Map<String, Object>> vSteps,
+                 Map<String, Map<String, Object>> eSteps,
+                 long degree, long skipDegree) {
+        E.checkArgument(degree == NO_LIMIT || degree > 0L,
+                        "The max degree must be > 0 or == -1, but got: %s", degree);
+        HugeTraverser.checkSkipDegree(skipDegree, degree, NO_LIMIT);
+
+        this.direction = direction;
+
+        // parse vertex steps
+        this.vertexSteps = new HashMap<>();
+        if (vSteps != null && !vSteps.isEmpty()) {
+            initVertexFilter(graph, vSteps);
+        }
+
+        // parse edge steps
+        this.edgeSteps = new HashMap<>();
+        if (eSteps != null && !eSteps.isEmpty()) {
+            initEdgeFilter(graph, eSteps);
+        }
+
+        this.degree = degree;
+        this.skipDegree = skipDegree;
+    }
+
+    private void initVertexFilter(HugeGraph graph, Map<String, Map<String, Object>> vSteps) {
+        for (Map.Entry<String, Map<String, Object>> entry : vSteps.entrySet()) {
+            if (checkEntryEmpty(entry)) {
+                continue;
+            }
+            E.checkArgument(entry.getKey() != null && !entry.getKey().isEmpty(),
+                            "The vertex step label could not be null");
+
+            VertexLabel vertexLabel = graph.vertexLabel(entry.getKey());
+            StepEntity stepEntity = handleStepEntity(graph, entry, vertexLabel.id());
+            this.vertexSteps.put(vertexLabel.id(), stepEntity);
+        }
+    }
+
+    private void initEdgeFilter(HugeGraph graph, Map<String, Map<String, Object>> eSteps) {
+        for (Map.Entry<String, Map<String, Object>> entry : eSteps.entrySet()) {
+            if (checkEntryEmpty(entry)) {
+                continue;
+            }
+            E.checkArgument(entry.getKey() != null && !entry.getKey().isEmpty(),
+                            "The edge step label could not be null");
+
+            EdgeLabel edgeLabel = graph.edgeLabel(entry.getKey());
+            StepEntity stepEntity = handleStepEntity(graph, entry, edgeLabel.id());
+            this.edgeSteps.put(edgeLabel.id(), stepEntity);
+        }
+    }
+
+    private StepEntity handleStepEntity(HugeGraph graph,
+                                        Map.Entry<String, Map<String, Object>> entry,
+                                        Id id) {
+        Map<Id, Object> properties = null;
+        if (entry.getValue() != null) {
+            properties = TraversalUtil.transProperties(graph, entry.getValue());
+        }
+        return new StepEntity(id, entry.getKey(), properties);
+    }
+
+    private boolean checkEntryEmpty(Map.Entry<String, Map<String, Object>> entry) {
+        return (entry.getKey() == null || entry.getKey().isEmpty()) &&
+               (entry.getValue() == null || entry.getValue().isEmpty());
+    }
+
+    public long degree() {
+        return degree;
+    }
+
+    public Map<Id, StepEntity> edgeSteps() {
+        return edgeSteps;
+    }
+
+    public Map<Id, StepEntity> vertexSteps() {
+        return vertexSteps;
+    }
+
+    public long skipDegree() {
+        return skipDegree;
+    }
+
+    public Directions direction() {
+        return direction;
+    }
+
+    public long limit() {
+        return this.skipDegree > 0L ? this.skipDegree : this.degree;
+    }
+
+    public List<Id> edgeLabels() {
+        return new ArrayList<>(this.edgeSteps.keySet());
+    }
+
+    public boolean isVertexEmpty() {
+        return this.vertexSteps.isEmpty();
+    }
+
+    public boolean isEdgeStepPropertiesEmpty() {
+        if (this.edgeSteps.isEmpty()) {
+            return true;
+        }
+        for (Map.Entry<Id, StepEntity> entry : this.edgeSteps.entrySet()) {
+            Map<Id, Object> properties = entry.getValue().getProperties();
+            if (properties != null && !properties.isEmpty()) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    @Override
+    public String toString() {
+        return "Steps{" +
+               "edgeSteps=" + edgeSteps +
+               ", vertexSteps=" + vertexSteps +
+               ", direction=" + direction +
+               ", degree=" + degree +
+               ", skipDegree=" + skipDegree +
+               '}';
+    }
+
+    public static class StepEntity {
+        protected final Id id;
+        protected final String label;
+        protected final Map<Id, Object> properties;
+
+        public StepEntity(Id id, String label, Map<Id, Object> properties) {
+            this.id = id;
+            this.label = label;
+            this.properties = properties;
+        }
+
+        public Id getId() {
+            return id;
+        }
+
+        public String getLabel() {
+            return label;
+        }
+
+        public Map<Id, Object> getProperties() {
+            return properties;
+        }
+
+        @Override
+        public String toString() {
+            return String.format("StepEntity{id=%s,label=%s," +
+                                 "properties=%s}", this.id,
+                                 this.label, this.properties);
+        }
+    }
+}

--- a/hugegraph-core/src/main/java/org/apache/hugegraph/traversal/algorithm/steps/Steps.java
+++ b/hugegraph-core/src/main/java/org/apache/hugegraph/traversal/algorithm/steps/Steps.java
@@ -111,23 +111,23 @@ public class Steps {
     }
 
     public long degree() {
-        return degree;
+        return this.degree;
     }
 
     public Map<Id, StepEntity> edgeSteps() {
-        return edgeSteps;
+        return this.edgeSteps;
     }
 
     public Map<Id, StepEntity> vertexSteps() {
-        return vertexSteps;
+        return this.vertexSteps;
     }
 
     public long skipDegree() {
-        return skipDegree;
+        return this.skipDegree;
     }
 
     public Directions direction() {
-        return direction;
+        return this.direction;
     }
 
     public long limit() {
@@ -145,15 +145,16 @@ public class Steps {
     @Override
     public String toString() {
         return "Steps{" +
-               "edgeSteps=" + edgeSteps +
-               ", vertexSteps=" + vertexSteps +
-               ", direction=" + direction +
-               ", degree=" + degree +
-               ", skipDegree=" + skipDegree +
+               "edgeSteps=" + this.edgeSteps +
+               ", vertexSteps=" + this.vertexSteps +
+               ", direction=" + this.direction +
+               ", degree=" + this.degree +
+               ", skipDegree=" + this.skipDegree +
                '}';
     }
 
     public static class StepEntity {
+
         protected final Id id;
         protected final String label;
         protected final Map<Id, Object> properties;
@@ -165,15 +166,15 @@ public class Steps {
         }
 
         public Id id() {
-            return id;
+            return this.id;
         }
 
         public String label() {
-            return label;
+            return this.label;
         }
 
         public Map<Id, Object> properties() {
-            return properties;
+            return this.properties;
         }
 
         @Override

--- a/hugegraph-core/src/main/java/org/apache/hugegraph/traversal/optimize/TraversalUtil.java
+++ b/hugegraph-core/src/main/java/org/apache/hugegraph/traversal/optimize/TraversalUtil.java
@@ -626,8 +626,8 @@ public final class TraversalUtil {
         // Extract all has steps in traversal
         @SuppressWarnings("rawtypes")
         List<HasStep> steps =
-                TraversalHelper.getStepsOfAssignableClassRecursively(
-                        HasStep.class, traversal);
+                      TraversalHelper.getStepsOfAssignableClassRecursively(
+                      HasStep.class, traversal);
 
         if (steps.isEmpty()) {
             return;

--- a/hugegraph-core/src/main/java/org/apache/hugegraph/traversal/optimize/TraversalUtil.java
+++ b/hugegraph-core/src/main/java/org/apache/hugegraph/traversal/optimize/TraversalUtil.java
@@ -243,7 +243,7 @@ public final class TraversalUtil {
                     long limit = holder.setRange(range.getLowRange(),
                                                  range.getHighRange());
                     RangeGlobalStep<Object> newRange = new RangeGlobalStep<>(
-                            traversal, 0, limit);
+                                                       traversal, 0, limit);
                     TraversalHelper.replaceStep(range, newRange, traversal);
                 }
             }
@@ -311,9 +311,9 @@ public final class TraversalUtil {
     }
 
     public static ConditionQuery fillConditionQuery(
-            ConditionQuery query,
-            List<HasContainer> hasContainers,
-            HugeGraph graph) {
+                                 ConditionQuery query,
+                                 List<HasContainer> hasContainers,
+                                 HugeGraph graph) {
         HugeType resultType = query.resultType();
 
         for (HasContainer has : hasContainers) {
@@ -550,7 +550,7 @@ public final class TraversalUtil {
         // Convert contains-key or contains-value
         BiPredicate<?, ?> bp = has.getPredicate().getBiPredicate();
         E.checkArgument(bp == Compare.eq, "CONTAINS query with relation " +
-                                          "'%s' is not supported", bp);
+                        "'%s' is not supported", bp);
 
         HugeKeys key = token2HugeKey(has.getKey());
         E.checkNotNull(key, "token key");
@@ -602,8 +602,8 @@ public final class TraversalUtil {
 
     @SuppressWarnings("unchecked")
     public static <V> Iterator<V> filterResult(
-            List<HasContainer> hasContainers,
-            Iterator<? extends Element> iterator) {
+                                  List<HasContainer> hasContainers,
+                                  Iterator<? extends Element> iterator) {
         if (hasContainers.isEmpty()) {
             return (Iterator<V>) iterator;
         }
@@ -644,8 +644,8 @@ public final class TraversalUtil {
             }
 
             Optional<Graph> parentGraph = ((Traversal<?, ?>) traversal.getParent())
-                    .asAdmin()
-                    .getGraph();
+                                                                      .asAdmin()
+                                                                      .getGraph();
             if (parentGraph.filter(g -> !(g instanceof EmptyGraph)).isPresent()) {
                 traversal.setGraph(parentGraph.get());
             }
@@ -980,7 +980,7 @@ public final class TraversalUtil {
             }
 
             throw new HugeException(
-                    "Invalid value '%s', expect a number", e, value);
+                      "Invalid value '%s', expect a number", e, value);
         }
     }
 
@@ -1005,7 +1005,7 @@ public final class TraversalUtil {
                 continue;
             }
             throw new HugeException(
-                    "Invalid value '%s', expect a list of number", value);
+                      "Invalid value '%s', expect a list of number", value);
         }
         return values.toArray(new Number[0]);
     }
@@ -1016,7 +1016,7 @@ public final class TraversalUtil {
             return (V) JsonUtil.fromJson(value, Object.class);
         } catch (Exception e) {
             throw new HugeException(
-                    "Invalid value '%s', expect a single value", e, value);
+                      "Invalid value '%s', expect a single value", e, value);
         }
     }
 
@@ -1026,7 +1026,7 @@ public final class TraversalUtil {
             return JsonUtil.fromJson("[" + value + "]", List.class);
         } catch (Exception e) {
             throw new HugeException(
-                    "Invalid value '%s', expect a list", e, value);
+                      "Invalid value '%s', expect a list", e, value);
         }
     }
 }

--- a/hugegraph-core/src/main/java/org/apache/hugegraph/traversal/optimize/TraversalUtil.java
+++ b/hugegraph-core/src/main/java/org/apache/hugegraph/traversal/optimize/TraversalUtil.java
@@ -39,11 +39,18 @@ import org.apache.hugegraph.backend.query.Aggregate;
 import org.apache.hugegraph.backend.query.Condition;
 import org.apache.hugegraph.backend.query.ConditionQuery;
 import org.apache.hugegraph.backend.query.Query;
+import org.apache.hugegraph.exception.NotSupportException;
+import org.apache.hugegraph.iterator.FilterIterator;
 import org.apache.hugegraph.schema.PropertyKey;
 import org.apache.hugegraph.schema.SchemaLabel;
+import org.apache.hugegraph.structure.HugeElement;
+import org.apache.hugegraph.structure.HugeProperty;
 import org.apache.hugegraph.type.HugeType;
 import org.apache.hugegraph.type.define.Directions;
 import org.apache.hugegraph.type.define.HugeKeys;
+import org.apache.hugegraph.util.CollectionUtil;
+import org.apache.hugegraph.util.DateUtil;
+import org.apache.hugegraph.util.E;
 import org.apache.hugegraph.util.JsonUtil;
 import org.apache.tinkerpop.gremlin.process.traversal.Compare;
 import org.apache.tinkerpop.gremlin.process.traversal.Contains;
@@ -83,13 +90,6 @@ import org.apache.tinkerpop.gremlin.structure.T;
 import org.apache.tinkerpop.gremlin.structure.Vertex;
 import org.apache.tinkerpop.gremlin.structure.util.empty.EmptyGraph;
 
-import org.apache.hugegraph.exception.NotSupportException;
-import org.apache.hugegraph.iterator.FilterIterator;
-import org.apache.hugegraph.structure.HugeElement;
-import org.apache.hugegraph.structure.HugeProperty;
-import org.apache.hugegraph.util.CollectionUtil;
-import org.apache.hugegraph.util.DateUtil;
-import org.apache.hugegraph.util.E;
 import com.google.common.collect.ImmutableList;
 
 public final class TraversalUtil {
@@ -146,7 +146,8 @@ public final class TraversalUtil {
                 }
                 local.setGraph(graph);
             }
-            for (final Traversal.Admin<?, ?> global : ((TraversalParent) step).getGlobalChildren()) {
+            for (final Traversal.Admin<?, ?> global :
+                    ((TraversalParent) step).getGlobalChildren()) {
                 if (global.getGraph().filter(g -> !(g instanceof EmptyGraph)).isPresent()) {
                     continue;
                 }
@@ -242,7 +243,7 @@ public final class TraversalUtil {
                     long limit = holder.setRange(range.getLowRange(),
                                                  range.getHighRange());
                     RangeGlobalStep<Object> newRange = new RangeGlobalStep<>(
-                                                       traversal, 0, limit);
+                            traversal, 0, limit);
                     TraversalHelper.replaceStep(range, newRange, traversal);
                 }
             }
@@ -310,9 +311,9 @@ public final class TraversalUtil {
     }
 
     public static ConditionQuery fillConditionQuery(
-                                 ConditionQuery query,
-                                 List<HasContainer> hasContainers,
-                                 HugeGraph graph) {
+            ConditionQuery query,
+            List<HasContainer> hasContainers,
+            HugeGraph graph) {
         HugeType resultType = query.resultType();
 
         for (HasContainer has : hasContainers) {
@@ -549,7 +550,7 @@ public final class TraversalUtil {
         // Convert contains-key or contains-value
         BiPredicate<?, ?> bp = has.getPredicate().getBiPredicate();
         E.checkArgument(bp == Compare.eq, "CONTAINS query with relation " +
-                        "'%s' is not supported", bp);
+                                          "'%s' is not supported", bp);
 
         HugeKeys key = token2HugeKey(has.getKey());
         E.checkNotNull(key, "token key");
@@ -601,8 +602,8 @@ public final class TraversalUtil {
 
     @SuppressWarnings("unchecked")
     public static <V> Iterator<V> filterResult(
-                                  List<HasContainer> hasContainers,
-                                  Iterator<? extends Element> iterator) {
+            List<HasContainer> hasContainers,
+            Iterator<? extends Element> iterator) {
         if (hasContainers.isEmpty()) {
             return (Iterator<V>) iterator;
         }
@@ -625,8 +626,8 @@ public final class TraversalUtil {
         // Extract all has steps in traversal
         @SuppressWarnings("rawtypes")
         List<HasStep> steps =
-                      TraversalHelper.getStepsOfAssignableClassRecursively(
-                      HasStep.class, traversal);
+                TraversalHelper.getStepsOfAssignableClassRecursively(
+                        HasStep.class, traversal);
 
         if (steps.isEmpty()) {
             return;
@@ -643,8 +644,8 @@ public final class TraversalUtil {
             }
 
             Optional<Graph> parentGraph = ((Traversal<?, ?>) traversal.getParent())
-                                                                      .asAdmin()
-                                                                      .getGraph();
+                    .asAdmin()
+                    .getGraph();
             if (parentGraph.filter(g -> !(g instanceof EmptyGraph)).isPresent()) {
                 traversal.setGraph(parentGraph.get());
             }
@@ -690,7 +691,7 @@ public final class TraversalUtil {
         return token2HugeKey(key) != null;
     }
 
-    @SuppressWarnings({ "unchecked", "rawtypes" })
+    @SuppressWarnings({"unchecked", "rawtypes"})
     private static void collectPredicates(List<P<Object>> results,
                                           List<P<?>> predicates) {
         for (P<?> p : predicates) {
@@ -781,7 +782,7 @@ public final class TraversalUtil {
 
     public static void retrieveSysprop(List<HasContainer> hasContainers,
                                        Function<HasContainer, Boolean> func) {
-        for (Iterator<HasContainer> iter = hasContainers.iterator(); iter.hasNext();) {
+        for (Iterator<HasContainer> iter = hasContainers.iterator(); iter.hasNext(); ) {
             HasContainer container = iter.next();
             if (container.getKey().startsWith("~") && func.apply(container)) {
                 iter.remove();
@@ -842,7 +843,7 @@ public final class TraversalUtil {
     public static Map<Id, Object> transProperties(HugeGraph graph,
                                                   Map<String, Object> props) {
         Map<Id, Object> pks = new HashMap<>(props.size());
-        for (Map.Entry<String, Object> e: props.entrySet()) {
+        for (Map.Entry<String, Object> e : props.entrySet()) {
             PropertyKey pk = graph.propertyKey(e.getKey());
             pks.put(pk.id(), e.getValue());
         }
@@ -979,7 +980,7 @@ public final class TraversalUtil {
             }
 
             throw new HugeException(
-                      "Invalid value '%s', expect a number", e, value);
+                    "Invalid value '%s', expect a number", e, value);
         }
     }
 
@@ -1004,7 +1005,7 @@ public final class TraversalUtil {
                 continue;
             }
             throw new HugeException(
-                      "Invalid value '%s', expect a list of number", value);
+                    "Invalid value '%s', expect a list of number", value);
         }
         return values.toArray(new Number[0]);
     }
@@ -1015,7 +1016,7 @@ public final class TraversalUtil {
             return (V) JsonUtil.fromJson(value, Object.class);
         } catch (Exception e) {
             throw new HugeException(
-                      "Invalid value '%s', expect a single value", e, value);
+                    "Invalid value '%s', expect a single value", e, value);
         }
     }
 
@@ -1025,7 +1026,7 @@ public final class TraversalUtil {
             return JsonUtil.fromJson("[" + value + "]", List.class);
         } catch (Exception e) {
             throw new HugeException(
-                      "Invalid value '%s', expect a list", e, value);
+                    "Invalid value '%s', expect a list", e, value);
         }
     }
 }

--- a/hugegraph-test/src/main/java/org/apache/hugegraph/api/traversers/KneighborApiTest.java
+++ b/hugegraph-test/src/main/java/org/apache/hugegraph/api/traversers/KneighborApiTest.java
@@ -20,14 +20,15 @@ package org.apache.hugegraph.api.traversers;
 import java.util.List;
 import java.util.Map;
 
-import jakarta.ws.rs.core.Response;
+import org.apache.hugegraph.api.BaseApiTest;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
-import org.apache.hugegraph.api.BaseApiTest;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
+
+import jakarta.ws.rs.core.Response;
 
 public class KneighborApiTest extends BaseApiTest {
 
@@ -64,13 +65,18 @@ public class KneighborApiTest extends BaseApiTest {
         String markoId = name2Ids.get("marko");
         String reqBody = String.format("{ " +
                                        "\"source\": \"%s\", " +
-                                       "\"step\": { " +
+                                       "\"steps\": { " +
                                        " \"direction\": \"BOTH\", " +
-                                       " \"labels\": [\"knows\", " +
-                                       " \"created\"], " +
-                                       "\"properties\": { " +
-                                       " \"weight\": \"P.gt(0.1)\"}, " +
-                                       " \"degree\": 10000, " +
+                                       " \"edge_steps\": [" +
+                                       "  {\"label\": \"knows\"," +
+                                       "  \"properties\": {" +
+                                       "  \"weight\": \"P.gt(0.1)\"}}," +
+                                       "  {\"label\": \"created\"," +
+                                       "  \"properties\": {" +
+                                       "  \"weight\": \"P.gt(0.1)\"}}" +
+                                       "  ], " +
+                                       " \"vertex_steps\": []," +
+                                       " \"max_degree\": 10000, " +
                                        " \"skip_degree\": 100000}, " +
                                        "\"max_depth\": 3, " +
                                        "\"limit\": 10000, " +

--- a/hugegraph-test/src/main/java/org/apache/hugegraph/api/traversers/KoutApiTest.java
+++ b/hugegraph-test/src/main/java/org/apache/hugegraph/api/traversers/KoutApiTest.java
@@ -20,14 +20,15 @@ package org.apache.hugegraph.api.traversers;
 import java.util.List;
 import java.util.Map;
 
-import jakarta.ws.rs.core.Response;
+import org.apache.hugegraph.api.BaseApiTest;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
-import org.apache.hugegraph.api.BaseApiTest;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+
+import jakarta.ws.rs.core.Response;
 
 public class KoutApiTest extends BaseApiTest {
 
@@ -75,13 +76,18 @@ public class KoutApiTest extends BaseApiTest {
         String markoId = name2Ids.get("marko");
         String reqBody = String.format("{ " +
                                        "\"source\": \"%s\", " +
-                                       "\"step\": { " +
+                                       "\"steps\": { " +
                                        " \"direction\": \"BOTH\", " +
-                                       " \"labels\": [\"knows\", " +
-                                       " \"created\"], " +
-                                       "\"properties\": { " +
-                                       " \"weight\": \"P.gt(0.1)\"}, " +
-                                       " \"degree\": 10000, " +
+                                       " \"edge_steps\": [" +
+                                       "  {\"label\": \"knows\"," +
+                                       "  \"properties\": {" +
+                                       "  \"weight\": \"P.gt(0.1)\"}}," +
+                                       "  {\"label\": \"created\"," +
+                                       "  \"properties\": {" +
+                                       "  \"weight\": \"P.gt(0.1)\"}}" +
+                                       "  ], " +
+                                       " \"vertex_steps\": []," +
+                                       " \"max_degree\": 10000, " +
                                        " \"skip_degree\": 100000}, " +
                                        "\"max_depth\": 1, " +
                                        "\"nearest\": true, " +


### PR DESCRIPTION
<!-- 
  Thank you very much for contributing to Apache HugeGraph, we are happy that you want to help us improve it!

  Here are some tips for you:
    1. If this is your first time, please read the [contributing guidelines](https://github.com/apache/hugegraph/blob/master/CONTRIBUTING.md)

    2. If a PR fix/close an issue, type the message "close xxx" (xxx is the link of related 
issue) in the content, GitHub will auto link it (Required)

    3. Name the PR title in "Google Commit Format", start with "feat | fix | perf | refactor | doc | chore", 
      such like: "feat(core): support the PageRank algorithm" or "fix: wrong break in the compute loop" (module is optional)
      skip it if you are unsure about which is the best component.

    4. One PR address one issue, better not to mix up multiple issues.

    5. Put an `x` in the `[ ]` to mark the item as CHECKED. `[x]` (or click it directly after 
published)
-->

## Purpose of the PR

- Support label & property filtering for both edge and vertex and the filtering is implemented in Kout Post and Kneighbor Post Apis, reducing unnecessary graph searches through pruning
- Support Kout dfs mode in Kout Post Api
- related issue #2276

<!--
Please explain more context in this section, clarify why the changes are needed. 
e.g:
- If you propose a new API, clarify the use case for a new API.
- If you fix a bug, you can clarify why it is a bug, and should be associated with an issue.
-->

## Main Changes

### Label & property filtering for edge and vertex

> The filtering is supported in Kout Post and Kneighbor Post Apis, and is there a need for other apis?

Originally only edge label filtering was supported, now label and property filtering for edge and vertex is supported.

- add classes VEStepEntity and VEStep to support serialization in request
- add class Steps to support filtering of edge and vertex in runtime(core)
- add new method edgesOfVertex(Id source, Steps steps) to support label and property filtering for both edge and vertex in HugeTraverser.java
- [design document](https://hugegraph.feishu.cn/wiki/ZYjSw3PJji5cvxkfJbVcP5MrnJl)

![项目架构-顶点和边过滤](https://github.com/apache/incubator-hugegraph/assets/77946882/b175bb56-57dc-43a4-9227-0a44a6d13510)


### Kout dfs mode

Add DFS-based Kout mode in Kout Post Api and users can select the algorithm throught request parameters.

* add dfs kout in KoutTraverser.java
* add class NestedIterator to support dfs traversal which can remember the vertices and layers you traversed in the past
* [design document](https://hugegraph.feishu.cn/wiki/EOOMwn0pUiqo8TkqQobcqzYknNb)


<!-- Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. These change logs are helpful for better ant faster reviews.)

For example:

- If you introduce a new feature, please show detailed design here or add the link of design documentation.
- If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
- If there is a discussion in the mailing list, please add the link. -->

## Verifying these changes

<!-- Please pick the proper options below -->

- [ ] Trivial rework / code cleanup without any test coverage. (No Need)
- [ ] Already covered by existing tests, such as *(please modify tests here)*.
- [x] Need tests and can be verified as follows:
    - Postman Test: the tests of `Kout Post` are shown below

### Initialize the Graph

* Initialze the graph according to the [link](https://hugegraph.apache.org/docs/clients/restful-api/traverser/#32-detailed-explanation-of-traverser-api-1)

### Label & property filtering for edge and vertex in Kout Post

- Method & Url

```
POST http://localhost:8080/graphs/{graph}/traversers/kout
```

- Request Body

```json
{
  "source": "1:marko",
    "steps": {
    "direction": "BOTH",
    "edge_steps": [
        {
            "label": "knows",
            "properties": {
                "weight": "P.gt(1.2)"
            }
        },
        {
            "label": "created",
            "properties": {
                "weight": "P.gt(0.39)"
            }
        }
    ],
    "vertex_steps": [
        {
            "label": "person",
            "properties": {
                "age": "P.lt(33)"
            }
        },
        {
            "label": "software",
            "properties": {}
        }
    ],
    "max_degree": 10000,
    "skip_degree": 100000
    },
  "max_depth": 3,
  "nearest": false,
  "limit": 10000,
  "with_vertex": false,
  "with_path": true,
  "with_edge": false
}
```

- Response Body

```json
{
    "kout": [
        "2:ripple",
        "2:lop"
    ],
    "size": 2,
    "paths": [
        {
            "objects": [
                "1:marko",
                "2:lop",
                "1:josh",
                "2:lop"
            ]
        },
        {
            "objects": [
                "1:marko",
                "2:lop",
                "1:josh",
                "2:ripple"
            ]
        }
    ],
    "vertices": [
        "2:ripple",
        "1:marko",
        "1:josh",
        "2:lop"
    ],
    "edges": [
        "S1:josh>2>>S2:ripple",
        "S1:josh>2>>S2:lop",
        "S1:marko>2>>S2:lop"
    ],
    "measure": {
        "edge_iterations": 5,
        "vertice_iterations": 3,
        "cost(ns)": 175009500
    }
}
```

### Kout Post dfs mode

- Method & Url

```
POST http://localhost:8080/graphs/{graph}/traversers/kout
```

- Request Body

```json
{
  "source": "1:marko",
    "steps": {
    "direction": "BOTH",
    "edge_steps": [
        {
            "label": "knows",
            "properties": {
                "weight": "P.gt(1.2)"
            }
        },
        {
            "label": "created",
            "properties": {
                "weight": "P.gt(0.39)"
            }
        }
    ],
    "vertex_steps": [
        {
            "label": "person",
            "properties": {
                "age": "P.lt(33)"
            }
        },
        {
            "label": "software",
            "properties": {}
        }
    ],
    "max_degree": 10000,
    "skip_degree": 100000
    },
  "max_depth": 3,
  "nearest": false,
  "limit": 10000,
  "with_vertex": false,
  "with_path": true,
  "with_edge": false,
  "algorithm": "depth_first_search"
}
```

- Response Body

```json
{
    "kout": [
        "2:ripple",
        "2:lop"
    ],
    "size": 2,
    "paths": [
        {
            "objects": [
                "1:marko",
                "2:lop",
                "1:josh",
                "2:lop"
            ]
        },
        {
            "objects": [
                "1:marko",
                "2:lop",
                "1:josh",
                "2:ripple"
            ]
        }
    ],
    "vertices": [
        "2:ripple",
        "1:marko",
        "1:josh",
        "2:lop"
    ],
    "edges": [
        "S1:josh>2>>S2:ripple",
        "S1:josh>2>>S2:lop",
        "S1:marko>2>>S2:lop"
    ],
    "measure": {
        "edge_iterations": 6,
        "vertice_iterations": 3,
        "cost(ns)": 60305791
    }
}
```

<img width="853" alt="image" src="https://github.com/apache/incubator-hugegraph/assets/77946882/5190bea0-ca00-4ab2-acfc-48416b73d724">


## Does this PR potentially affect the following parts?

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ]  Nope
- [ ]  Dependencies (add/update license info) <!-- Don't forget to add/update the info in "LICENSE" & "NOTICE" files (both in root & dist module) -->
- [ ]  Modify configurations
- [x]  The public API
- [ ]  Other affects (typed here)

## Documentation Status

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [x]  `Doc - TODO` <!-- Your PR changes impact docs and you will update later -->
- [ ]  `Doc - Done` <!-- Related docs have been already added or updated -->
- [ ]  `Doc - No Need` <!-- Your PR changes don't impact/need docs -->
