### PR TITLE
chore: intro `editorconfig-maven-plugin` for verifying code style defined in `.editorconfig`

### DIFF
--- a/hugegraph-server/hugegraph-api/pom.xml
+++ b/hugegraph-server/hugegraph-api/pom.xml
@@ -164,12 +164,12 @@
             <artifactId>arthas-packaging</artifactId>
             <version>${arthas.version}</version>
         </dependency>
-      <dependency>
-        <groupId>org.gridkit.jvmtool</groupId>
-        <artifactId>sjk-core</artifactId>
-        <version>0.22</version>
-        <scope>compile</scope>
-      </dependency>
+        <dependency>
+            <groupId>org.gridkit.jvmtool</groupId>
+            <artifactId>sjk-core</artifactId>
+            <version>0.22</version>
+            <scope>compile</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/hugegraph-server/pom.xml
+++ b/hugegraph-server/pom.xml
@@ -274,20 +274,6 @@
         <pluginManagement>
             <plugins>
                 <plugin>
-                    <artifactId>maven-compiler-plugin</artifactId>
-                    <version>3.1</version>
-                    <configuration>
-                        <source>${maven.compiler.source}</source>
-                        <target>${maven.compiler.target}</target>
-                        <compilerArguments>
-                            <Xmaxerrs>500</Xmaxerrs>
-                        </compilerArguments>
-                        <compilerArgs>
-                            <arg>-Xlint:unchecked</arg>
-                        </compilerArgs>
-                    </configuration>
-                </plugin>
-                <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-clean-plugin</artifactId>
                     <configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -269,7 +269,7 @@
                         <!-- Note that maven submodule directories and many non-source file patterns are excluded by default -->
                         <!-- see https://github.com/ec4j/editorconfig-linters/blob/master/editorconfig-lint-api/src/main/java/org/ec4j/lint/api/Constants.java#L37 -->
                         <!-- You can exclude further files from processing: -->
-                        <exclude>src/main/**/*.whatever</exclude>
+                        <exclude>**/*.txt</exclude>
                     </excludes>
                     <!-- All files are included by default:
                     <includes>

--- a/pom.xml
+++ b/pom.xml
@@ -270,6 +270,7 @@
                         <!-- see https://github.com/ec4j/editorconfig-linters/blob/master/editorconfig-lint-api/src/main/java/org/ec4j/lint/api/Constants.java#L37 -->
                         <!-- You can exclude further files from processing: -->
                         <exclude>**/*.txt</exclude>
+                        <exclude>**/.flattened-pom.xml</exclude>
                     </excludes>
                     <!-- All files are included by default:
                     <includes>
@@ -343,7 +344,7 @@
         </profile>
 
         <!-- Use mvn -P stage to enable the remote apache-stage repo -->
-        <profile>
+         <profile>
             <id>stage</id>
             <repositories>
                 <repository>

--- a/pom.xml
+++ b/pom.xml
@@ -270,6 +270,7 @@
                         <!-- see https://github.com/ec4j/editorconfig-linters/blob/master/editorconfig-lint-api/src/main/java/org/ec4j/lint/api/Constants.java#L37 -->
                         <!-- You can exclude further files from processing: -->
                         <exclude>**/*.txt</exclude>
+                        <exclude>**/.flattened-pom.xml</exclude>
                     </excludes>
                     <!-- All files are included by default:
                     <includes>

--- a/pom.xml
+++ b/pom.xml
@@ -344,7 +344,7 @@
         </profile>
 
         <!-- Use mvn -P stage to enable the remote apache-stage repo -->
-         <profile>
+        <profile>
             <id>stage</id>
             <repositories>
                 <repository>

--- a/pom.xml
+++ b/pom.xml
@@ -219,8 +219,23 @@
                         </execution>
                     </executions>
                 </plugin>
+                <plugin>
+                    <artifactId>maven-compiler-plugin</artifactId>
+                    <version>3.1</version>
+                    <configuration>
+                        <source>${maven.compiler.source}</source>
+                        <target>${maven.compiler.target}</target>
+                        <compilerArguments>
+                            <Xmaxerrs>500</Xmaxerrs>
+                        </compilerArguments>
+                        <compilerArgs>
+                            <arg>-Xlint:unchecked</arg>
+                        </compilerArgs>
+                    </configuration>
+                </plugin>
             </plugins>
         </pluginManagement>
+
         <plugins>
             <plugin>
                 <groupId>org.apache.rat</groupId>
@@ -234,6 +249,34 @@
                         <phase>validate</phase>
                     </execution>
                 </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.ec4j.maven</groupId>
+                <artifactId>editorconfig-maven-plugin</artifactId>
+                <version>0.1.3</version>
+                <executions>
+                    <execution>
+                        <id>style-check</id>
+                        <goals>
+                            <goal>check</goal>
+                        </goals>
+                        <phase>validate</phase>
+                    </execution>
+                </executions>
+                <configuration>
+                    <!-- See http://ec4j.github.io/editorconfig-maven-plugin/ for full configuration reference -->
+                    <excludes>
+                        <!-- Note that maven submodule directories and many non-source file patterns are excluded by default -->
+                        <!-- see https://github.com/ec4j/editorconfig-linters/blob/master/editorconfig-lint-api/src/main/java/org/ec4j/lint/api/Constants.java#L37 -->
+                        <!-- You can exclude further files from processing: -->
+                        <exclude>src/main/**/*.whatever</exclude>
+                    </excludes>
+                    <!-- All files are included by default:
+                    <includes>
+                      <include>**</include>
+                    </includes>
+                    -->
+                </configuration>
             </plugin>
         </plugins>
     </build>

--- a/pom.xml
+++ b/pom.xml
@@ -260,7 +260,7 @@
                         <goals>
                             <goal>check</goal>
                         </goals>
-                        <phase>validate</phase>
+                        <phase>verify</phase>
                     </execution>
                 </executions>
                 <configuration>
@@ -270,7 +270,6 @@
                         <!-- see https://github.com/ec4j/editorconfig-linters/blob/master/editorconfig-lint-api/src/main/java/org/ec4j/lint/api/Constants.java#L37 -->
                         <!-- You can exclude further files from processing: -->
                         <exclude>**/*.txt</exclude>
-                        <exclude>**/.flattened-pom.xml</exclude>
                     </excludes>
                     <!-- All files are included by default:
                     <includes>


### PR DESCRIPTION
follow up #2561

- check code style during the verify phase of the build
- use `mvn editorconfig:format` for one-click code formatting