### PR TITLE
feat(core): support batch+parallel edges traverse

### DIFF
--- a/hugegraph-core/src/main/java/org/apache/hugegraph/backend/query/EdgesQueryIterator.java
+++ b/hugegraph-core/src/main/java/org/apache/hugegraph/backend/query/EdgesQueryIterator.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with this
+ * work for additional information regarding copyright ownership. The ASF
+ * licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.hugegraph.backend.query;
+
+import java.util.Iterator;
+import java.util.List;
+
+import org.apache.hugegraph.backend.id.Id;
+import org.apache.hugegraph.backend.tx.GraphTransaction;
+import org.apache.hugegraph.type.define.Directions;
+
+public class EdgesQueryIterator implements Iterator<Query> {
+    private final List<Id> labels;
+    private final Directions directions;
+    private final long limit;
+    private final Iterator<Id> sources;
+
+    public EdgesQueryIterator(Iterator<Id> sources,
+                              Directions directions,
+                              List<Id> labels,
+                              long limit) {
+        this.sources = sources;
+        this.labels = labels;
+        this.directions = directions;
+        // Traverse NO_LIMIT 和 Query.NO_LIMIT 不同
+        this.limit = limit < 0 ? Query.NO_LIMIT : limit;
+    }
+
+    @Override
+    public boolean hasNext() {
+        return sources.hasNext();
+    }
+
+    @Override
+    public Query next() {
+        Id sourceId = this.sources.next();
+        ConditionQuery query = GraphTransaction.constructEdgesQuery(sourceId,
+                                                                    this.directions,
+                                                                    this.labels);
+        if (this.limit != Query.NO_LIMIT) {
+            query.limit(this.limit);
+            query.capacity(this.limit);
+        } else {
+            query.capacity(Query.NO_CAPACITY);
+        }
+        return query;
+    }
+
+}

--- a/hugegraph-core/src/main/java/org/apache/hugegraph/backend/query/EdgesQueryIterator.java
+++ b/hugegraph-core/src/main/java/org/apache/hugegraph/backend/query/EdgesQueryIterator.java
@@ -25,6 +25,7 @@ import org.apache.hugegraph.backend.tx.GraphTransaction;
 import org.apache.hugegraph.type.define.Directions;
 
 public class EdgesQueryIterator implements Iterator<Query> {
+
     private final List<Id> labels;
     private final Directions directions;
     private final long limit;
@@ -60,5 +61,4 @@ public class EdgesQueryIterator implements Iterator<Query> {
         }
         return query;
     }
-
 }

--- a/hugegraph-core/src/main/java/org/apache/hugegraph/task/TaskManager.java
+++ b/hugegraph-core/src/main/java/org/apache/hugegraph/task/TaskManager.java
@@ -49,9 +49,8 @@ public final class TaskManager {
     public static final String TASK_SCHEDULER = "task-scheduler-%d";
 
     protected static final long SCHEDULE_PERIOD = 1000L; // unit ms
-
+    private static final long TX_CLOSE_TIMEOUT = 30L; // unit s
     private static final int THREADS = 4;
-    private static final int TX_CLOSE_TIMEOUT = 30;
     private static final TaskManager MANAGER = new TaskManager(THREADS);
 
     private final Map<HugeGraphParams, TaskScheduler> schedulers;

--- a/hugegraph-core/src/main/java/org/apache/hugegraph/task/TaskManager.java
+++ b/hugegraph-core/src/main/java/org/apache/hugegraph/task/TaskManager.java
@@ -48,9 +48,10 @@ public final class TaskManager {
                                "server-info-db-worker-%d";
     public static final String TASK_SCHEDULER = "task-scheduler-%d";
 
-    static final long SCHEDULE_PERIOD = 1000L; // unit ms
+    protected static final long SCHEDULE_PERIOD = 1000L; // unit ms
 
     private static final int THREADS = 4;
+    private static final int TX_CLOSE_TIMEOUT = 30;
     private static final TaskManager MANAGER = new TaskManager(THREADS);
 
     private final Map<HugeGraphParams, TaskScheduler> schedulers;
@@ -135,7 +136,7 @@ public final class TaskManager {
                 graph.closeTx();
             } else {
                 Consumers.executeOncePerThread(this.taskExecutor, totalThreads,
-                                               graph::closeTx, 5, TimeUnit.SECONDS);
+                                               graph::closeTx, TX_CLOSE_TIMEOUT);
             }
         } catch (Exception e) {
             throw new HugeException("Exception when closing task tx", e);
@@ -243,7 +244,7 @@ public final class TaskManager {
         return size;
     }
 
-    void notifyNewTask(HugeTask<?> task) {
+    protected void notifyNewTask(HugeTask<?> task) {
         Queue<Runnable> queue = ((ThreadPoolExecutor) this.schedulerExecutor)
                                                           .getQueue();
         if (queue.size() <= 1) {
@@ -358,11 +359,11 @@ public final class TaskManager {
 
     private static final ThreadLocal<String> CONTEXTS = new ThreadLocal<>();
 
-    static void setContext(String context) {
+    protected static void setContext(String context) {
         CONTEXTS.set(context);
     }
 
-    static void resetContext() {
+    protected static void resetContext() {
         CONTEXTS.remove();
     }
 

--- a/hugegraph-core/src/main/java/org/apache/hugegraph/traversal/algorithm/HugeTraverser.java
+++ b/hugegraph-core/src/main/java/org/apache/hugegraph/traversal/algorithm/HugeTraverser.java
@@ -1017,29 +1017,31 @@ public class HugeTraverser {
     }
 
     public class EdgesIterator implements Iterator<Iterator<Edge>>, Closeable {
-        private final Iterator<Iterator<Edge>> currentIt;
 
-        public EdgesIterator(EdgesQueryIterator queryIterator) {
+        private final Iterator<Iterator<Edge>> currentIter;
+
+        public EdgesIterator(EdgesQueryIterator queries) {
             List<Iterator<Edge>> iteratorList = new ArrayList<>();
-            while (queryIterator.hasNext()) {
-                iteratorList.add(graph().edges(queryIterator.next()));
+            while (queries.hasNext()) {
+                iteratorList.add(
+                        graph().edges(queries.next()));
             }
-            this.currentIt = iteratorList.iterator();
+            this.currentIter = iteratorList.iterator();
         }
 
         @Override
         public boolean hasNext() {
-            return this.currentIt.hasNext();
+            return this.currentIter.hasNext();
         }
 
         @Override
         public Iterator<Edge> next() {
-            return this.currentIt.next();
+            return this.currentIter.next();
         }
 
         @Override
         public void close() throws IOException {
-            CloseableIterator.closeIterator(currentIt);
+            CloseableIterator.closeIterator(currentIter);
         }
     }
 }

--- a/hugegraph-core/src/main/java/org/apache/hugegraph/traversal/algorithm/HugeTraverser.java
+++ b/hugegraph-core/src/main/java/org/apache/hugegraph/traversal/algorithm/HugeTraverser.java
@@ -1028,8 +1028,8 @@ public class HugeTraverser {
         public EdgesIterator(EdgesQueryIterator queries) {
             List<Iterator<Edge>> iteratorList = new ArrayList<>();
             while (queries.hasNext()) {
-                iteratorList.add(
-                        graph().edges(queries.next()));
+                Iterator<Edge> edges = graph.edges(queries.next());
+                iteratorList.add(edges);
             }
             this.currentIter = iteratorList.iterator();
         }

--- a/hugegraph-core/src/main/java/org/apache/hugegraph/traversal/algorithm/HugeTraverser.java
+++ b/hugegraph-core/src/main/java/org/apache/hugegraph/traversal/algorithm/HugeTraverser.java
@@ -485,6 +485,11 @@ public class HugeTraverser {
             cq.limit(steps.limit());
         }
 
+        if (steps.isEdgeEmpty()) {
+            Iterator<Edge> edges = this.graph().edges(cq);
+            return edgesOfVertexStep(edges, steps);
+        }
+
         Map<Id, ConditionQuery> edgeConditions =
                 getFilterQueryConditions(steps.edgeSteps(), HugeType.EDGE);
 

--- a/hugegraph-core/src/main/java/org/apache/hugegraph/traversal/algorithm/KneighborTraverser.java
+++ b/hugegraph-core/src/main/java/org/apache/hugegraph/traversal/algorithm/KneighborTraverser.java
@@ -55,7 +55,6 @@ public class KneighborTraverser extends OltpTraverser {
                 return;
             }
             records.addPath(edgeId.ownerVertexId(), edgeId.otherVertexId());
-            this.edgeIterCounter.addAndGet(1L);
         };
 
         while (depth-- > 0) {
@@ -89,7 +88,6 @@ public class KneighborTraverser extends OltpTraverser {
             EdgeId edgeId = ((HugeEdge) edge).id();
             records.addPath(edgeId.ownerVertexId(), edgeId.otherVertexId());
             records.edgeResults().addEdge(edgeId.ownerVertexId(), edgeId.otherVertexId(), edge);
-            this.edgeIterCounter.addAndGet(1L);
         };
 
         while (maxDepth-- > 0) {

--- a/hugegraph-core/src/main/java/org/apache/hugegraph/traversal/algorithm/KneighborTraverser.java
+++ b/hugegraph-core/src/main/java/org/apache/hugegraph/traversal/algorithm/KneighborTraverser.java
@@ -59,7 +59,7 @@ public class KneighborTraverser extends OltpTraverser {
 
         while (depth-- > 0) {
             records.startOneLayer(true);
-            bfsQuery(records.keys(), dir, labelId, degree, NO_LIMIT, consumer);
+            traverseIdsByBfs(records.keys(), dir, labelId, degree, NO_LIMIT, consumer);
             records.finishOneLayer();
             if (reachLimit(limit, records.size())) {
                 break;
@@ -68,7 +68,7 @@ public class KneighborTraverser extends OltpTraverser {
 
         this.vertexIterCounter.addAndGet(records.size());
 
-        return records.idSet(limit);
+        return records.idsBySet(limit);
     }
 
     public KneighborRecords customizedKneighbor(Id source, Steps steps,
@@ -92,7 +92,7 @@ public class KneighborTraverser extends OltpTraverser {
 
         while (maxDepth-- > 0) {
             records.startOneLayer(true);
-            bfsQuery(records.keys(), steps, NO_LIMIT, consumer);
+            traverseIdsByBfs(records.keys(), steps, NO_LIMIT, consumer);
             records.finishOneLayer();
             if (this.reachLimit(limit, records.size())) {
                 break;

--- a/hugegraph-core/src/main/java/org/apache/hugegraph/traversal/algorithm/KoutTraverser.java
+++ b/hugegraph-core/src/main/java/org/apache/hugegraph/traversal/algorithm/KoutTraverser.java
@@ -131,7 +131,6 @@ public class KoutTraverser extends OltpTraverser {
             EdgeId edgeId = ((HugeEdge) edge).id();
             records.addPath(edgeId.ownerVertexId(), edgeId.otherVertexId());
             records.edgeResults().addEdge(edgeId.ownerVertexId(), edgeId.otherVertexId(), edge);
-            this.edgeIterCounter.addAndGet(1L);
         };
 
         while (depth[0]-- > 0) {

--- a/hugegraph-core/src/main/java/org/apache/hugegraph/traversal/algorithm/KoutTraverser.java
+++ b/hugegraph-core/src/main/java/org/apache/hugegraph/traversal/algorithm/KoutTraverser.java
@@ -92,7 +92,7 @@ public class KoutTraverser extends OltpTraverser {
             this.vertexIterCounter.addAndGet(sources.size());
             this.edgeIterCounter.addAndGet(neighbors.size());
 
-            bfsQuery(sources.iterator(), dir, labelId, degree, capacity, consumer);
+            traverseIdsByBfs(sources.iterator(), dir, labelId, degree, capacity, consumer);
 
             sources.clear();
 
@@ -136,7 +136,7 @@ public class KoutTraverser extends OltpTraverser {
         while (depth[0]-- > 0) {
             List<Id> sources = records.ids(Query.NO_LIMIT);
             records.startOneLayer(true);
-            bfsQuery(sources.iterator(), steps, capacity, consumer);
+            traverseIdsByBfs(sources.iterator(), steps, capacity, consumer);
             this.vertexIterCounter.addAndGet(sources.size());
             records.finishOneLayer();
             checkCapacity(capacity, records.accessed(), depth[0]);

--- a/hugegraph-core/src/main/java/org/apache/hugegraph/traversal/algorithm/OltpTraverser.java
+++ b/hugegraph-core/src/main/java/org/apache/hugegraph/traversal/algorithm/OltpTraverser.java
@@ -17,27 +17,39 @@
 
 package org.apache.hugegraph.traversal.algorithm;
 
+import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Consumer;
 
-import com.google.common.base.Objects;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.hugegraph.HugeGraph;
+import org.apache.hugegraph.backend.id.EdgeId;
 import org.apache.hugegraph.backend.id.Id;
+import org.apache.hugegraph.backend.query.EdgesQueryIterator;
 import org.apache.hugegraph.config.CoreOptions;
+import org.apache.hugegraph.iterator.FilterIterator;
+import org.apache.hugegraph.iterator.MapperIterator;
+import org.apache.hugegraph.structure.HugeEdge;
+import org.apache.hugegraph.traversal.algorithm.steps.Steps;
+import org.apache.hugegraph.type.define.Directions;
 import org.apache.hugegraph.util.Consumers;
+import org.apache.tinkerpop.gremlin.structure.Edge;
 import org.apache.tinkerpop.gremlin.structure.Element;
 import org.apache.tinkerpop.gremlin.structure.Property;
 import org.apache.tinkerpop.gremlin.structure.Vertex;
 import org.apache.tinkerpop.gremlin.structure.util.CloseableIterator;
 
-import org.apache.hugegraph.iterator.FilterIterator;
+import com.google.common.base.Objects;
 
 public abstract class OltpTraverser extends HugeTraverser
-                                    implements AutoCloseable {
+        implements AutoCloseable {
 
     private static final String EXECUTOR_NAME = "oltp";
     private static Consumers.ExecutorPool executors;
@@ -59,11 +71,6 @@ public abstract class OltpTraverser extends HugeTraverser
         }
     }
 
-    @Override
-    public void close() {
-        // pass
-    }
-
     public static void destroy() {
         synchronized (OltpTraverser.class) {
             if (executors != null) {
@@ -71,6 +78,11 @@ public abstract class OltpTraverser extends HugeTraverser
                 executors = null;
             }
         }
+    }
+
+    @Override
+    public void close() {
+        // pass
     }
 
     protected long traversePairs(Iterator<Pair<Id, Id>> pairs,
@@ -129,6 +141,64 @@ public abstract class OltpTraverser extends HugeTraverser
         return total;
     }
 
+    protected <K> long traverseBatch(Iterator<Iterator<K>> iterator,
+                                     Consumer<Iterator<K>> consumer,
+                                     String name, int queueWorkerSize) {
+        if (!iterator.hasNext()) {
+            return 0L;
+        }
+        AtomicBoolean done = new AtomicBoolean(false);
+        Consumers<Iterator<K>> consumers = null;
+        try {
+            consumers = getConsumers(consumer, queueWorkerSize, done,
+                                     executors.getExecutor());
+            return consumersStart(iterator, name, done, consumers);
+        } finally {
+            assert consumers != null;
+            executors.returnExecutor(consumers.executor());
+        }
+    }
+
+    private <K> long consumersStart(Iterator<Iterator<K>> iterator, String name,
+                                    AtomicBoolean done,
+                                    Consumers<Iterator<K>> consumers) {
+        long total = 0L;
+        try {
+            consumers.start(name);
+            while (iterator.hasNext() && !done.get()) {
+                total++;
+                Iterator<K> v = iterator.next();
+                consumers.provide(v);
+            }
+        } catch (Consumers.StopExecution e) {
+            // pass
+        } catch (Throwable e) {
+            throw Consumers.wrapException(e);
+        } finally {
+            try {
+                consumers.await();
+            } catch (Throwable e) {
+                throw Consumers.wrapException(e);
+            } finally {
+                CloseableIterator.closeIterator(iterator);
+            }
+        }
+        return total;
+    }
+
+    private <K> Consumers<Iterator<K>> getConsumers(Consumer<Iterator<K>> consumer,
+                                                    int queueWorkerSize,
+                                                    AtomicBoolean done,
+                                                    ExecutorService executor) {
+        Consumers<Iterator<K>> consumers;
+        consumers = new Consumers<>(executor,
+                                    consumer,
+                                    null,
+                                    e -> done.set(true),
+                                    queueWorkerSize);
+        return consumers;
+    }
+
     protected Iterator<Vertex> filter(Iterator<Vertex> vertices,
                                       String key, Object value) {
         return new FilterIterator<>(vertices, vertex -> {
@@ -144,8 +214,41 @@ public abstract class OltpTraverser extends HugeTraverser
         return p.isPresent() && Objects.equal(p.value(), value);
     }
 
+    protected void bfsQuery(Iterator<Id> vertices,
+                            Directions dir,
+                            Id label,
+                            long degree,
+                            long capacity,
+                            Consumer<EdgeId> parseConsumer) {
+        List<Id> labels =
+                label == null ? Collections.emptyList() : Collections.singletonList(label);
+        CapacityConsumer consumer = new CapacityConsumer(parseConsumer, capacity);
+
+        EdgesIterator edgeIts = edgesOfVertices(vertices, dir, labels, degree);
+        // 并行乱序处理
+        this.traverseBatch(edgeIts, consumer, "traverse-ite-edge", 1);
+    }
+
+    protected void bfsQuery(Iterator<Id> vertices,
+                            Steps steps,
+                            long capacity,
+                            Consumer<Edge> parseConsumer) {
+        CapacityConsumerWithStep consumer =
+                new CapacityConsumerWithStep(parseConsumer, capacity, steps);
+
+        EdgesQueryIterator queryIterator =
+                new EdgesQueryIterator(vertices, steps.direction(), steps.edgeLabels(),
+                                       steps.degree());
+
+        // 这里获取边数据，以便支持 step
+        EdgesIterator edgeIts = new EdgesIterator(queryIterator);
+
+        // 并行乱序处理
+        this.traverseBatch(edgeIts, consumer, "traverse-ite-edge", 1);
+    }
+
     public static class ConcurrentMultiValuedMap<K, V>
-                  extends ConcurrentHashMap<K, List<V>> {
+            extends ConcurrentHashMap<K, List<V>> {
 
         private static final long serialVersionUID = -7249946839643493614L;
 
@@ -175,4 +278,100 @@ public abstract class OltpTraverser extends HugeTraverser
             return values;
         }
     }
+
+    public static class ConcurrentVerticesConsumer implements Consumer<EdgeId> {
+        private final Id sourceV;
+        private final Set<Id> excluded;
+        private final Set<Id> neighbors;
+        private final long limit;
+        private final AtomicInteger count = new AtomicInteger(0);
+
+        public ConcurrentVerticesConsumer(Id sourceV, Set<Id> excluded, long limit,
+                                          Set<Id> neighbors) {
+            this.sourceV = sourceV;
+            this.excluded = excluded;
+            this.limit = limit;
+            this.neighbors = neighbors;
+        }
+
+        @Override
+        public void accept(EdgeId edgeId) {
+            if (limit != NO_LIMIT && count.get() >= limit) {
+                throw new Consumers.StopExecution("reach limit");
+            }
+
+            Id targetV = edgeId.otherVertexId();
+            if (sourceV.equals(targetV)) {
+                return;
+            }
+
+            if (excluded != null && excluded.contains(targetV)) {
+                return;
+            }
+
+            if (neighbors.add(targetV)) {
+                if (limit != NO_LIMIT) {
+                    count.getAndIncrement();
+                }
+            }
+        }
+    }
+
+    public abstract class EdgeItConsumer<T, E> implements Consumer<Iterator<T>> {
+        private final Consumer<E> parseConsumer;
+        private final long capacity;
+
+        public EdgeItConsumer(Consumer<E> parseConsumer, long capacity) {
+            this.parseConsumer = parseConsumer;
+            this.capacity = capacity;
+        }
+
+        protected abstract Iterator<E> prepare(Iterator<T> it);
+
+        @Override
+        public void accept(Iterator<T> edges) {
+            Iterator<E> ids = prepare(edges);
+            long counter = 0;
+            while (ids.hasNext()) {
+                if (Thread.currentThread().isInterrupted()) {
+                    LOG.warn("Consumer isInterrupted");
+                    break;
+                }
+                counter++;
+                parseConsumer.accept(ids.next());
+            }
+            long total = edgeIterCounter.addAndGet(counter);
+            // 按批次检测 capacity，以提高性能
+            if (this.capacity != NO_LIMIT && total >= capacity) {
+                throw new Consumers.StopExecution("reach capacity");
+            }
+        }
+    }
+
+    public class CapacityConsumer extends EdgeItConsumer<Edge, EdgeId> {
+        public CapacityConsumer(Consumer<EdgeId> parseConsumer, long capacity) {
+            super(parseConsumer, capacity);
+        }
+
+        @Override
+        protected Iterator<EdgeId> prepare(Iterator<Edge> edges) {
+            return new MapperIterator<>(edges, (e) -> ((HugeEdge) e).id());
+        }
+    }
+
+    public class CapacityConsumerWithStep extends EdgeItConsumer<Edge, Edge> {
+        private final Steps steps;
+
+        public CapacityConsumerWithStep(Consumer<Edge> parseConsumer, long capacity,
+                                        Steps steps) {
+            super(parseConsumer, capacity);
+            this.steps = steps;
+        }
+
+        @Override
+        protected Iterator<Edge> prepare(Iterator<Edge> edges) {
+            return edgesOfVertexStep(edges, steps);
+        }
+    }
+
 }

--- a/hugegraph-core/src/main/java/org/apache/hugegraph/traversal/algorithm/OltpTraverser.java
+++ b/hugegraph-core/src/main/java/org/apache/hugegraph/traversal/algorithm/OltpTraverser.java
@@ -285,6 +285,7 @@ public abstract class OltpTraverser extends HugeTraverser
         private final Set<Id> excluded;
         private final Set<Id> neighbors;
         private final long limit;
+        private final AtomicInteger count;
 
         public ConcurrentVerticesConsumer(Id sourceV, Set<Id> excluded, long limit,
                                           Set<Id> neighbors) {
@@ -292,9 +293,8 @@ public abstract class OltpTraverser extends HugeTraverser
             this.excluded = excluded;
             this.limit = limit;
             this.neighbors = neighbors;
+            this.count = new AtomicInteger(0);
         }
-
-        private final AtomicInteger count = new AtomicInteger(0);
 
         @Override
         public void accept(EdgeId edgeId) {

--- a/hugegraph-core/src/main/java/org/apache/hugegraph/traversal/algorithm/OltpTraverser.java
+++ b/hugegraph-core/src/main/java/org/apache/hugegraph/traversal/algorithm/OltpTraverser.java
@@ -49,7 +49,7 @@ import org.apache.tinkerpop.gremlin.structure.util.CloseableIterator;
 import com.google.common.base.Objects;
 
 public abstract class OltpTraverser extends HugeTraverser
-        implements AutoCloseable {
+                                    implements AutoCloseable {
 
     private static final String EXECUTOR_NAME = "oltp";
     private static Consumers.ExecutorPool executors;
@@ -71,6 +71,11 @@ public abstract class OltpTraverser extends HugeTraverser
         }
     }
 
+    @Override
+    public void close() {
+        // pass
+    }
+
     public static void destroy() {
         synchronized (OltpTraverser.class) {
             if (executors != null) {
@@ -78,11 +83,6 @@ public abstract class OltpTraverser extends HugeTraverser
                 executors = null;
             }
         }
-    }
-
-    @Override
-    public void close() {
-        // pass
     }
 
     protected long traversePairs(Iterator<Pair<Id, Id>> pairs,
@@ -248,7 +248,7 @@ public abstract class OltpTraverser extends HugeTraverser
     }
 
     public static class ConcurrentMultiValuedMap<K, V>
-            extends ConcurrentHashMap<K, List<V>> {
+                  extends ConcurrentHashMap<K, List<V>> {
 
         private static final long serialVersionUID = -7249946839643493614L;
 

--- a/hugegraph-core/src/main/java/org/apache/hugegraph/traversal/algorithm/OltpTraverser.java
+++ b/hugegraph-core/src/main/java/org/apache/hugegraph/traversal/algorithm/OltpTraverser.java
@@ -148,8 +148,8 @@ public abstract class OltpTraverser extends HugeTraverser
                                     long degree,
                                     long capacity,
                                     Consumer<EdgeId> consumer) {
-        List<Id> labels =
-                label == null ? Collections.emptyList() : Collections.singletonList(label);
+        List<Id> labels = label == null ? Collections.emptyList() :
+                                          Collections.singletonList(label);
         OneStepEdgeIterConsumer edgeIterConsumer = new OneStepEdgeIterConsumer(consumer, capacity);
 
         EdgesIterator edgeIter = edgesOfVertices(vertices, dir, labels, degree);
@@ -285,7 +285,6 @@ public abstract class OltpTraverser extends HugeTraverser
         private final Set<Id> excluded;
         private final Set<Id> neighbors;
         private final long limit;
-        private final AtomicInteger count = new AtomicInteger(0);
 
         public ConcurrentVerticesConsumer(Id sourceV, Set<Id> excluded, long limit,
                                           Set<Id> neighbors) {
@@ -294,6 +293,8 @@ public abstract class OltpTraverser extends HugeTraverser
             this.limit = limit;
             this.neighbors = neighbors;
         }
+
+        private final AtomicInteger count = new AtomicInteger(0);
 
         @Override
         public void accept(EdgeId edgeId) {

--- a/hugegraph-core/src/main/java/org/apache/hugegraph/traversal/algorithm/OltpTraverser.java
+++ b/hugegraph-core/src/main/java/org/apache/hugegraph/traversal/algorithm/OltpTraverser.java
@@ -334,7 +334,7 @@ public abstract class OltpTraverser extends HugeTraverser
             long counter = 0;
             while (ids.hasNext()) {
                 if (Thread.currentThread().isInterrupted()) {
-                    LOG.warn("Consumer isInterrupted");
+                    LOG.warn("Consumer is Interrupted");
                     break;
                 }
                 counter++;

--- a/hugegraph-core/src/main/java/org/apache/hugegraph/traversal/algorithm/records/KneighborRecords.java
+++ b/hugegraph-core/src/main/java/org/apache/hugegraph/traversal/algorithm/records/KneighborRecords.java
@@ -51,7 +51,7 @@ public class KneighborRecords extends SingleWayMultiPathsRecords {
         return ids;
     }
 
-    public Set<Id> idSet(long limit) {
+    public Set<Id> idsBySet(long limit) {
         Set<Id> ids = CollectionFactory.newSet(CollectionType.EC);
         this.getRecords(limit, ids);
         return ids;

--- a/hugegraph-core/src/main/java/org/apache/hugegraph/traversal/algorithm/records/KneighborRecords.java
+++ b/hugegraph-core/src/main/java/org/apache/hugegraph/traversal/algorithm/records/KneighborRecords.java
@@ -19,7 +19,9 @@ package org.apache.hugegraph.traversal.algorithm.records;
 
 import static org.apache.hugegraph.traversal.algorithm.HugeTraverser.NO_LIMIT;
 
+import java.util.Collection;
 import java.util.List;
+import java.util.Set;
 import java.util.Stack;
 
 import org.apache.hugegraph.backend.id.Id;
@@ -45,6 +47,17 @@ public class KneighborRecords extends SingleWayMultiPathsRecords {
     @Override
     public List<Id> ids(long limit) {
         List<Id> ids = CollectionFactory.newList(CollectionType.EC);
+        this.getRecords(limit, ids);
+        return ids;
+    }
+
+    public Set<Id> idSet(long limit) {
+        Set<Id> ids = CollectionFactory.newSet(CollectionType.EC);
+        this.getRecords(limit, ids);
+        return ids;
+    }
+
+    private void getRecords(long limit, Collection<Id> ids) {
         Stack<Record> records = this.records();
         // Not include record(i=0) to ignore source vertex
         for (int i = 1; i < records.size(); i++) {
@@ -54,7 +67,6 @@ public class KneighborRecords extends SingleWayMultiPathsRecords {
                 limit--;
             }
         }
-        return ids;
     }
 
     @Override

--- a/hugegraph-core/src/main/java/org/apache/hugegraph/traversal/algorithm/steps/Steps.java
+++ b/hugegraph-core/src/main/java/org/apache/hugegraph/traversal/algorithm/steps/Steps.java
@@ -138,6 +138,10 @@ public class Steps {
         return new ArrayList<>(this.edgeSteps.keySet());
     }
 
+    public boolean isEdgeEmpty() {
+        return this.edgeSteps.isEmpty();
+    }
+
     public boolean isVertexEmpty() {
         return this.vertexSteps.isEmpty();
     }

--- a/hugegraph-core/src/main/java/org/apache/hugegraph/util/Consumers.java
+++ b/hugegraph-core/src/main/java/org/apache/hugegraph/util/Consumers.java
@@ -27,16 +27,16 @@ import java.util.concurrent.Callable;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Future;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Consumer;
 
-import org.apache.hugegraph.config.CoreOptions;
-import org.slf4j.Logger;
-
 import org.apache.hugegraph.HugeException;
+import org.apache.hugegraph.config.CoreOptions;
 import org.apache.hugegraph.task.TaskManager.ContextCallable;
+import org.slf4j.Logger;
 
 public final class Consumers<V> {
 
@@ -49,13 +49,13 @@ public final class Consumers<V> {
     private final ExecutorService executor;
     private final Consumer<V> consumer;
     private final Runnable done;
-
+    private final Consumer<Throwable> exceptionHandle;
     private final int workers;
+    private final List<Future> runnings;
     private final int queueSize;
     private final CountDownLatch latch;
-    private final BlockingQueue<V> queue;
-
-    private volatile boolean ending = false;
+    private final BlockingQueue<VWrapper<V>> queue;
+    private final VWrapper<V> queueEnd = new VWrapper(null);
     private volatile Throwable exception = null;
 
     public Consumers(ExecutorService executor, Consumer<V> consumer) {
@@ -64,22 +64,39 @@ public final class Consumers<V> {
 
     public Consumers(ExecutorService executor,
                      Consumer<V> consumer, Runnable done) {
+        this(executor, consumer, done, QUEUE_WORKER_SIZE);
+    }
+
+    public Consumers(ExecutorService executor,
+                     Consumer<V> consumer,
+                     Runnable done,
+                     int queueWorkerSize) {
+        this(executor, consumer, done, null, queueWorkerSize);
+    }
+
+    public Consumers(ExecutorService executor,
+                     Consumer<V> consumer,
+                     Runnable done,
+                     Consumer<Throwable> handle,
+                     int queueWorkerSize) {
         this.executor = executor;
         this.consumer = consumer;
         this.done = done;
+        this.exceptionHandle = handle;
 
         int workers = THREADS;
         if (this.executor instanceof ThreadPoolExecutor) {
             workers = ((ThreadPoolExecutor) this.executor).getCorePoolSize();
         }
         this.workers = workers;
-        this.queueSize = QUEUE_WORKER_SIZE * workers;
+
+        this.runnings = new ArrayList<>(workers);
+        this.queueSize = queueWorkerSize * workers + 1;
         this.latch = new CountDownLatch(workers);
         this.queue = new ArrayBlockingQueue<>(this.queueSize);
     }
 
     public void start(String name) {
-        this.ending = false;
         this.exception = null;
         if (this.executor == null) {
             return;
@@ -87,7 +104,7 @@ public final class Consumers<V> {
         LOG.info("Starting {} workers[{}] with queue size {}...",
                  this.workers, name, this.queueSize);
         for (int i = 0; i < this.workers; i++) {
-            this.executor.submit(new ContextCallable<>(this::runAndDone));
+            this.runnings.add(this.executor.submit(new ContextCallable<>(this::runAndDone)));
         }
     }
 
@@ -95,11 +112,15 @@ public final class Consumers<V> {
         try {
             this.run();
         } catch (Throwable e) {
-            // Only the first exception of one thread can be stored
-            this.exception = e;
-            if (!(e instanceof StopExecution)) {
+            if (e instanceof StopExecution) {
+                this.queue.clear();
+                putEnd();
+            } else {
+                // Only the first exception of one thread can be stored
+                this.exception = e;
                 LOG.error("Error when running task", e);
             }
+            exceptionHandle(e);
         } finally {
             this.done();
             this.latch.countDown();
@@ -109,11 +130,7 @@ public final class Consumers<V> {
 
     private void run() {
         LOG.debug("Start to work...");
-        while (!this.ending) {
-            this.consume();
-        }
-        assert this.ending;
-        while (this.consume()){
+        while (this.consume()) {
             // ignore
         }
 
@@ -121,19 +138,39 @@ public final class Consumers<V> {
     }
 
     private boolean consume() {
-        V elem;
-        try {
-            elem = this.queue.poll(CONSUMER_WAKE_PERIOD, TimeUnit.MILLISECONDS);
-        } catch (InterruptedException e) {
-            // ignore
-            return true;
+        VWrapper<V> elem = null;
+        while (elem == null) {
+            try {
+                elem = this.queue.poll(CONSUMER_WAKE_PERIOD, TimeUnit.MILLISECONDS);
+            } catch (InterruptedException e) {
+                // ignore
+                return false;
+            }
         }
-        if (elem == null) {
+
+        if (elem == queueEnd) {
+            putEnd();
             return false;
         }
         // do job
-        this.consumer.accept(elem);
+        this.consumer.accept(elem.v);
         return true;
+    }
+
+    private void exceptionHandle(Throwable e) {
+        if (this.exceptionHandle == null) {
+            return;
+        }
+
+        try {
+            this.exceptionHandle.accept(e);
+        } catch (Throwable ex) {
+            if (this.exception == null) {
+                this.exception = ex;
+            } else {
+                LOG.warn("Error while calling exceptionHandle()", ex);
+            }
+        }
     }
 
     private void done() {
@@ -168,7 +205,17 @@ public final class Consumers<V> {
             throw this.throwException();
         } else {
             try {
-                this.queue.put(v);
+                this.queue.put(new VWrapper<>(v));
+            } catch (InterruptedException e) {
+                LOG.warn("Interrupted while enqueue", e);
+            }
+        }
+    }
+
+    private void putEnd() {
+        if (this.executor != null) {
+            try {
+                this.queue.put(queueEnd);
             } catch (InterruptedException e) {
                 LOG.warn("Interrupted while enqueue", e);
             }
@@ -176,15 +223,18 @@ public final class Consumers<V> {
     }
 
     public void await() throws Throwable {
-        this.ending = true;
         if (this.executor == null) {
             // call done() directly if without thread pool
             this.done();
         } else {
             try {
+                putEnd();
                 this.latch.await();
             } catch (InterruptedException e) {
                 String error = "Interrupted while waiting for consumers";
+                for (Future f: this.runnings) {
+                    f.cancel(true);
+                }
                 this.exception = new HugeException(error, e);
                 LOG.warn(error, e);
             }
@@ -202,7 +252,7 @@ public final class Consumers<V> {
     public static void executeOncePerThread(ExecutorService executor,
                                             int totalThreads,
                                             Runnable callback)
-                                            throws InterruptedException {
+            throws InterruptedException {
         // Ensure callback execute at least once for every thread
         final Map<Thread, Integer> threadsTimes = new ConcurrentHashMap<>();
         final List<Callable<Void>> tasks = new ArrayList<>();
@@ -230,7 +280,7 @@ public final class Consumers<V> {
         for (int i = 0; i < totalThreads; i++) {
             tasks.add(task);
         }
-        executor.invokeAll(tasks);
+        executor.invokeAll(tasks, 5, TimeUnit.SECONDS);
     }
 
     public static ExecutorService newThreadPool(String prefix, int workers) {
@@ -290,13 +340,21 @@ public final class Consumers<V> {
         public synchronized void returnExecutor(ExecutorService executor) {
             E.checkNotNull(executor, "executor");
             if (!this.executors.offer(executor)) {
-                executor.shutdown();
+                try {
+                    executor.shutdown();
+                } catch (Exception e) {
+                    LOG.warn("close ExecutorService with error:", e);
+                }
             }
         }
 
         public synchronized void destroy() {
             for (ExecutorService executor : this.executors) {
-                executor.shutdown();
+                try {
+                    executor.shutdownNow();
+                } catch (Exception e) {
+                    LOG.warn("close ExecutorService with error:", e);
+                }
             }
             this.executors.clear();
         }
@@ -312,6 +370,14 @@ public final class Consumers<V> {
 
         public StopExecution(String message, Object... args) {
             super(message, args);
+        }
+    }
+
+    public static class VWrapper<V> {
+        public V v;
+
+        public VWrapper(V v) {
+            this.v = v;
         }
     }
 }

--- a/hugegraph-core/src/main/java/org/apache/hugegraph/util/Consumers.java
+++ b/hugegraph-core/src/main/java/org/apache/hugegraph/util/Consumers.java
@@ -43,7 +43,7 @@ public final class Consumers<V> {
     public static final int THREADS = 4 + CoreOptions.CPUS / 4;
     public static final int QUEUE_WORKER_SIZE = 1000;
     public static final long CONSUMER_WAKE_PERIOD = 1;
-    private static final Object QUEUE_END = new Object();
+    private static final Object QUEUE_END = new VWrapper<>(null);
 
     private static final Logger LOG = Log.logger(Consumers.class);
 

--- a/hugegraph-core/src/main/java/org/apache/hugegraph/util/Consumers.java
+++ b/hugegraph-core/src/main/java/org/apache/hugegraph/util/Consumers.java
@@ -43,7 +43,7 @@ public final class Consumers<V> {
     public static final int THREADS = 4 + CoreOptions.CPUS / 4;
     public static final int QUEUE_WORKER_SIZE = 1000;
     public static final long CONSUMER_WAKE_PERIOD = 1;
-    private static final Object QUEUE_END = new VWrapper(null);
+    private static final Object QUEUE_END = new Object();
 
     private static final Logger LOG = Log.logger(Consumers.class);
 
@@ -232,7 +232,7 @@ public final class Consumers<V> {
                 this.latch.await();
             } catch (InterruptedException e) {
                 String error = "Interrupted while waiting for consumers";
-                for (Future f: this.runningFutures) {
+                for (Future f : this.runningFutures) {
                     f.cancel(true);
                 }
                 this.exception = new HugeException(error, e);
@@ -252,8 +252,7 @@ public final class Consumers<V> {
     public static void executeOncePerThread(ExecutorService executor,
                                             int totalThreads,
                                             Runnable callback,
-                                            int invokeTimeout,
-                                            TimeUnit unit)
+                                            int invokeTimeout)
                                             throws InterruptedException {
         // Ensure callback execute at least once for every thread
         final Map<Thread, Integer> threadsTimes = new ConcurrentHashMap<>();
@@ -282,7 +281,7 @@ public final class Consumers<V> {
         for (int i = 0; i < totalThreads; i++) {
             tasks.add(task);
         }
-        executor.invokeAll(tasks, invokeTimeout, unit);
+        executor.invokeAll(tasks, invokeTimeout, TimeUnit.SECONDS);
     }
 
     public static ExecutorService newThreadPool(String prefix, int workers) {

--- a/hugegraph-core/src/main/java/org/apache/hugegraph/util/Consumers.java
+++ b/hugegraph-core/src/main/java/org/apache/hugegraph/util/Consumers.java
@@ -208,7 +208,7 @@ public final class Consumers<V> {
             try {
                 this.queue.put(v);
             } catch (InterruptedException e) {
-                LOG.warn("Interrupted while enqueue", e);
+                LOG.warn("Interrupt while queuing QUEUE_END", e);
             }
         }
     }

--- a/hugegraph-rocksdb/src/main/java/org/apache/hugegraph/backend/store/rocksdb/RocksDBStore.java
+++ b/hugegraph-rocksdb/src/main/java/org/apache/hugegraph/backend/store/rocksdb/RocksDBStore.java
@@ -94,6 +94,7 @@ public abstract class RocksDBStore extends AbstractBackendStore<RocksDBSessions.
     private static final String TABLE_GENERAL_KEY = "general";
     private static final String DB_OPEN = "db-open-%s";
     private static final long OPEN_TIMEOUT = 600L;
+    private static final int TX_CLOSE_TIMEOUT = 30;
     /*
      * This is threads number used to concurrently opening RocksDB dbs,
      * 8 is supposed enough due to configurable data disks and
@@ -279,7 +280,7 @@ public abstract class RocksDBStore extends AbstractBackendStore<RocksDBSessions.
         this.useSessions();
         try {
             Consumers.executeOncePerThread(openPool, OPEN_POOL_THREADS,
-                                           this::closeSessions, 5, TimeUnit.SECONDS);
+                                           this::closeSessions, TX_CLOSE_TIMEOUT);
         } catch (InterruptedException e) {
             throw new BackendException("Failed to close session opened by " +
                                        "open-pool");

--- a/hugegraph-rocksdb/src/main/java/org/apache/hugegraph/backend/store/rocksdb/RocksDBStore.java
+++ b/hugegraph-rocksdb/src/main/java/org/apache/hugegraph/backend/store/rocksdb/RocksDBStore.java
@@ -93,8 +93,8 @@ public abstract class RocksDBStore extends AbstractBackendStore<RocksDBSessions.
 
     private static final String TABLE_GENERAL_KEY = "general";
     private static final String DB_OPEN = "db-open-%s";
-    private static final long OPEN_TIMEOUT = 600L;
-    private static final int TX_CLOSE_TIMEOUT = 30;
+    private static final long DB_OPEN_TIMEOUT = 600L; // unit s
+    private static final long DB_CLOSE_TIMEOUT = 30L; // unit s
     /*
      * This is threads number used to concurrently opening RocksDB dbs,
      * 8 is supposed enough due to configurable data disks and
@@ -280,7 +280,7 @@ public abstract class RocksDBStore extends AbstractBackendStore<RocksDBSessions.
         this.useSessions();
         try {
             Consumers.executeOncePerThread(openPool, OPEN_POOL_THREADS,
-                                           this::closeSessions, TX_CLOSE_TIMEOUT);
+                                           this::closeSessions, DB_CLOSE_TIMEOUT);
         } catch (InterruptedException e) {
             throw new BackendException("Failed to close session opened by " +
                                        "open-pool");
@@ -289,7 +289,7 @@ public abstract class RocksDBStore extends AbstractBackendStore<RocksDBSessions.
         boolean terminated;
         openPool.shutdown();
         try {
-            terminated = openPool.awaitTermination(OPEN_TIMEOUT,
+            terminated = openPool.awaitTermination(DB_OPEN_TIMEOUT,
                                                    TimeUnit.SECONDS);
         } catch (Throwable e) {
             throw new BackendException(

--- a/hugegraph-rocksdb/src/main/java/org/apache/hugegraph/backend/store/rocksdb/RocksDBStore.java
+++ b/hugegraph-rocksdb/src/main/java/org/apache/hugegraph/backend/store/rocksdb/RocksDBStore.java
@@ -44,9 +44,6 @@ import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
 import org.apache.commons.io.FileUtils;
-import org.rocksdb.RocksDBException;
-import org.slf4j.Logger;
-
 import org.apache.hugegraph.HugeException;
 import org.apache.hugegraph.backend.BackendException;
 import org.apache.hugegraph.backend.id.Id;
@@ -69,6 +66,9 @@ import org.apache.hugegraph.util.E;
 import org.apache.hugegraph.util.ExecutorUtil;
 import org.apache.hugegraph.util.InsertionOrderUtil;
 import org.apache.hugegraph.util.Log;
+import org.rocksdb.RocksDBException;
+import org.slf4j.Logger;
+
 import com.google.common.collect.ImmutableList;
 
 public abstract class RocksDBStore extends AbstractBackendStore<RocksDBSessions.Session> {
@@ -279,7 +279,7 @@ public abstract class RocksDBStore extends AbstractBackendStore<RocksDBSessions.
         this.useSessions();
         try {
             Consumers.executeOncePerThread(openPool, OPEN_POOL_THREADS,
-                                           this::closeSessions);
+                                           this::closeSessions, 5, TimeUnit.SECONDS);
         } catch (InterruptedException e) {
             throw new BackendException("Failed to close session opened by " +
                                        "open-pool");


### PR DESCRIPTION
<!-- 
  Thank you very much for contributing to Apache HugeGraph, we are happy that you want to help us improve it!

  Here are some tips for you:
    1. If this is your first time, please read the [contributing guidelines](https://github.com/apache/hugegraph/blob/master/CONTRIBUTING.md)

    2. If a PR fix/close an issue, type the message "close xxx" (xxx is the link of related 
issue) in the content, GitHub will auto link it (Required)

    3. Name the PR title in "Google Commit Format", start with "feat | fix | perf | refactor | doc | chore", 
      such like: "feat(core): support the PageRank algorithm" or "fix: wrong break in the compute loop" (module is optional)
      skip it if you are unsure about which is the best component.

    4. One PR address one issue, better not to mix up multiple issues.

    5. Put an `x` in the `[ ]` to mark the item as CHECKED. `[x]` (or click it directly after 
published)
-->

## Purpose of the PR

- Support batch processing and concurrent execution using multiple threads
  - KoutTraverser & KneighborTraverser
- #2276

<!--
Please explain more context in this section, clarify why the changes are needed. 
e.g:
- If you propose a new API, clarify the use case for a new API.
- If you fix a bug, you can clarify why it is a bug, and should be associated with an issue.
-->

## Main Changes

<!-- Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. These change logs are helpful for better ant faster reviews.)

For example:

- If you introduce a new feature, please show detailed design here or add the link of design documentation.
- If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
- If there is a discussion in the mailing list, please add the link. -->

- Enhance Consumers.java, supporting ExceptionHandle and `Future` to handle InterruptedException when awaiting
- Add Nested Iterator Edge and support batch execution
- Support batch execution & thread parallel in KoutTraverser and Kneighbor
- [design document](https://hugegraph.feishu.cn/wiki/KMbuwfye9itAHokr0mCcm129nrb)

## Verifying these changes

<!-- Please pick the proper options below -->

- [ ] Trivial rework / code cleanup without any test coverage. (No Need)
- [ ] Already covered by existing tests, such as *(please modify tests here)*.
- [x] Need tests and can be verified as follows:
    - Postman Test & Runtime Log: the tests of Kout Post are shown below

### Initialize the Graph
- Initialze the graph according to the [link](https://hugegraph.apache.org/docs/clients/restful-api/traverser/#32-detailed-explanation-of-traverser-api-1)

### Add LOG in consumer

<img width="880" alt="image" src="https://github.com/apache/incubator-hugegraph/assets/77946882/16240ea2-5939-4c13-84ba-0e24bda27f8a">

### Postman Test & Check Log

<img width="783" alt="image" src="https://github.com/apache/incubator-hugegraph/assets/77946882/dab937d3-214d-4b0c-8bfc-6763e5bf6e51">

<img width="1614" alt="image" src="https://github.com/apache/incubator-hugegraph/assets/77946882/93c78a5b-a1d5-4e21-8703-208bc1c115a3">

- About correctness, we conducted multiple sets of serial and parallel comparison tests and found no differences
- About parallel acceleration, there is no significant acceleration due to the lack of larger levels of test data

## Does this PR potentially affect the following parts?

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ]  Nope
- [ ]  Dependencies (add/update license info) <!-- Don't forget to add/update the info in "LICENSE" & "NOTICE" files (both in root & dist module) -->
- [ ]  Modify configurations
- [ ]  The public API
- [x]  Other affects (typed here)
  - Traverser execution logic

## Documentation Status

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ]  `Doc - TODO` <!-- Your PR changes impact docs and you will update later -->
- [ ]  `Doc - Done` <!-- Related docs have been already added or updated -->
- [x]  `Doc - No Need` <!-- Your PR changes don't impact/need docs -->
