### PR TITLE
fix(pd-store): partially fix hstore backend core tests failure

### DIFF
--- a/hugegraph-server/hugegraph-core/src/main/java/org/apache/hugegraph/backend/serializer/BinaryBackendEntry.java
+++ b/hugegraph-server/hugegraph-core/src/main/java/org/apache/hugegraph/backend/serializer/BinaryBackendEntry.java
@@ -48,6 +48,7 @@ public class BinaryBackendEntry implements BackendEntry {
         this(type, BytesBuffer.wrap(bytes).parseId(type, enablePartition));
     }
 
+    // FIXME: `enablePartition` is unused here
     public BinaryBackendEntry(HugeType type, byte[] bytes, boolean enablePartition, boolean isOlap) {
         this(type, BytesBuffer.wrap(bytes).parseOlapId(type, isOlap));
     }

--- a/hugegraph-server/hugegraph-core/src/main/java/org/apache/hugegraph/backend/serializer/BinarySerializer.java
+++ b/hugegraph-server/hugegraph-core/src/main/java/org/apache/hugegraph/backend/serializer/BinarySerializer.java
@@ -689,8 +689,10 @@ public class BinarySerializer extends AbstractSerializer {
         if (cq.paging() && !cq.page().isEmpty()) {
             includeStart = true;
             byte[] position = PageState.fromString(cq.page()).position();
-            E.checkArgument(Bytes.compare(position, startId.asBytes()) >= 0,
-                            "Invalid page out of lower bound");
+            // FIXME: Due to the inconsistency in the definition of `position` of RocksDB
+            //  scan iterator and Hstore, temporarily remove the following check.
+            // E.checkArgument(Bytes.compare(position, startId.asBytes()) >= 0,
+            //                 "Invalid page out of lower bound");
             startId = new BinaryId(position, null);
         }
         if (range.keyMax() == null) {
@@ -800,8 +802,10 @@ public class BinarySerializer extends AbstractSerializer {
             if (start == null) {
                 return new IdPrefixQuery(query, id);
             }
-            E.checkArgument(Bytes.compare(start.asBytes(), id.asBytes()) >= 0,
-                            "Invalid page out of lower bound");
+            // FIXME: Due to the inconsistency in the definition of `position` of RocksDB
+            //  scan iterator and Hstore, temporarily remove the following check.
+            // E.checkArgument(Bytes.compare(start.asBytes(), id.asBytes()) >= 0,
+            //                 "Invalid page out of lower bound");
             return new IdPrefixQuery(query, start, id);
         }
 
@@ -830,8 +834,10 @@ public class BinarySerializer extends AbstractSerializer {
         if (start == null) {
             start = min;
         } else {
-            E.checkArgument(Bytes.compare(start.asBytes(), min.asBytes()) >= 0,
-                            "Invalid page out of lower bound");
+            // FIXME: Due to the inconsistency in the definition of `position` of RocksDB
+            //  scan iterator and Hstore, temporarily remove the following check.
+            // E.checkArgument(Bytes.compare(start.asBytes(), min.asBytes()) >= 0,
+            //                 "Invalid page out of lower bound");
         }
 
         if (keyMax == null) {
@@ -924,7 +930,7 @@ public class BinarySerializer extends AbstractSerializer {
              * the page to id and use it as the starting row for this query
              */
             byte[] position = PageState.fromString(query.page()).position();
-            // FIXME: Due to the inconsistency in the definition of the position of the RocksDB
+            // FIXME: Due to the inconsistency in the definition of `position` of RocksDB
             //  scan iterator and Hstore, temporarily remove the following check.
             // E.checkArgument(Bytes.compare(position, prefix.asBytes()) >= 0,
             //                "Invalid page out of lower bound");

--- a/hugegraph-server/hugegraph-core/src/main/java/org/apache/hugegraph/backend/serializer/BinarySerializer.java
+++ b/hugegraph-server/hugegraph-core/src/main/java/org/apache/hugegraph/backend/serializer/BinarySerializer.java
@@ -924,8 +924,10 @@ public class BinarySerializer extends AbstractSerializer {
              * the page to id and use it as the starting row for this query
              */
             byte[] position = PageState.fromString(query.page()).position();
-            E.checkArgument(Bytes.compare(position, prefix.asBytes()) >= 0,
-                            "Invalid page out of lower bound");
+            // FIXME: Due to the inconsistency in the definition of the position of the RocksDB
+            //  scan iterator and Hstore, temporarily remove the following check.
+            // E.checkArgument(Bytes.compare(position, prefix.asBytes()) >= 0,
+            //                "Invalid page out of lower bound");
             BinaryId start = new BinaryId(position, null);
             newQuery = new IdPrefixQuery(query, start, prefix);
         } else {

--- a/hugegraph-server/hugegraph-test/src/main/java/org/apache/hugegraph/core/EdgeCoreTest.java
+++ b/hugegraph-server/hugegraph-test/src/main/java/org/apache/hugegraph/core/EdgeCoreTest.java
@@ -517,7 +517,7 @@ public class EdgeCoreTest extends BaseCoreTest {
                 Assert.assertContains("Zero bytes may not occur in string " +
                                       "parameters", e.getCause().getMessage());
             });
-        } else if (backend.equals("rocksdb") || backend.equals("hbase")) {
+        } else if (ImmutableSet.of("rocksdb", "hbase", "hstore").contains(backend)) {
             Assert.assertThrows(IllegalArgumentException.class, () -> {
                 james.addEdge("write", book, "time", "2017-5-27\u0000");
                 graph.tx().commit();
@@ -5822,7 +5822,7 @@ public class EdgeCoreTest extends BaseCoreTest {
 
         String backend = graph.backend();
         Set<String> nonZeroBackends = ImmutableSet.of("postgresql",
-                                                      "rocksdb", "hbase");
+                                                      "rocksdb", "hbase", "hstore");
         if (nonZeroBackends.contains(backend)) {
             Assert.assertThrows(Exception.class, () -> {
                 louise.addEdge("strike", sean, "id", 4,

--- a/hugegraph-server/hugegraph-test/src/main/java/org/apache/hugegraph/core/VertexCoreTest.java
+++ b/hugegraph-server/hugegraph-test/src/main/java/org/apache/hugegraph/core/VertexCoreTest.java
@@ -6254,7 +6254,7 @@ public class VertexCoreTest extends BaseCoreTest {
 
         String backend = graph.backend();
         Set<String> nonZeroBackends = ImmutableSet.of("postgresql",
-                                                      "rocksdb", "hbase");
+                                                      "rocksdb", "hbase", "hstore");
         if (nonZeroBackends.contains(backend)) {
             Assert.assertThrows(Exception.class, () -> {
                 graph.addVertex(T.label, "person", "name", "0",
@@ -9071,7 +9071,7 @@ public class VertexCoreTest extends BaseCoreTest {
         Assert.assertEquals(0, vertices.size());
 
         String backend = graph.backend();
-        if (ImmutableSet.of("rocksdb", "hbase").contains(backend)) {
+        if (ImmutableSet.of("rocksdb", "hbase", "hstore").contains(backend)) {
             Assert.assertThrows(Exception.class, () -> {
                 graph.addVertex(T.label, "person", "name", "0",
                                 "city", "xyz\u0000efg", "age", 0);


### PR DESCRIPTION
<!-- 
  Thank you very much for contributing to Apache HugeGraph, we are happy that you want to help us improve it!

  Here are some tips for you:
    1. If this is your first time, please read the [contributing guidelines](https://github.com/apache/hugegraph/blob/master/CONTRIBUTING.md)

    2. If a PR fix/close an issue, type the message "close xxx" (xxx is the link of related 
issue) in the content, GitHub will auto link it (Required)

    3. Name the PR title in "Google Commit Format", start with "feat | fix | perf | refactor | doc | chore", 
      such like: "feat(core): support the PageRank algorithm" or "fix: wrong break in the compute loop" (module is optional)
      skip it if you are unsure about which is the best component.

    4. One PR address one issue, better not to mix up multiple issues.

    5. Put an `x` in the `[ ]` to mark the item as CHECKED. `[x]` (or click it directly after 
published)
-->

## Purpose of the PR

close https://github.com/apache/incubator-hugegraph/issues/2420

<!--
Please explain more context in this section, clarify why the changes are needed. 
e.g:
- If you propose a new API, clarify the use case for a new API.
- If you fix a bug, you can clarify why it is a bug, and should be associated with an issue.
-->

## Main Changes

<!-- Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. These change logs are helpful for better ant faster reviews.)

For example:

- If you introduce a new feature, please show detailed design here or add the link of design documentation.
- If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
- If there is a discussion in the mailing list, please add the link. -->

Some tests that are currently failing (not addressed in this PR):

1. Tests related to OLAP in `VertexCoreTest`: Not adapted yet.
2. Tests related to page in `VertexCoreTest` and `EdgeCoreTest`: Inconsistency in the definition of `position` between RocksDB scan iterator and Hstore.
3. Some `RamTableTest` cases: The ramtable feature is not supported by the hstore backend.
4. ...

## Verifying these changes

<!-- Please pick the proper options below -->

- [ ] Trivial rework / code cleanup without any test coverage. (No Need)
- [ ] Already covered by existing tests, such as *(please modify tests here)*.
- [x] Need tests and can be verified as follows:
    - CI

## Does this PR potentially affect the following parts?

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [x]  Nope
- [ ]  Dependencies (add/update license info) <!-- Don't forget to add/update the info in "LICENSE" & "NOTICE" files (both in root & dist module) -->
- [ ]  Modify configurations
- [ ]  The public API
- [ ]  Other affects (typed here)

## Documentation Status

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ]  `Doc - TODO` <!-- Your PR changes impact docs and you will update later -->
- [ ]  `Doc - Done` <!-- Related docs have been already added or updated -->
- [x]  `Doc - No Need` <!-- Your PR changes don't impact/need docs -->
