### PR TITLE
chore: improve maven Reproducible Builds → upgrade plugins

### DIFF
--- a/hugegraph-cluster-test/hugegraph-clustertest-dist/pom.xml
+++ b/hugegraph-cluster-test/hugegraph-clustertest-dist/pom.xml
@@ -42,7 +42,6 @@
         <plugins>
             <plugin>
                 <artifactId>maven-assembly-plugin</artifactId>
-                <version>2.4</version>
                 <executions>
                     <execution>
                         <id>assembly-hugegraph-ct</id>

--- a/hugegraph-pd/hg-pd-dist/pom.xml
+++ b/hugegraph-pd/hg-pd-dist/pom.xml
@@ -48,7 +48,6 @@
         <plugins>
             <plugin>
                 <artifactId>maven-assembly-plugin</artifactId>
-                <version>2.4</version>
                 <executions>
                     <execution>
                         <id>assembly-hugegraph-pd</id>

--- a/hugegraph-pd/hg-pd-service/pom.xml
+++ b/hugegraph-pd/hg-pd-service/pom.xml
@@ -150,7 +150,7 @@
             <plugin>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
-                <version>2.5.0</version>
+                <version>2.7.1</version>
                 <executions>
                     <execution>
                         <configuration>

--- a/hugegraph-server/hugegraph-core/pom.xml
+++ b/hugegraph-server/hugegraph-core/pom.xml
@@ -359,7 +359,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
-                <version>3.0.2</version>
                 <configuration>
                     <archive>
                         <index>true</index>

--- a/hugegraph-server/hugegraph-dist/pom.xml
+++ b/hugegraph-server/hugegraph-dist/pom.xml
@@ -165,7 +165,6 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-assembly-plugin</artifactId>
-                    <version>2.4</version>
                     <executions>
                         <execution>
                             <id>assembly-hugegraph</id>
@@ -177,9 +176,11 @@
                                 <attach>false</attach>
                                 <appendAssemblyId>false</appendAssemblyId>
                                 <outputDirectory>${top.level.dir}</outputDirectory>
-                                <descriptor>
-                                    ${assembly.descriptor.dir}/assembly.xml
-                                </descriptor>
+                                <descriptors>
+                                    <descriptor>
+                                        ${assembly.descriptor.dir}/assembly.xml
+                                    </descriptor>
+                                </descriptors>
                                 <finalName>${final.name}</finalName>
                             </configuration>
                         </execution>

--- a/hugegraph-store/hg-store-cli/pom.xml
+++ b/hugegraph-store/hg-store-cli/pom.xml
@@ -67,7 +67,7 @@
             <plugin>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
-                <version>2.5.14</version>
+                <version>2.7.1</version>
                 <executions>
                     <execution>
                         <goals>

--- a/hugegraph-store/hg-store-dist/pom.xml
+++ b/hugegraph-store/hg-store-dist/pom.xml
@@ -48,7 +48,6 @@
         <plugins>
             <plugin>
                 <artifactId>maven-assembly-plugin</artifactId>
-                <version>2.4</version>
                 <executions>
                     <execution>
                         <id>assembly-hugegraph-store</id>

--- a/hugegraph-store/hg-store-node/pom.xml
+++ b/hugegraph-store/hg-store-node/pom.xml
@@ -156,7 +156,7 @@
             <plugin>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
-                <version>2.5.14</version>
+                <version>2.7.1</version>
                 <executions>
                     <execution>
                         <goals>

--- a/pom.xml
+++ b/pom.xml
@@ -251,6 +251,14 @@
                         </compilerArgs>
                     </configuration>
                 </plugin>
+                <plugin>
+                    <artifactId>maven-remote-resources-plugin</artifactId>
+                    <version>3.3.0</version>
+                </plugin>
+                <plugin>
+                    <artifactId>maven-shade-plugin</artifactId>
+                    <version>3.6.1</version>
+                </plugin>
             </plugins>
         </pluginManagement>
 


### PR DESCRIPTION
## Purpose of the PR

fix Reproducible Builds issues found after rebuilding release 1.5.0
https://github.com/jvm-repo-rebuild/reproducible-central/blob/master/content/org/apache/hugegraph/README.md

## Main Changes

upgrade plugins known to improve Reproducible Builds, as detected by
`mvn artifact:check-buildplan`

see https://maven.apache.org/guides/mini/guide-reproducible-builds.html for more details

## Verifying these changes

it still builds, but I don't have expertise on really checking if something more subtle is broken

## Does this PR potentially affect the following parts?

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ]  Dependencies ([add/update license](https://hugegraph.apache.org/docs/contribution-guidelines/contribute/#321-check-licenses) info & [regenerate_known_dependencies.sh](../install-dist/scripts/dependency/regenerate_known_dependencies.sh)) <!-- Don't forget to add/update the info in "LICENSE" & "NOTICE" files (both in root & dist module) -->
- [ ]  Modify configurations
- [ ]  The public API
- [ ]  Other affects (typed here)
- [X]  Nope


## Documentation Status

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ]  `Doc - TODO` <!-- Your PR changes impact docs and you will update later -->
- [ ]  `Doc - Done` <!-- Related docs have been already added or updated -->
- [X]  `Doc - No Need` <!-- Your PR changes don't impact/need docs -->
