### PR TITLE
refact: enhance cache invalidation of the partition -> leader shard in ClientCache

### DIFF
--- a/hugegraph-pd/hg-pd-client/src/main/java/org/apache/hugegraph/pd/client/ClientCache.java
+++ b/hugegraph-pd/hg-pd-client/src/main/java/org/apache/hugegraph/pd/client/ClientCache.java
@@ -275,6 +275,7 @@ public class ClientCache {
         groups = new ConcurrentHashMap<>();
         stores = new ConcurrentHashMap<>();
         caches = new ConcurrentHashMap<>();
+        initialized.set(false);
     }
 
     public Shard getLeader(int partitionId) {

--- a/hugegraph-pd/hg-pd-client/src/main/java/org/apache/hugegraph/pd/client/PDClient.java
+++ b/hugegraph-pd/hg-pd-client/src/main/java/org/apache/hugegraph/pd/client/PDClient.java
@@ -461,7 +461,9 @@ public class PDClient {
      */
     public KVPair<Metapb.Partition, Metapb.Shard> getPartition(String graphName, byte[] key) throws
                                                                                              PDException {
-        KVPair<Metapb.Partition, Metapb.Shard> partShard = cache.getPartitionByKey(graphName, key);
+
+        KVPair<Metapb.Partition, Metapb.Shard> partShard =
+                this.getPartitionByCode(graphName, PartitionUtils.calcHashcode(key));
         partShard = getKvPair(graphName, key, partShard);
         return partShard;
     }


### PR DESCRIPTION
Resolved the cache invalidation of the partition->leader shard in ClientCache

Purpose of the PR
close https://github.com/apache/incubator-hugegraph/issues/2576

Main Changes
1、Set the initialization flag to false after resetting the cache, allowing reinitialization;
2、If the cache misses, the cache is updated with the results of the query from the PD.