### PR TITLE
fix(server): make CacheManager constructor private to satisfy the singleton pattern

### DIFF
--- a/hugegraph-server/hugegraph-core/src/main/java/org/apache/hugegraph/backend/cache/CacheManager.java
+++ b/hugegraph-server/hugegraph-core/src/main/java/org/apache/hugegraph/backend/cache/CacheManager.java
@@ -56,7 +56,7 @@ public class CacheManager {
         return cache.enableMetrics(enabled);
     }
 
-    public CacheManager() {
+    private CacheManager() {
         this.caches = new ConcurrentHashMap<>();
         this.timer = new Timer("cache-expirer", true);
 


### PR DESCRIPTION
For the sake of regulation and safety, we should privatize the constructor of cacheManager to satisfy the singleton pattern