### PR TITLE
chore(dist): intro additional Dockerfile to build the server image & skip init-hstore backend

### DIFF
--- a/hugegraph-server/Dockerfile-hstore
+++ b/hugegraph-server/Dockerfile-hstore
@@ -1,0 +1,73 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# Dockerfile for HugeGraph Server
+# 1st stage: build source code
+FROM maven:3.9.0-eclipse-temurin-11 AS build
+
+COPY . /pkg
+WORKDIR /pkg
+ARG MAVEN_ARGS
+
+RUN mvn package $MAVEN_ARGS -e -B -ntp -DskipTests -Dmaven.javadoc.skip=true && pwd && ls -l && rm \
+    ./hugegraph-server/*.tar.gz && rm ./hugegraph-pd/*.tar.gz && rm ./hugegraph-store/*.tar.gz
+
+# 2nd stage: runtime env
+# Note: ZGC (The Z Garbage Collector) is only supported on ARM-Mac with java > 13 
+FROM openjdk:11-slim
+
+# remove hugegraph.properties and rename hstore.properties.template for default hstore backend
+RUN cd /pkg/hugegraph-server/apache-hugegraph-server-incubating-*/conf/graphs \
+    && rm hugegraph.properties && mv hstore.properties.template hugegraph.properties
+
+COPY --from=build /pkg/hugegraph-server/apache-hugegraph-server-incubating-*/ /hugegraph-server/
+LABEL maintainer="HugeGraph Docker Maintainers <dev@hugegraph.apache.org>"
+
+# TODO: use g1gc or zgc as default
+ENV JAVA_OPTS="-XX:+UnlockExperimentalVMOptions -XX:+UseContainerSupport -XX:MaxRAMPercentage=50 -XshowSettings:vm" \
+    HUGEGRAPH_HOME="hugegraph-server"
+
+#COPY . /hugegraph/hugegraph-server
+WORKDIR /hugegraph-server/
+
+# 1. Install environment and init HugeGraph Sever
+RUN set -x \
+    && apt-get -q update \
+    && apt-get -q install -y --no-install-recommends --no-install-suggests \
+       dumb-init \
+       procps \
+       curl \
+       lsof \
+       vim \
+       cron \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/* \
+    && service cron start \
+    && pwd && cd /hugegraph-server/ \
+    && sed -i "s/^restserver.url.*$/restserver.url=http:\/\/0.0.0.0:8080/g" ./conf/rest-server.properties
+
+# 2. Init docker script
+COPY hugegraph-server/hugegraph-dist/docker/scripts/remote-connect.groovy ./scripts
+COPY hugegraph-server/hugegraph-dist/docker/scripts/detect-storage.groovy ./scripts
+COPY hugegraph-server/hugegraph-dist/docker/docker-entrypoint.sh .
+RUN chmod 755 ./docker-entrypoint.sh
+
+EXPOSE 8080
+VOLUME /hugegraph-server
+
+ENTRYPOINT ["/usr/bin/dumb-init", "--"]
+CMD ["./docker-entrypoint.sh"]

--- a/hugegraph-server/Dockerfile-hstore
+++ b/hugegraph-server/Dockerfile-hstore
@@ -30,11 +30,11 @@ RUN mvn package $MAVEN_ARGS -e -B -ntp -DskipTests -Dmaven.javadoc.skip=true && 
 # Note: ZGC (The Z Garbage Collector) is only supported on ARM-Mac with java > 13 
 FROM openjdk:11-slim
 
+COPY --from=build /pkg/hugegraph-server/apache-hugegraph-server-incubating-*/ /hugegraph-server/
 # remove hugegraph.properties and rename hstore.properties.template for default hstore backend
-RUN cd /pkg/hugegraph-server/apache-hugegraph-server-incubating-*/conf/graphs \
+RUN cd /hugegraph-server/conf/graphs \
     && rm hugegraph.properties && mv hstore.properties.template hugegraph.properties
 
-COPY --from=build /pkg/hugegraph-server/apache-hugegraph-server-incubating-*/ /hugegraph-server/
 LABEL maintainer="HugeGraph Docker Maintainers <dev@hugegraph.apache.org>"
 
 # TODO: use g1gc or zgc as default

--- a/hugegraph-server/hugegraph-dist/src/assembly/static/conf/graphs/hstore.properties.template
+++ b/hugegraph-server/hugegraph-dist/src/assembly/static/conf/graphs/hstore.properties.template
@@ -1,0 +1,109 @@
+# gremlin entrance to create graph
+# auth config: org.apache.hugegraph.auth.HugeFactoryAuthProxy
+gremlin.graph=org.apache.hugegraph.HugeFactory
+
+# cache config
+#schema.cache_capacity=100000
+# vertex-cache default is 1000w, 10min expired
+vertex.cache_type=l2
+#vertex.cache_capacity=10000000
+#vertex.cache_expire=600
+# edge-cache default is 100w, 10min expired
+edge.cache_type=l2
+#edge.cache_capacity=1000000
+#edge.cache_expire=600
+
+
+# schema illegal name template
+#schema.illegal_name_regex=\s+|~.*
+
+#vertex.default_label=vertex
+
+backend=hstore
+serializer=binary
+
+store=hugegraph
+
+# pd config
+pd.peers=127.0.0.1:8686
+
+# task config
+task.scheduler_type=local
+task.schedule_period=10
+task.retry=0
+task.wait_timeout=10
+
+# raft config
+raft.mode=false
+raft.path=./raft-log
+raft.safe_read=true
+raft.use_replicator_pipeline=true
+raft.election_timeout=10000
+raft.snapshot_interval=3600
+raft.backend_threads=48
+raft.read_index_threads=8
+raft.snapshot_threads=4
+raft.snapshot_parallel_compress=false
+raft.snapshot_compress_threads=4
+raft.snapshot_decompress_threads=4
+raft.read_strategy=ReadOnlyLeaseBased
+raft.queue_size=16384
+raft.queue_publish_timeout=60
+raft.apply_batch=1
+raft.rpc_threads=80
+raft.rpc_connect_timeout=5000
+raft.rpc_timeout=60
+raft.install_snapshot_rpc_timeout=36000
+
+# search config
+search.text_analyzer=jieba
+search.text_analyzer_mode=INDEX
+
+# rocksdb backend config
+#rocksdb.data_path=/path/to/disk
+#rocksdb.wal_path=/path/to/disk
+
+
+# cassandra backend config
+cassandra.host=localhost
+cassandra.port=9042
+cassandra.username=
+cassandra.password=
+#cassandra.connect_timeout=5
+#cassandra.read_timeout=20
+#cassandra.keyspace.strategy=SimpleStrategy
+#cassandra.keyspace.replication=3
+
+# hbase backend config
+#hbase.hosts=localhost
+#hbase.port=2181
+#hbase.znode_parent=/hbase
+#hbase.threads_max=64
+# IMPORTANT: recommend to modify the HBase partition number
+#            by the actual/env data amount & RS amount before init store
+#            It will influence the load speed a lot
+#hbase.enable_partition=true
+#hbase.vertex_partitions=10
+#hbase.edge_partitions=30
+
+# mysql backend config
+#jdbc.driver=com.mysql.jdbc.Driver
+#jdbc.url=jdbc:mysql://127.0.0.1:3306
+#jdbc.username=root
+#jdbc.password=
+#jdbc.reconnect_max_times=3
+#jdbc.reconnect_interval=3
+#jdbc.ssl_mode=false
+
+# postgresql & cockroachdb backend config
+#jdbc.driver=org.postgresql.Driver
+#jdbc.url=jdbc:postgresql://localhost:5432/
+#jdbc.username=postgres
+#jdbc.password=
+#jdbc.postgresql.connect_database=template1
+
+# palo backend config
+#palo.host=127.0.0.1
+#palo.poll_interval=10
+#palo.temp_dir=./palo-data
+#palo.file_limit_size=32

--- a/hugegraph-server/hugegraph-dist/src/assembly/static/conf/graphs/hugegraph.properties
+++ b/hugegraph-server/hugegraph-dist/src/assembly/static/conf/graphs/hugegraph.properties
@@ -19,13 +19,13 @@ edge.cache_type=l2
 
 #vertex.default_label=vertex
 
-backend=hstore
+backend=rocksdb
 serializer=binary
 
 store=hugegraph
 
 # pd config
-pd.peers=127.0.0.1:8686
+#pd.peers=127.0.0.1:8686
 
 # task config
 task.scheduler_type=local

--- a/hugegraph-server/hugegraph-dist/src/main/java/org/apache/hugegraph/cmd/InitStore.java
+++ b/hugegraph-server/hugegraph-dist/src/main/java/org/apache/hugegraph/cmd/InitStore.java
@@ -21,6 +21,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 import org.apache.commons.collections.map.MultiValueMap;
 import org.apache.hugegraph.HugeFactory;
@@ -77,7 +78,13 @@ public class InitStore {
         List<HugeGraph> graphs = new ArrayList<>(graph2ConfigPaths.size());
         try {
             for (Map.Entry<String, String> entry : graph2ConfigPaths.entrySet()) {
-                graphs.add(initGraph(entry.getValue()));
+                String configPath = entry.getValue();
+                HugeConfig config = new HugeConfig(configPath);
+                if (Objects.equals(config.get(CoreOptions.BACKEND), "hstore")) {
+                    // skip initializing hstore backend
+                    continue;
+                }
+                graphs.add(initGraph(configPath));
             }
             StandardAuthenticator.initAdminUserIfNeeded(restConf);
         } finally {

--- a/hugegraph-store/hg-store-dist/src/assembly/static/bin/start-hugegraph-store.sh
+++ b/hugegraph-store/hg-store-dist/src/assembly/static/bin/start-hugegraph-store.sh
@@ -74,12 +74,12 @@ export FILE_LIMITN=1024
 
 function check_evn_limit() {
     local limit_check=$(ulimit -n)
-    if [ ${limit_check} -lt ${FILE_LIMITN} ]; then
+    if [[ ${limit_check} != "unlimited" && ${limit_check} -lt ${FILE_LIMITN} ]]; then
         echo -e "${BASH_SOURCE[0]##*/}:${LINENO}:\E[1;32m ulimit -n 可以打开的最大文件描述符数太少,需要(${FILE_LIMITN})!! \E[0m"
         return 1
     fi
     limit_check=$(ulimit -u)
-    if [ ${limit_check} -lt ${PROC_LIMITN} ]; then
+    if [[ ${limit_check} != "unlimited" && ${limit_check} -lt ${PROC_LIMITN} ]]; then
         echo -e "${BASH_SOURCE[0]##*/}:${LINENO}:\E[1;32m ulimit -u  用户最大可用的进程数太少,需要(${PROC_LIMITN})!! \E[0m"
         return 2
     fi

--- a/pom.xml
+++ b/pom.xml
@@ -151,6 +151,7 @@
                             <exclude>**/*.conf</exclude>
                             <exclude>**/*.map</exclude>
                             <exclude>**/*.properties</exclude>
+                            <exclude>**/*.template</exclude>
                             <exclude>**/bin/hugegraph.service</exclude>
                             <exclude>**/swagger-ui/**/*</exclude>
                             <exclude>scripts/dev/reviewers</exclude>


### PR DESCRIPTION
For the compatibility of https://hub.docker.com/r/hugegraph/hugegraph image, the default backend of `hugegraph.properties` is still configured as rocksdb; the backend of https://hub.docker.com/r/hugegraph/server image defaults to hstore.