### PR TITLE
fix: check leader role before `setPdConfig`

### DIFF
--- a/hugegraph-pd/hg-pd-core/src/main/java/org/apache/hugegraph/pd/ConfigService.java
+++ b/hugegraph-pd/hg-pd-core/src/main/java/org/apache/hugegraph/pd/ConfigService.java
@@ -24,6 +24,7 @@ import org.apache.hugegraph.pd.config.PDConfig;
 import org.apache.hugegraph.pd.grpc.Metapb;
 import org.apache.hugegraph.pd.meta.ConfigMetaStore;
 import org.apache.hugegraph.pd.meta.MetadataFactory;
+import org.apache.hugegraph.pd.raft.RaftEngine;
 import org.apache.hugegraph.pd.raft.RaftStateListener;
 
 import lombok.extern.slf4j.Slf4j;
@@ -87,6 +88,8 @@ public class ConfigService implements RaftStateListener {
                                          .setMaxShardsPerStore(
                                                  pdConfig.getPartition().getMaxShardsPerStore())
                                          .build();
+            }
+            if (RaftEngine.getInstance().isLeader()) {
                 this.meta.setPdConfig(mConfig);
             }
             pdConfig = updatePDConfig(mConfig);


### PR DESCRIPTION
<!-- 
  Thank you very much for contributing to Apache HugeGraph, we are happy that you want to help us improve it!

  Here are some tips for you:
    1. If this is your first time, please read the [contributing guidelines](https://github.com/apache/hugegraph/blob/master/CONTRIBUTING.md)

    2. If a PR fix/close an issue, type the message "close xxx" (xxx is the link of related 
issue) in the content, GitHub will auto link it (Required)

    3. Name the PR title in "Google Commit Format", start with "feat | fix | perf | refactor | doc | chore", 
      such like: "feat(core): support the PageRank algorithm" or "fix: wrong break in the compute loop" (module is optional)
      skip it if you are unsure about which is the best component.

    4. One PR address one issue, better not to mix up multiple issues.

    5. Put an `x` in the `[ ]` to mark the item as CHECKED. `[x]` (or click it directly after 
published)
-->

## Purpose of the PR

When the PD cluster is configured with three nodes (A, B, C), if nodes A (leader) and B are started in sequence, it is possible for node B to encounter an error (without affecting correctness).

```text
2023-11-03 16:41:53 [JRaft-Closure-Executor-0] [ERROR] o.a.h.p.ConfigService - ConfigService loadConfig exception {}
org.apache.hugegraph.pd.common.PDException: org.apache.hugegraph.pd.common.PDException: org.apache.hugegraph.pd.common.PDException: Error code = 100
	at org.apache.hugegraph.pd.meta.MetadataRocksDBStore.put(MetadataRocksDBStore.java:79) ~[hg-pd-core-1.5.0.1.jar!/:1.5.0.1]
	at org.apache.hugegraph.pd.meta.ConfigMetaStore.setPdConfig(ConfigMetaStore.java:59) ~[hg-pd-core-1.5.0.1.jar!/:1.5.0.1]
	at org.apache.hugegraph.pd.ConfigService.loadConfig(ConfigService.java:91) ~[hg-pd-core-1.5.0.1.jar!/:1.5.0.1]
	at org.apache.hugegraph.pd.ConfigService.onRaftLeaderChanged(ConfigService.java:134) ~[hg-pd-core-1.5.0.1.jar!/:1.5.0.1]
	at org.apache.hugegraph.pd.raft.RaftStateMachine.lambda$onStartFollowing$2(RaftStateMachine.java:139) ~[hg-pd-core-1.5.0.1.jar!/:1.5.0.1]
	at java.util.concurrent.CopyOnWriteArrayList.forEach(CopyOnWriteArrayList.java:807) ~[?:?]
	at org.apache.hugegraph.pd.raft.RaftStateMachine.lambda$onStartFollowing$3(RaftStateMachine.java:138) ~[hg-pd-core-1.5.0.1.jar!/:1.5.0.1]
	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:515) ~[?:?]
	at java.util.concurrent.FutureTask.run$$$capture(FutureTask.java:264) ~[?:?]
	at java.util.concurrent.FutureTask.run(FutureTask.java) ~[?:?]
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128) ~[?:?]
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628) ~[?:?]
	at java.lang.Thread.run(Thread.java:829) ~[?:?]
Caused by: org.apache.hugegraph.pd.common.PDException: org.apache.hugegraph.pd.common.PDException: Error code = 100
	at org.apache.hugegraph.pd.store.RaftKVStore.put(RaftKVStore.java:78) ~[hg-pd-core-1.5.0.1.jar!/:1.5.0.1]
	at org.apache.hugegraph.pd.meta.MetadataRocksDBStore.put(MetadataRocksDBStore.java:77) ~[hg-pd-core-1.5.0.1.jar!/:1.5.0.1]
	... 12 more
```

The error code 100 represents `NOT_LEADER`.

The reason for this is that the configuration service of node A and node B may have a concurrency issue in the callback function registered in the `RaftStateMachine` (`org.apache.hugegraph.pd.ConfigService#onRaftLeaderChanged`). If the callback function of node B is executed **before** the callback function of node A, the above error may occur.

<!--
Please explain more context in this section, clarify why the changes are needed. 
e.g:
- If you propose a new API, clarify the use case for a new API.
- If you fix a bug, you can clarify why it is a bug, and should be associated with an issue.
-->

## Main Changes

To address this, a check is added before `setPdConfig` to determine if the node itself is the leader.

<!-- Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. These change logs are helpful for better ant faster reviews.)

For example:

- If you introduce a new feature, please show detailed design here or add the link of design documentation.
- If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
- If there is a discussion in the mailing list, please add the link. -->

## Verifying these changes

<!-- Please pick the proper options below -->

- [ ] Trivial rework / code cleanup without any test coverage. (No Need)
- [ ] Already covered by existing tests, such as *(please modify tests here)*.
- [x] Need tests and can be verified as follows:
    - PD Multi-Node Testing (**maybe available in future CI**)

## Does this PR potentially affect the following parts?

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ]  Nope
- [ ]  Dependencies (add/update license info) <!-- Don't forget to add/update the info in "LICENSE" & "NOTICE" files (both in root & dist module) -->
- [ ]  Modify configurations
- [ ]  The public API
- [x]  Other affects (typed here)

## Documentation Status

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ]  `Doc - TODO` <!-- Your PR changes impact docs and you will update later -->
- [ ]  `Doc - Done` <!-- Related docs have been already added or updated -->
- [x]  `Doc - No Need` <!-- Your PR changes don't impact/need docs -->
