### PR TITLE
fix(pd): log4j version conflict & follower NPE

### DIFF
--- a/hugegraph-pd/hg-pd-core/src/main/java/org/apache/hugegraph/pd/raft/RaftRpcClient.java
+++ b/hugegraph-pd/hg-pd-core/src/main/java/org/apache/hugegraph/pd/raft/RaftRpcClient.java
@@ -59,7 +59,7 @@ public class RaftRpcClient {
     private <V> void internalCallAsyncWithRpc(final Endpoint endpoint,
                                               final RaftRpcProcessor.BaseRequest request,
                                               final FutureClosureAdapter<V> closure) {
-        final InvokeContext invokeCtx = null;
+        final InvokeContext invokeCtx = new InvokeContext();
         final InvokeCallback invokeCallback = new InvokeCallback() {
 
             @Override

--- a/hugegraph-pd/hg-pd-service/pom.xml
+++ b/hugegraph-pd/hg-pd-service/pom.xml
@@ -99,6 +99,12 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-log4j2</artifactId>
             <version>2.5.14</version>
+            <exclusions>
+                <exclusion>
+                    <artifactId>log4j-slf4j-impl</artifactId>
+                    <groupId>org.apache.logging.log4j</groupId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>com.lmax</groupId>


### PR DESCRIPTION
close #2340 
Distributed pd deployment, when the second pd node was inited on `this.raftNode = raftGroupService.start(false);`, this error will be reported

![gAXj7cmjRj](https://github.com/apache/incubator-hugegraph/assets/18065113/9c293797-70e2-48bc-829d-2ab4f9a168b0)
