### PR TITLE
docs: revise Docker usage instructions in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,8 +37,7 @@ Use Docker to quickly start a HugeGraph server with `RocksDB` (in the background
 
 ```
 # (Optional) 
-# 1. remove "-e PASSWORD=xxx" to disable the auth system
-# 2. add "-e PRELOAD=true" to auto-load a sample graph
+# - add "-e PRELOAD=true" to auto-load a sample graph
 docker run -itd --name=graph -e PASSWORD=xxx -p 8080:8080 hugegraph/hugegraph:1.5.0
 ```
 


### PR DESCRIPTION
Updated Docker instructions for HugeGraph server. (Let users enable auth by default)