### PR TITLE
#2576 Resolve the cache invalidation of the partition->leader shard in ClientCache

### DIFF
--- a/hugegraph-pd/hg-pd-client/src/main/java/org/apache/hugegraph/pd/client/ClientCache.java
+++ b/hugegraph-pd/hg-pd-client/src/main/java/org/apache/hugegraph/pd/client/ClientCache.java
@@ -290,6 +290,7 @@ public class ClientCache {
         groups = new ConcurrentHashMap<>();
         stores = new ConcurrentHashMap<>();
         caches = new ConcurrentHashMap<>();
+        initialized.set(false);
     }
 
     public Shard getLeader(int partitionId) {

--- a/hugegraph-pd/hg-pd-client/src/main/java/org/apache/hugegraph/pd/client/PDClient.java
+++ b/hugegraph-pd/hg-pd-client/src/main/java/org/apache/hugegraph/pd/client/PDClient.java
@@ -461,7 +461,8 @@ public class PDClient {
     public KVPair<Metapb.Partition, Metapb.Shard> getPartition(String graphName, byte[] key) throws
                                                                                              PDException {
         // 先查cache，cache没有命中，在调用PD
-        KVPair<Metapb.Partition, Metapb.Shard> partShard = cache.getPartitionByKey(graphName, key);
+        int code = PartitionUtils.calcHashcode(key);
+        KVPair<Metapb.Partition, Metapb.Shard> partShard = this.getPartitionByCode(graphName, code);
         partShard = getKvPair(graphName, key, partShard);
         return partShard;
     }


### PR DESCRIPTION
Resolved the cache invalidation of the partition->leader shard in ClientCache



## Purpose of the PR

 close #2576 

<!--
Please explain more context in this section, clarify why the changes are needed. 
e.g:
- If you propose a new API, clarify the use case for a new API.
- If you fix a bug, you can clarify why it is a bug, and should be associated with an issue.
-->

## Main Changes

1、Set the initialization flag to false after resetting the cache, allowing reinitialization;
2、If the cache misses, the cache is updated with the results of the query from the PD.


