### PR TITLE
fix(server): switch rocksdb backend to memory when executing gremlin example

### DIFF
--- a/hugegraph-server/hugegraph-dist/src/assembly/static/scripts/example.groovy
+++ b/hugegraph-server/hugegraph-dist/src/assembly/static/scripts/example.groovy
@@ -19,9 +19,11 @@ import org.apache.hugegraph.dist.RegisterUtil
 import org.apache.hugegraph.masterelection.GlobalMasterInfo
 import org.apache.tinkerpop.gremlin.structure.T
 
-RegisterUtil.registerRocksDB()
+RegisterUtil.registerBackends()
 
-conf = "conf/graphs/hugegraph.properties"
+conf = HugeFactory.getLocalConfig("conf/graphs/hugegraph.properties")
+conf.setProperty("backend", "memory")
+conf.setProperty("serializer", "text")
 graph = HugeFactory.open(conf)
 graph.serverStarted(GlobalMasterInfo.master("server-tinkerpop"))
 schema = graph.schema()


### PR DESCRIPTION
An error occurs when using Gremlin-Console Stand-alone in offline mode:

```text
Error in scripts/example.groovy at [26: graph.serverStarted(GlobalMasterInfo.master("server-tinkerpop"))] - Failed to update/query server info: java.util.concurrent.ExecutionException: org.apache.hugegraph.backend.BackendException: Table 'hugegraph+v' is not opened
```

Due to difficulty in pinpointing the cause and considering the above scenario as an example only, the RocksDB backend will be changed to the memory backend.

@imbajin Perhaps the documentation at [https://hugegraph.apache.org/docs/clients/gremlin-console/](https://hugegraph.apache.org/docs/clients/gremlin-console/) also needs corresponding adjustments. It is not recommended for users to use it in production environments and is intended for example purposes only.
