### PR TITLE
Add comments to the initial-store-count attribute in pd application.yml

### DIFF
--- a/hugegraph-pd/hg-pd-dist/src/assembly/static/conf/application.yml
+++ b/hugegraph-pd/hg-pd-dist/src/assembly/static/conf/application.yml
@@ -69,6 +69,7 @@ store:
   monitor_data_interval: 1 minute
   # 监控数据的保留时间 1 天; day, month, year
   monitor_data_retention: 1 day
+  # 最少存活的store节点数量，少于该数值整个集群不可用
   initial-store-count: 1
 
 partition:


### PR DESCRIPTION

## Purpose of the PR

close #2579 

PD cluster will assess the overall health of the cluster. If the number of store nodes is less than the initial-store-count, the cluster will be unavailable