### PR TITLE
chore: refine the hg-style.xml specification

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -21,7 +21,3 @@ root = true
 charset = utf-8
 end_of_line = lf
 insert_final_newline = true
-
-[*.{java,xml,py}]
-indent_style = space
-indent_size = 4

--- a/.editorconfig
+++ b/.editorconfig
@@ -21,3 +21,10 @@ root = true
 charset = utf-8
 end_of_line = lf
 insert_final_newline = true
+
+[*.{java,xml,py}]
+indent_style = space
+indent_size = 4
+
+[*.{java,xml}]
+continuation_indent_size = 8

--- a/hugegraph-style.xml
+++ b/hugegraph-style.xml
@@ -42,9 +42,6 @@
       </value>
     </option>
   </JavaCodeStyleSettings>
-  <XML>
-    <option name="XML_LEGACY_SETTINGS_IMPORTED" value="true" />
-  </XML>
   <codeStyleSettings language="JAVA">
     <option name="LINE_COMMENT_AT_FIRST_COLUMN" value="false" />
     <option name="ALIGN_MULTILINE_CHAINED_METHODS" value="true" />
@@ -74,8 +71,27 @@
     <option name="WRAP_LONG_LINES" value="true" />
     <option name="PARAMETER_ANNOTATION_WRAP" value="1" />
     <option name="ENUM_CONSTANTS_WRAP" value="2" />
+    <option name="WRAP_ON_TYPING" value="1" />
+    <option name="SOFT_MARGINS" value="100" />
+    <option name="RIGHT_MARGIN" value="100" />
+    <option name="KEEP_BLANK_LINES_IN_DECLARATIONS" value="1" />
+    <option name="KEEP_BLANK_LINES_IN_CODE" value="1" />
+    <option name="KEEP_BLANK_LINES_BETWEEN_PACKAGE_DECLARATION_AND_HEADER" value="1" />
+    <option name="KEEP_BLANK_LINES_BEFORE_RBRACE" value="1" />
     <indentOptions>
       <option name="SMART_TABS" value="true" />
     </indentOptions>
   </codeStyleSettings>
+  <codeStyleSettings language="XML">
+    <option name="RIGHT_MARGIN" value="120" />
+    <option name="WRAP_ON_TYPING" value="1" />
+    <option name="SOFT_MARGINS" value="120" />
+  </codeStyleSettings>
+  <XML>
+    <option name="XML_TEXT_WRAP" value="0" />
+    <option name="XML_LEGACY_SETTINGS_IMPORTED" value="true" />
+  </XML>
+  <Properties>
+    <option name="KEEP_BLANK_LINES" value="true" />
+  </Properties>
 </code_scheme>

--- a/hugegraph-style.xml
+++ b/hugegraph-style.xml
@@ -17,85 +17,86 @@
 
 <!-- This file could be imported in IDEA for correct code-style -->
 <code_scheme name="hugegraph-style" version="173">
-  <option name="LINE_SEPARATOR" value="&#xA;"/>
-  <option name="RIGHT_MARGIN" value="100"/>
-  <option name="WRAP_WHEN_TYPING_REACHES_RIGHT_MARGIN" value="true"/>
-  <option name="SOFT_MARGINS" value="100"/>
+  <option name="LINE_SEPARATOR" value="&#xA;" />
+  <option name="RIGHT_MARGIN" value="100" />
+  <option name="WRAP_WHEN_TYPING_REACHES_RIGHT_MARGIN" value="true" />
+  <option name="SOFT_MARGINS" value="100" />
   <JavaCodeStyleSettings>
     <option name="JD_P_AT_EMPTY_LINES" value="true" />
     <option name="JD_DO_NOT_WRAP_ONE_LINE_COMMENTS" value="true" />
-    <option name="ANNOTATION_PARAMETER_WRAP" value="1"/>
-    <option name="ALIGN_MULTILINE_ANNOTATION_PARAMETERS" value="true"/>
-    <option name="CLASS_COUNT_TO_USE_IMPORT_ON_DEMAND" value="100"/>
-    <option name="NAMES_COUNT_TO_USE_IMPORT_ON_DEMAND" value="100"/>
+    <option name="ANNOTATION_PARAMETER_WRAP" value="1" />
+    <option name="ALIGN_MULTILINE_ANNOTATION_PARAMETERS" value="true" />
+    <option name="CLASS_COUNT_TO_USE_IMPORT_ON_DEMAND" value="100" />
+    <option name="NAMES_COUNT_TO_USE_IMPORT_ON_DEMAND" value="100" />
     <option name="IMPORT_LAYOUT_TABLE">
       <value>
-        <package name="" withSubpackages="true" static="true"/>
-        <emptyLine/>
-        <package name="java" withSubpackages="true" static="false"/>
-        <emptyLine/>
-        <package name="javax" withSubpackages="true" static="false"/>
-        <emptyLine/>
-        <package name="org" withSubpackages="true" static="false"/>
-        <emptyLine/>
-        <package name="com" withSubpackages="true" static="false"/>
-        <emptyLine/>
-        <package name="" withSubpackages="true" static="false"/>
+        <package name="" withSubpackages="true" static="true" />
+        <emptyLine />
+        <package name="java" withSubpackages="true" static="false" />
+        <emptyLine />
+        <package name="javax" withSubpackages="true" static="false" />
+        <emptyLine />
+        <package name="org" withSubpackages="true" static="false" />
+        <emptyLine />
+        <package name="com" withSubpackages="true" static="false" />
+        <emptyLine />
+        <package name="" withSubpackages="true" static="false" />
       </value>
     </option>
   </JavaCodeStyleSettings>
   <codeStyleSettings language="JAVA">
-    <option name="LINE_COMMENT_AT_FIRST_COLUMN" value="false"/>
-    <option name="ALIGN_MULTILINE_CHAINED_METHODS" value="true"/>
-    <option name="ALIGN_MULTILINE_PARAMETERS_IN_CALLS" value="true"/>
-    <option name="ALIGN_MULTILINE_BINARY_OPERATION" value="true"/>
-    <option name="ALIGN_MULTILINE_ASSIGNMENT" value="true"/>
-    <option name="ALIGN_MULTILINE_TERNARY_OPERATION" value="true"/>
-    <option name="ALIGN_MULTILINE_THROWS_LIST" value="true"/>
-    <option name="ALIGN_MULTILINE_EXTENDS_LIST" value="true"/>
-    <option name="ALIGN_MULTILINE_ARRAY_INITIALIZER_EXPRESSION" value="true"/>
-    <option name="CALL_PARAMETERS_WRAP" value="1"/>
-    <option name="METHOD_PARAMETERS_WRAP" value="1"/>
-    <option name="RESOURCE_LIST_WRAP" value="1"/>
-    <option name="EXTENDS_LIST_WRAP" value="1"/>
-    <option name="THROWS_LIST_WRAP" value="1"/>
-    <option name="METHOD_CALL_CHAIN_WRAP" value="1"/>
-    <option name="BINARY_OPERATION_WRAP" value="1"/>
-    <option name="TERNARY_OPERATION_WRAP" value="1"/>
-    <option name="FOR_STATEMENT_WRAP" value="1"/>
-    <option name="ARRAY_INITIALIZER_WRAP" value="1"/>
-    <option name="ASSIGNMENT_WRAP" value="1"/>
-    <option name="ASSERT_STATEMENT_WRAP" value="1"/>
-    <option name="IF_BRACE_FORCE" value="1"/>
-    <option name="DOWHILE_BRACE_FORCE" value="3"/>
-    <option name="WHILE_BRACE_FORCE" value="1"/>
-    <option name="FOR_BRACE_FORCE" value="1"/>
-    <option name="WRAP_LONG_LINES" value="true"/>
-    <option name="PARAMETER_ANNOTATION_WRAP" value="1"/>
-    <option name="ENUM_CONSTANTS_WRAP" value="2"/>
-    <option name="WRAP_ON_TYPING" value="1"/>
-    <option name="SOFT_MARGINS" value="100"/>
-    <option name="RIGHT_MARGIN" value="100"/>
-    <option name="KEEP_BLANK_LINES_IN_DECLARATIONS" value="1"/>
-    <option name="KEEP_BLANK_LINES_IN_CODE" value="1"/>
-    <option name="KEEP_BLANK_LINES_BETWEEN_PACKAGE_DECLARATION_AND_HEADER" value="1"/>
-    <option name="KEEP_BLANK_LINES_BEFORE_RBRACE" value="1"/>
+    <option name="LINE_COMMENT_AT_FIRST_COLUMN" value="false" />
+    <option name="ALIGN_MULTILINE_CHAINED_METHODS" value="true" />
+    <option name="ALIGN_MULTILINE_PARAMETERS_IN_CALLS" value="true" />
+    <option name="ALIGN_MULTILINE_BINARY_OPERATION" value="true" />
+    <option name="ALIGN_MULTILINE_ASSIGNMENT" value="true" />
+    <option name="ALIGN_MULTILINE_TERNARY_OPERATION" value="true" />
+    <option name="ALIGN_MULTILINE_THROWS_LIST" value="true" />
+    <option name="ALIGN_MULTILINE_EXTENDS_LIST" value="true" />
+    <option name="ALIGN_MULTILINE_ARRAY_INITIALIZER_EXPRESSION" value="true" />
+    <option name="CALL_PARAMETERS_WRAP" value="1" />
+    <option name="METHOD_PARAMETERS_WRAP" value="1" />
+    <option name="RESOURCE_LIST_WRAP" value="1" />
+    <option name="EXTENDS_LIST_WRAP" value="1" />
+    <option name="THROWS_LIST_WRAP" value="1" />
+    <option name="METHOD_CALL_CHAIN_WRAP" value="1" />
+    <option name="BINARY_OPERATION_WRAP" value="1" />
+    <option name="TERNARY_OPERATION_WRAP" value="1" />
+    <option name="FOR_STATEMENT_WRAP" value="1" />
+    <option name="ARRAY_INITIALIZER_WRAP" value="1" />
+    <option name="ASSIGNMENT_WRAP" value="1" />
+    <option name="ASSERT_STATEMENT_WRAP" value="1" />
+    <option name="IF_BRACE_FORCE" value="1" />
+    <option name="DOWHILE_BRACE_FORCE" value="3" />
+    <option name="WHILE_BRACE_FORCE" value="1" />
+    <option name="FOR_BRACE_FORCE" value="1" />
+    <option name="WRAP_LONG_LINES" value="true" />
+    <option name="PARAMETER_ANNOTATION_WRAP" value="1" />
+    <option name="ENUM_CONSTANTS_WRAP" value="2" />
+    <option name="WRAP_ON_TYPING" value="1" />
+    <option name="SOFT_MARGINS" value="100" />
+    <option name="RIGHT_MARGIN" value="100" />
+    <option name="KEEP_BLANK_LINES_IN_DECLARATIONS" value="1" />
+    <option name="KEEP_BLANK_LINES_IN_CODE" value="1" />
+    <option name="KEEP_BLANK_LINES_BETWEEN_PACKAGE_DECLARATION_AND_HEADER" value="1" />
+    <option name="KEEP_BLANK_LINES_BEFORE_RBRACE" value="1" />
     <option name="BLANK_LINES_AROUND_CLASS" value="1" />
     <indentOptions>
-      <option name="SMART_TABS" value="true"/>
+      <option name="SMART_TABS" value="true" />
     </indentOptions>
   </codeStyleSettings>
   <codeStyleSettings language="XML">
-    <option name="RIGHT_MARGIN" value="120"/>
-    <option name="WRAP_ON_TYPING" value="1"/>
-    <option name="SOFT_MARGINS" value="120"/>
+    <option name="RIGHT_MARGIN" value="120" />
+    <option name="WRAP_ON_TYPING" value="1" />
+    <option name="SOFT_MARGINS" value="120" />
   </codeStyleSettings>
   <XML>
-    <option name="XML_TEXT_WRAP" value="0"/>
-    <option name="XML_LEGACY_SETTINGS_IMPORTED" value="true"/>
+    <option name="XML_TEXT_WRAP" value="0" />
+    <option name="XML_LEGACY_SETTINGS_IMPORTED" value="true" />
+    <option name="XML_SPACE_INSIDE_EMPTY_TAG" value="true" />
   </XML>
   <Properties>
-    <option name="KEEP_BLANK_LINES" value="true"/>
+    <option name="KEEP_BLANK_LINES" value="true" />
   </Properties>
   <codeStyleSettings language="yaml">
     <option name="SPACE_WITHIN_BRACKETS" value="false" />

--- a/hugegraph-style.xml
+++ b/hugegraph-style.xml
@@ -17,81 +17,88 @@
 
 <!-- This file could be imported in IDEA for correct code-style -->
 <code_scheme name="hugegraph-style" version="173">
-  <option name="LINE_SEPARATOR" value="&#xA;" />
-  <option name="RIGHT_MARGIN" value="100" />
-  <option name="WRAP_WHEN_TYPING_REACHES_RIGHT_MARGIN" value="true" />
-  <option name="SOFT_MARGINS" value="100" />
+  <option name="LINE_SEPARATOR" value="&#xA;"/>
+  <option name="RIGHT_MARGIN" value="100"/>
+  <option name="WRAP_WHEN_TYPING_REACHES_RIGHT_MARGIN" value="true"/>
+  <option name="SOFT_MARGINS" value="100"/>
   <JavaCodeStyleSettings>
-    <option name="ANNOTATION_PARAMETER_WRAP" value="1" />
-    <option name="ALIGN_MULTILINE_ANNOTATION_PARAMETERS" value="true" />
-    <option name="CLASS_COUNT_TO_USE_IMPORT_ON_DEMAND" value="100" />
-    <option name="NAMES_COUNT_TO_USE_IMPORT_ON_DEMAND" value="100" />
+    <option name="JD_P_AT_EMPTY_LINES" value="true" />
+    <option name="JD_DO_NOT_WRAP_ONE_LINE_COMMENTS" value="true" />
+    <option name="ANNOTATION_PARAMETER_WRAP" value="1"/>
+    <option name="ALIGN_MULTILINE_ANNOTATION_PARAMETERS" value="true"/>
+    <option name="CLASS_COUNT_TO_USE_IMPORT_ON_DEMAND" value="100"/>
+    <option name="NAMES_COUNT_TO_USE_IMPORT_ON_DEMAND" value="100"/>
     <option name="IMPORT_LAYOUT_TABLE">
       <value>
-        <package name="" withSubpackages="true" static="true" />
-        <emptyLine />
-        <package name="java" withSubpackages="true" static="false" />
-        <emptyLine />
-        <package name="javax" withSubpackages="true" static="false" />
-        <emptyLine />
-        <package name="org" withSubpackages="true" static="false" />
-        <emptyLine />
-        <package name="com" withSubpackages="true" static="false" />
-        <emptyLine />
-        <package name="" withSubpackages="true" static="false" />
+        <package name="" withSubpackages="true" static="true"/>
+        <emptyLine/>
+        <package name="java" withSubpackages="true" static="false"/>
+        <emptyLine/>
+        <package name="javax" withSubpackages="true" static="false"/>
+        <emptyLine/>
+        <package name="org" withSubpackages="true" static="false"/>
+        <emptyLine/>
+        <package name="com" withSubpackages="true" static="false"/>
+        <emptyLine/>
+        <package name="" withSubpackages="true" static="false"/>
       </value>
     </option>
   </JavaCodeStyleSettings>
   <codeStyleSettings language="JAVA">
-    <option name="LINE_COMMENT_AT_FIRST_COLUMN" value="false" />
-    <option name="ALIGN_MULTILINE_CHAINED_METHODS" value="true" />
-    <option name="ALIGN_MULTILINE_PARAMETERS_IN_CALLS" value="true" />
-    <option name="ALIGN_MULTILINE_BINARY_OPERATION" value="true" />
-    <option name="ALIGN_MULTILINE_ASSIGNMENT" value="true" />
-    <option name="ALIGN_MULTILINE_TERNARY_OPERATION" value="true" />
-    <option name="ALIGN_MULTILINE_THROWS_LIST" value="true" />
-    <option name="ALIGN_MULTILINE_EXTENDS_LIST" value="true" />
-    <option name="ALIGN_MULTILINE_ARRAY_INITIALIZER_EXPRESSION" value="true" />
-    <option name="CALL_PARAMETERS_WRAP" value="1" />
-    <option name="METHOD_PARAMETERS_WRAP" value="1" />
-    <option name="RESOURCE_LIST_WRAP" value="1" />
-    <option name="EXTENDS_LIST_WRAP" value="1" />
-    <option name="THROWS_LIST_WRAP" value="1" />
-    <option name="METHOD_CALL_CHAIN_WRAP" value="1" />
-    <option name="BINARY_OPERATION_WRAP" value="1" />
-    <option name="TERNARY_OPERATION_WRAP" value="1" />
-    <option name="FOR_STATEMENT_WRAP" value="1" />
-    <option name="ARRAY_INITIALIZER_WRAP" value="1" />
-    <option name="ASSIGNMENT_WRAP" value="1" />
-    <option name="ASSERT_STATEMENT_WRAP" value="1" />
-    <option name="IF_BRACE_FORCE" value="1" />
-    <option name="DOWHILE_BRACE_FORCE" value="3" />
-    <option name="WHILE_BRACE_FORCE" value="1" />
-    <option name="FOR_BRACE_FORCE" value="1" />
-    <option name="WRAP_LONG_LINES" value="true" />
-    <option name="PARAMETER_ANNOTATION_WRAP" value="1" />
-    <option name="ENUM_CONSTANTS_WRAP" value="2" />
-    <option name="WRAP_ON_TYPING" value="1" />
-    <option name="SOFT_MARGINS" value="100" />
-    <option name="RIGHT_MARGIN" value="100" />
-    <option name="KEEP_BLANK_LINES_IN_DECLARATIONS" value="1" />
-    <option name="KEEP_BLANK_LINES_IN_CODE" value="1" />
-    <option name="KEEP_BLANK_LINES_BETWEEN_PACKAGE_DECLARATION_AND_HEADER" value="1" />
-    <option name="KEEP_BLANK_LINES_BEFORE_RBRACE" value="1" />
+    <option name="LINE_COMMENT_AT_FIRST_COLUMN" value="false"/>
+    <option name="ALIGN_MULTILINE_CHAINED_METHODS" value="true"/>
+    <option name="ALIGN_MULTILINE_PARAMETERS_IN_CALLS" value="true"/>
+    <option name="ALIGN_MULTILINE_BINARY_OPERATION" value="true"/>
+    <option name="ALIGN_MULTILINE_ASSIGNMENT" value="true"/>
+    <option name="ALIGN_MULTILINE_TERNARY_OPERATION" value="true"/>
+    <option name="ALIGN_MULTILINE_THROWS_LIST" value="true"/>
+    <option name="ALIGN_MULTILINE_EXTENDS_LIST" value="true"/>
+    <option name="ALIGN_MULTILINE_ARRAY_INITIALIZER_EXPRESSION" value="true"/>
+    <option name="CALL_PARAMETERS_WRAP" value="1"/>
+    <option name="METHOD_PARAMETERS_WRAP" value="1"/>
+    <option name="RESOURCE_LIST_WRAP" value="1"/>
+    <option name="EXTENDS_LIST_WRAP" value="1"/>
+    <option name="THROWS_LIST_WRAP" value="1"/>
+    <option name="METHOD_CALL_CHAIN_WRAP" value="1"/>
+    <option name="BINARY_OPERATION_WRAP" value="1"/>
+    <option name="TERNARY_OPERATION_WRAP" value="1"/>
+    <option name="FOR_STATEMENT_WRAP" value="1"/>
+    <option name="ARRAY_INITIALIZER_WRAP" value="1"/>
+    <option name="ASSIGNMENT_WRAP" value="1"/>
+    <option name="ASSERT_STATEMENT_WRAP" value="1"/>
+    <option name="IF_BRACE_FORCE" value="1"/>
+    <option name="DOWHILE_BRACE_FORCE" value="3"/>
+    <option name="WHILE_BRACE_FORCE" value="1"/>
+    <option name="FOR_BRACE_FORCE" value="1"/>
+    <option name="WRAP_LONG_LINES" value="true"/>
+    <option name="PARAMETER_ANNOTATION_WRAP" value="1"/>
+    <option name="ENUM_CONSTANTS_WRAP" value="2"/>
+    <option name="WRAP_ON_TYPING" value="1"/>
+    <option name="SOFT_MARGINS" value="100"/>
+    <option name="RIGHT_MARGIN" value="100"/>
+    <option name="KEEP_BLANK_LINES_IN_DECLARATIONS" value="1"/>
+    <option name="KEEP_BLANK_LINES_IN_CODE" value="1"/>
+    <option name="KEEP_BLANK_LINES_BETWEEN_PACKAGE_DECLARATION_AND_HEADER" value="1"/>
+    <option name="KEEP_BLANK_LINES_BEFORE_RBRACE" value="1"/>
+    <option name="BLANK_LINES_AROUND_CLASS" value="1" />
     <indentOptions>
-      <option name="SMART_TABS" value="true" />
+      <option name="SMART_TABS" value="true"/>
     </indentOptions>
   </codeStyleSettings>
   <codeStyleSettings language="XML">
-    <option name="RIGHT_MARGIN" value="120" />
-    <option name="WRAP_ON_TYPING" value="1" />
-    <option name="SOFT_MARGINS" value="120" />
+    <option name="RIGHT_MARGIN" value="120"/>
+    <option name="WRAP_ON_TYPING" value="1"/>
+    <option name="SOFT_MARGINS" value="120"/>
   </codeStyleSettings>
   <XML>
-    <option name="XML_TEXT_WRAP" value="0" />
-    <option name="XML_LEGACY_SETTINGS_IMPORTED" value="true" />
+    <option name="XML_TEXT_WRAP" value="0"/>
+    <option name="XML_LEGACY_SETTINGS_IMPORTED" value="true"/>
   </XML>
   <Properties>
-    <option name="KEEP_BLANK_LINES" value="true" />
+    <option name="KEEP_BLANK_LINES" value="true"/>
   </Properties>
+  <codeStyleSettings language="yaml">
+    <option name="SPACE_WITHIN_BRACKETS" value="false" />
+    <option name="SPACE_WITHIN_BRACES" value="false" />
+  </codeStyleSettings>
 </code_scheme>


### PR DESCRIPTION
<!-- 
  Thank you very much for contributing to Apache HugeGraph, we are happy that you want to help us improve it!

  Here are some tips for you:
    1. If this is your first time, please read the [contributing guidelines](https://github.com/apache/hugegraph/blob/master/CONTRIBUTING.md)

    2. If a PR fix/close an issue, type the message "close xxx" (xxx is the link of related 
issue) in the content, GitHub will auto link it (Required)

    3. Name the PR title in "Google Commit Format", start with "feat | fix | perf | refactor | doc | chore", 
      such like: "feat(core): support the PageRank algorithm" or "fix: wrong break in the compute loop" (module is optional)
      skip it if you are unsure about which is the best component.

    4. One PR address one issue, better not to mix up multiple issues.

    5. Put an `x` in the `[ ]` to mark the item as CHECKED. `[x]` (or click it directly after 
published)
-->

## Purpose of the PR

- fix the #2435 's subtask of refine the hg-style.xml specification.<!-- or use "fix #xxx", "xxx" is the ID-link of related issue, e.g: close #1024 -->

<!--
Please explain more context in this section, clarify why the changes are needed. 
e.g:
- If you propose a new API, clarify the use case for a new API.
- If you fix a bug, you can clarify why it is a bug, and should be associated with an issue.
-->

## Main Changes

<!-- Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. These change logs are helpful for better ant faster reviews.)

For example:

- If you introduce a new feature, please show detailed design here or add the link of design documentation.
- If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
- If there is a discussion in the mailing list, please add the link. -->
- Change the maximum wrap text length for XML to 120 (implemented through `hg-style.xml`)
- Add a blank line between method definitions, inner class definitions, and static code blocks (implemented through `hg-style.xml`)
- For Properties files, add the option "KEEP_BLANK_LINES." (implemented through `hg-style.xml`)
- Add `<p>` tags to JavaDoc blank lines (implemented through `hg-style.xml`)
- `.xml` file leaves a blank line at the end (through`.editorconfig`)
- Class declaration requires a blank line before and after each line (implemented via `hg-style.xml`)
- Javadoc line comment not in line (implemented via `hg-style.xml`)
- `.properties` file leaves empty lines (implemented via `hg-style.xml`)
- `.yaml` file braces `{}`, brackets `[]` remove spacing Spaces (implemented via `hg-style.xml`)


## Verifying these changes

<!-- Please pick the proper options below -->

- [ ] Trivial rework / code cleanup without any test coverage. (No Need)
- [ ] Already covered by existing tests, such as *(please modify tests here)*.
- [x] Need tests and can be verified as follows:
    - [x] By reformat the code modules that have completed merge at present, if there is no change, the test is successful😀

## Does this PR potentially affect the following parts?

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ]  Nope
- [ ]  Dependencies (add/update license info) <!-- Don't forget to add/update the info in "LICENSE" & "NOTICE" files (both in root & dist module) -->
- [x]  Modify configurations
- [ ]  The public API
- [x]  Other affects (typed here)
    - [x] When you use hugegraph-style.xml for code reformat, this pr mentions changes that will affect the final result
        However, you need to use the `ctrl+C` shortcut to enable the `.editorconfig` profile in addition to the reformat code option🙈

## Documentation Status

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [x]  `Doc - TODO` <!-- Your PR changes impact docs and you will update later -->
    - [ ] I'm writing the corresponding reformat code related documentation, and I will introduce the new pr corresponding documentation later
- [ ]  `Doc - Done` <!-- Related docs have been already added or updated -->
- [ ]  `Doc - No Need` <!-- Your PR changes don't impact/need docs -->
