### PR TITLE
fix(server): avoid overriding backend config in gremlin example script

### DIFF
--- a/hugegraph-server/hugegraph-dist/src/assembly/static/bin/start-hugegraph.sh
+++ b/hugegraph-server/hugegraph-dist/src/assembly/static/bin/start-hugegraph.sh
@@ -91,7 +91,7 @@ if [[ $PRELOAD == "true" ]]; then
     cp "${CONF}"/gremlin-server.yaml "${CONF}/${GREMLIN_SERVER_CONF}"
     cp "${SCRIPTS}"/example.groovy "${SCRIPTS}/${EXAMPLE_SCRIPT}"
     sed -i -e "s/empty-sample.groovy/$EXAMPLE_SCRIPT/g" "${CONF}/${GREMLIN_SERVER_CONF}"
-    sed -i -e '/registerRocksDB/d; /serverStarted/d' "${SCRIPTS}/${EXAMPLE_SCRIPT}"
+    sed -i -e '/registerBackends/d; /serverStarted/d' "${SCRIPTS}/${EXAMPLE_SCRIPT}"
 fi
 
 # TODO: show the output message in hugegraph-server.sh when start the server

--- a/hugegraph-server/hugegraph-dist/src/assembly/static/scripts/example.groovy
+++ b/hugegraph-server/hugegraph-dist/src/assembly/static/scripts/example.groovy
@@ -21,9 +21,7 @@ import org.apache.tinkerpop.gremlin.structure.T
 
 RegisterUtil.registerBackends()
 
-conf = HugeFactory.getLocalConfig("conf/graphs/hugegraph.properties")
-conf.setProperty("backend", "memory")
-conf.setProperty("serializer", "text")
+conf = "conf/graphs/hugegraph.properties"
 graph = HugeFactory.open(conf)
 graph.serverStarted(GlobalMasterInfo.master("server-tinkerpop"))
 schema = graph.schema()


### PR DESCRIPTION
fixup #2518, I noticed that the gremlin example script is also used when importing example graphs, so users should be advised to manually configure the backend to memory.

Corresponding documentation PR -> https://github.com/apache/incubator-hugegraph-doc/pull/354
