### PR TITLE
chore(backend): disable unnecssary backends

### DIFF
--- a/hugegraph-cluster-test/hugegraph-clustertest-dist/src/assembly/static/conf/hugegraph.properties.template
+++ b/hugegraph-cluster-test/hugegraph-clustertest-dist/src/assembly/static/conf/hugegraph.properties.template
@@ -81,16 +81,6 @@ search.text_analyzer_mode=INDEX
 #rocksdb.wal_path=/path/to/disk
 
 
-# cassandra backend config
-cassandra.host=localhost
-cassandra.port=9042
-cassandra.username=
-cassandra.password=
-#cassandra.connect_timeout=5
-#cassandra.read_timeout=20
-#cassandra.keyspace.strategy=SimpleStrategy
-#cassandra.keyspace.replication=3
-
 # hbase backend config
 #hbase.hosts=localhost
 #hbase.port=2181
@@ -102,25 +92,3 @@ cassandra.password=
 #hbase.enable_partition=true
 #hbase.vertex_partitions=10
 #hbase.edge_partitions=30
-
-# mysql backend config
-#jdbc.driver=com.mysql.jdbc.Driver
-#jdbc.url=jdbc:mysql://127.0.0.1:3306
-#jdbc.username=root
-#jdbc.password=
-#jdbc.reconnect_max_times=3
-#jdbc.reconnect_interval=3
-#jdbc.ssl_mode=false
-
-# postgresql & cockroachdb backend config
-#jdbc.driver=org.postgresql.Driver
-#jdbc.url=jdbc:postgresql://localhost:5432/
-#jdbc.username=postgres
-#jdbc.password=
-#jdbc.postgresql.connect_database=template1
-
-# palo backend config
-#palo.host=127.0.0.1
-#palo.poll_interval=10
-#palo.temp_dir=./palo-data
-#palo.file_limit_size=32

--- a/hugegraph-server/hugegraph-dist/docker/scripts/detect-storage.groovy
+++ b/hugegraph-server/hugegraph-dist/docker/scripts/detect-storage.groovy
@@ -21,11 +21,6 @@ import org.apache.hugegraph.dist.RegisterUtil
 // register all the backend to avoid changes if needs to support other backend
 RegisterUtil.registerPlugins()
 RegisterUtil.registerRocksDB()
-RegisterUtil.registerCassandra()
-RegisterUtil.registerScyllaDB()
 RegisterUtil.registerHBase()
-RegisterUtil.registerMysql()
-RegisterUtil.registerPalo()
-RegisterUtil.registerPostgresql()
 
 graph = HugeFactory.open('./conf/graphs/hugegraph.properties')

--- a/hugegraph-server/hugegraph-dist/src/assembly/static/conf/graphs/hstore.properties.template
+++ b/hugegraph-server/hugegraph-dist/src/assembly/static/conf/graphs/hstore.properties.template
@@ -19,6 +19,9 @@ edge.cache_type=l2
 
 #vertex.default_label=vertex
 
+# NOTE: since 1.7.0, only hstore, rocksdb, hbase, memory are supported for backend.
+# if you want to use cassandra, mysql, postgresql, cockroachdb or palo as backend, please find a
+# version before 1.7.0 of apache hugegraph for your application.
 backend=hstore
 serializer=binary
 
@@ -41,17 +44,6 @@ search.text_analyzer_mode=INDEX
 #rocksdb.data_path=/path/to/disk
 #rocksdb.wal_path=/path/to/disk
 
-
-# cassandra backend config
-cassandra.host=localhost
-cassandra.port=9042
-cassandra.username=
-cassandra.password=
-#cassandra.connect_timeout=5
-#cassandra.read_timeout=20
-#cassandra.keyspace.strategy=SimpleStrategy
-#cassandra.keyspace.replication=3
-
 # hbase backend config
 #hbase.hosts=localhost
 #hbase.port=2181
@@ -63,28 +55,6 @@ cassandra.password=
 #hbase.enable_partition=true
 #hbase.vertex_partitions=10
 #hbase.edge_partitions=30
-
-# mysql backend config
-#jdbc.driver=com.mysql.jdbc.Driver
-#jdbc.url=jdbc:mysql://127.0.0.1:3306
-#jdbc.username=root
-#jdbc.password=
-#jdbc.reconnect_max_times=3
-#jdbc.reconnect_interval=3
-#jdbc.ssl_mode=false
-
-# postgresql & cockroachdb backend config
-#jdbc.driver=org.postgresql.Driver
-#jdbc.url=jdbc:postgresql://localhost:5432/
-#jdbc.username=postgres
-#jdbc.password=
-#jdbc.postgresql.connect_database=template1
-
-# palo backend config
-#palo.host=127.0.0.1
-#palo.poll_interval=10
-#palo.temp_dir=./palo-data
-#palo.file_limit_size=32
 
 # WARNING: These raft configurations are deprecated, please use the latest version instead.
 # raft.mode=false

--- a/hugegraph-server/hugegraph-dist/src/assembly/static/conf/graphs/hugegraph.properties
+++ b/hugegraph-server/hugegraph-dist/src/assembly/static/conf/graphs/hugegraph.properties
@@ -19,6 +19,9 @@ edge.cache_type=l2
 
 #vertex.default_label=vertex
 
+# NOTE: since 1.7.0, only hstore, rocksdb, hbase, memory are supported for backend.
+# if you want to use cassandra, mysql, postgresql, cockroachdb or palo as backend, please find a
+# version before 1.7.0 of apache hugegraph for your application.
 backend=rocksdb
 serializer=binary
 
@@ -41,17 +44,6 @@ search.text_analyzer_mode=INDEX
 #rocksdb.data_path=/path/to/disk
 #rocksdb.wal_path=/path/to/disk
 
-
-# cassandra backend config
-cassandra.host=localhost
-cassandra.port=9042
-cassandra.username=
-cassandra.password=
-#cassandra.connect_timeout=5
-#cassandra.read_timeout=20
-#cassandra.keyspace.strategy=SimpleStrategy
-#cassandra.keyspace.replication=3
-
 # hbase backend config
 #hbase.hosts=localhost
 #hbase.port=2181
@@ -63,28 +55,6 @@ cassandra.password=
 #hbase.enable_partition=true
 #hbase.vertex_partitions=10
 #hbase.edge_partitions=30
-
-# mysql backend config
-#jdbc.driver=com.mysql.jdbc.Driver
-#jdbc.url=jdbc:mysql://127.0.0.1:3306
-#jdbc.username=root
-#jdbc.password=
-#jdbc.reconnect_max_times=3
-#jdbc.reconnect_interval=3
-#jdbc.ssl_mode=false
-
-# postgresql & cockroachdb backend config
-#jdbc.driver=org.postgresql.Driver
-#jdbc.url=jdbc:postgresql://localhost:5432/
-#jdbc.username=postgres
-#jdbc.password=
-#jdbc.postgresql.connect_database=template1
-
-# palo backend config
-#palo.host=127.0.0.1
-#palo.poll_interval=10
-#palo.temp_dir=./palo-data
-#palo.file_limit_size=32
 
 # WARNING: These raft configurations are deprecated, please use the latest version instead.
 # raft.mode=false

--- a/hugegraph-server/hugegraph-dist/src/main/java/org/apache/hugegraph/dist/RegisterUtil.java
+++ b/hugegraph-server/hugegraph-dist/src/main/java/org/apache/hugegraph/dist/RegisterUtil.java
@@ -70,26 +70,11 @@ public class RegisterUtil {
 
     private static void registerBackend(String backend) {
         switch (backend) {
-            case "cassandra":
-                registerCassandra();
-                break;
-            case "scylladb":
-                registerScyllaDB();
-                break;
             case "hbase":
                 registerHBase();
                 break;
             case "rocksdb":
                 registerRocksDB();
-                break;
-            case "mysql":
-                registerMysql();
-                break;
-            case "palo":
-                registerPalo();
-                break;
-            case "postgresql":
-                registerPostgresql();
                 break;
             case "hstore":
                 registerHstore();

--- a/hugegraph-server/hugegraph-example/src/main/java/org/apache/hugegraph/example/ExampleUtil.java
+++ b/hugegraph-server/hugegraph-example/src/main/java/org/apache/hugegraph/example/ExampleUtil.java
@@ -44,12 +44,8 @@ public class ExampleUtil {
         }
         registered = true;
 
-        RegisterUtil.registerCassandra();
-        RegisterUtil.registerScyllaDB();
         RegisterUtil.registerHBase();
         RegisterUtil.registerRocksDB();
-        RegisterUtil.registerMysql();
-        RegisterUtil.registerPalo();
     }
 
     public static HugeGraph loadGraph() {

--- a/hugegraph-server/hugegraph-example/src/main/resources/hugegraph.properties
+++ b/hugegraph-server/hugegraph-example/src/main/resources/hugegraph.properties
@@ -17,9 +17,6 @@
 
 gremlin.graph=org.apache.hugegraph.HugeFactory
 
-#backend=cassandra
-#serializer=cassandra
-
 backend=rocksdb
 serializer=binary
 
@@ -29,29 +26,6 @@ rate_limit=0
 search.text_analyzer=ikanalyzer
 search.text_analyzer_mode=smart
 
-# cassandra backend config
-cassandra.host=localhost
-cassandra.port=9042
-cassandra.username=
-cassandra.password=
-
 # rocksdb backend config
 #rocksdb.data_path=
 #rocksdb.wal_path=
-
-# mysql backend config
-jdbc.driver=com.mysql.jdbc.Driver
-jdbc.url=jdbc:mysql://127.0.0.1:3306
-jdbc.username=root
-jdbc.password=
-jdbc.reconnect_max_times=3
-jdbc.reconnect_interval=3
-
-# postgresql & cockroachdb backend config
-#jdbc.driver=org.postgresql.Driver
-#jdbc.url=jdbc:postgresql://localhost:5432/
-#jdbc.username=postgres
-#jdbc.password=
-
-# palo backend config
-palo.host=127.0.0.1

--- a/hugegraph-server/hugegraph-test/src/main/resources/hugegraph.properties
+++ b/hugegraph-server/hugegraph-test/src/main/resources/hugegraph.properties
@@ -39,14 +39,6 @@ query.index_intersect_threshold=2
 #query.ramtable_vertices_capacity=1800
 #query.ramtable_edges_capacity=1200
 
-# cassandra backend config
-cassandra.host=127.0.0.1
-cassandra.port=9042
-cassandra.username=
-cassandra.password=
-cassandra.connect_timeout=30
-cassandra.read_timeout=120
-
 # rocksdb backend config
 rocksdb.data_path=rocksdb-data
 rocksdb.wal_path=rocksdb-data
@@ -56,25 +48,6 @@ rocksdb.data_disks=[graph/secondary_index:rocksdb-index]
 hbase.hosts=localhost
 hbase.port=2181
 hbase.znode_parent=/hbase
-
-# mysql backend config
-jdbc.driver=com.mysql.jdbc.Driver
-jdbc.url=jdbc:mysql://127.0.0.1:3306
-jdbc.username=root
-jdbc.password=******
-jdbc.forced_auto_reconnect=true
-jdbc.reconnect_max_times=3
-jdbc.reconnect_interval=3
-jdbc.ssl_mode=false
-
-# postgresql & cockroachdb backend config
-#jdbc.driver=org.postgresql.Driver
-#jdbc.url=jdbc:postgresql://localhost:5432/
-#jdbc.username=postgres
-#jdbc.password=
-
-# palo backend config
-palo.host=localhost
 
 snowflake.force_string=true
 task.sync_deletion=true


### PR DESCRIPTION
as title.

sub task of https://github.com/apache/incubator-hugegraph/issues/2724

in 1.7.0, we tend to disable cassandra, mysql, postgresql, cockroachdb or palo as backend.
only hstore, rocksdb, hbase, memory are supported for backend.

if user want to use cassandra, mysql, postgresql, cockroachdb or palo as backend, please find a version before 1.7.0 of apache hugegraph for your application.