### PR TITLE
chore: set the `skipCommonsTests` property to `true` by default

### DIFF
--- a/.github/workflows/commons-ci.yml
+++ b/.github/workflows/commons-ci.yml
@@ -52,11 +52,11 @@ jobs:
 
       - name: Run common test
         run: |
-          mvn test -pl hugegraph-commons/hugegraph-common -Dtest=UnitTestSuite
+          mvn test -pl hugegraph-commons/hugegraph-common -Dtest=UnitTestSuite -DskipCommonsTests=false
 
       - name: Run rpc test
         run: |
-          mvn test -pl hugegraph-commons/hugegraph-rpc -Dtest=UnitTestSuite
+          mvn test -pl hugegraph-commons/hugegraph-rpc -Dtest=UnitTestSuite -DskipCommonsTests=false
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v3.0.0

--- a/hugegraph-commons/pom.xml
+++ b/hugegraph-commons/pom.xml
@@ -116,7 +116,7 @@
         <sun.xml.version>3.0.2</sun.xml.version>
         <checkstyle.plugin.version>3.1.2</checkstyle.plugin.version>
         <checkstyle.version>8.45</checkstyle.version>
-        <skipCommonsTests>false</skipCommonsTests>
+        <skipCommonsTests>true</skipCommonsTests>
     </properties>
 
     <modules>

--- a/hugegraph-server/hugegraph-dist/src/assembly/travis/run-api-test-for-raft.sh
+++ b/hugegraph-server/hugegraph-dist/src/assembly/travis/run-api-test-for-raft.sh
@@ -57,7 +57,7 @@ export HUGEGRAPH_PASSWORD=pa
 $RAFT_TOOLS --set-leader "hugegraph" "$RAFT_LEADER"
 
 # run api-test
-mvn test -pl hugegraph-server/hugegraph-test -am -P api-test,$BACKEND -DskipCommonsTests=true || (cat $RAFT1_DIR/logs/hugegraph-server.log && exit 1)
+mvn test -pl hugegraph-server/hugegraph-test -am -P api-test,$BACKEND || (cat $RAFT1_DIR/logs/hugegraph-server.log && exit 1)
 
 $TRAVIS_DIR/build-report.sh $BACKEND $JACOCO_PORT $REPORT_FILE
 

--- a/hugegraph-server/hugegraph-dist/src/assembly/travis/run-api-test.sh
+++ b/hugegraph-server/hugegraph-dist/src/assembly/travis/run-api-test.sh
@@ -58,7 +58,7 @@ authentication: {
 $TRAVIS_DIR/start-server.sh $SERVER_DIR $BACKEND $JACOCO_PORT || (cat $SERVER_DIR/logs/hugegraph-server.log && exit 1)
 
 # run api-test
-mvn test -pl hugegraph-server/hugegraph-test -am -P api-test,$BACKEND -DskipCommonsTests=true || (cat $SERVER_DIR/logs/hugegraph-server.log && exit 1)
+mvn test -pl hugegraph-server/hugegraph-test -am -P api-test,$BACKEND || (cat $SERVER_DIR/logs/hugegraph-server.log && exit 1)
 
 $TRAVIS_DIR/build-report.sh $BACKEND $JACOCO_PORT $REPORT_FILE
 

--- a/hugegraph-server/hugegraph-dist/src/assembly/travis/run-core-test.sh
+++ b/hugegraph-server/hugegraph-dist/src/assembly/travis/run-core-test.sh
@@ -19,4 +19,4 @@ set -ev
 
 BACKEND=$1
 
-mvn test -pl hugegraph-server/hugegraph-test -am -P core-test,$BACKEND -DskipCommonsTests=true
+mvn test -pl hugegraph-server/hugegraph-test -am -P core-test,$BACKEND

--- a/hugegraph-server/hugegraph-dist/src/assembly/travis/run-tinkerpop-test.sh
+++ b/hugegraph-server/hugegraph-dist/src/assembly/travis/run-tinkerpop-test.sh
@@ -21,9 +21,9 @@ BACKEND=$1
 SUITE=$2
 
 if [[ "$SUITE" == "structure" || "$SUITE" == "tinkerpop" ]]; then
-    mvn test -pl hugegraph-server/hugegraph-test -am -P tinkerpop-structure-test,$BACKEND -DskipCommonsTests=true
+    mvn test -pl hugegraph-server/hugegraph-test -am -P tinkerpop-structure-test,$BACKEND
 fi
 
 if [[ "$SUITE" == "process" || "$SUITE" == "tinkerpop" ]]; then
-    mvn test -pl hugegraph-server/hugegraph-test -am -P tinkerpop-process-test,$BACKEND -DskipCommonsTests=true
+    mvn test -pl hugegraph-server/hugegraph-test -am -P tinkerpop-process-test,$BACKEND
 fi

--- a/hugegraph-server/hugegraph-dist/src/assembly/travis/run-unit-test.sh
+++ b/hugegraph-server/hugegraph-dist/src/assembly/travis/run-unit-test.sh
@@ -20,5 +20,5 @@ set -ev
 BACKEND=$1
 
 if [[ "$BACKEND" == "memory" ]]; then
-    mvn test -pl hugegraph-server/hugegraph-test -am -P unit-test -DskipCommonsTests=true
+    mvn test -pl hugegraph-server/hugegraph-test -am -P unit-test
 fi


### PR DESCRIPTION
fixup [b087f085c1ee7936c0227738a47c1a106825a562](https://github.com/apache/incubator-hugegraph/commit/b087f085c1ee7936c0227738a47c1a106825a562) to avoid running commons tests during maven install...