### PR TITLE
feat: support disable RocksDB auto-compaction by configuration

### DIFF
--- a/hugegraph-store/hg-store-rocksdb/src/main/java/org/apache/hugegraph/rocksdb/access/RocksDBOptions.java
+++ b/hugegraph-store/hg-store-rocksdb/src/main/java/org/apache/hugegraph/rocksdb/access/RocksDBOptions.java
@@ -120,6 +120,13 @@ public class RocksDBOptions extends OptionHolder {
                     disallowEmpty(),
                     "rocksdb-snapshot"
             );
+    public static final ConfigOption<Boolean> DISABLE_AUTO_COMPACTION =
+            new ConfigOption<>(
+                    "rocksdb.disable_auto_compaction",
+                    "Set disable auto compaction.",
+                    disallowEmpty(),
+                    false
+            );
     public static final ConfigConvOption<String, CompactionStyle> COMPACTION_STYLE =
             new ConfigConvOption<>(
                     "rocksdb.compaction_style",

--- a/hugegraph-store/hg-store-rocksdb/src/main/java/org/apache/hugegraph/rocksdb/access/RocksDBSession.java
+++ b/hugegraph-store/hg-store-rocksdb/src/main/java/org/apache/hugegraph/rocksdb/access/RocksDBSession.java
@@ -430,6 +430,9 @@ public class RocksDBSession implements AutoCloseable, Cloneable {
             List<byte[]> columnFamilyBytes = RocksDB.listColumnFamilies(new Options(), dbPath);
 
             ColumnFamilyOptions cfOptions = new ColumnFamilyOptions();
+            if(hugeConfig.get(RocksDBOptions.DISABLE_AUTO_COMPACTION)){
+                cfOptions.setDisableAutoCompactions(true);
+            }
             RocksDBSession.initOptions(this.hugeConfig, null, null, cfOptions, cfOptions);
 
             if (columnFamilyBytes.size() > 0) {

--- a/hugegraph-store/hg-store-rocksdb/src/main/java/org/apache/hugegraph/rocksdb/access/RocksDBSession.java
+++ b/hugegraph-store/hg-store-rocksdb/src/main/java/org/apache/hugegraph/rocksdb/access/RocksDBSession.java
@@ -430,7 +430,7 @@ public class RocksDBSession implements AutoCloseable, Cloneable {
             List<byte[]> columnFamilyBytes = RocksDB.listColumnFamilies(new Options(), dbPath);
 
             ColumnFamilyOptions cfOptions = new ColumnFamilyOptions();
-            if(hugeConfig.get(RocksDBOptions.DISABLE_AUTO_COMPACTION)){
+            if (hugeConfig.get(RocksDBOptions.DISABLE_AUTO_COMPACTION)) {
                 cfOptions.setDisableAutoCompactions(true);
             }
             RocksDBSession.initOptions(this.hugeConfig, null, null, cfOptions, cfOptions);


### PR DESCRIPTION
support disable rocksdb auto compaction through configuration

close #2583 

Feature Description (功能描述)
A new parameter is provided, which allows control over whether to turn off RocksDB's auto compaction through the configuration file.