### PR TITLE
chore(server): upgrade tinkerpop from 3.5 → 3.7.2

### DIFF
--- a/docker/configs/server1-conf/gremlin-driver-settings.yaml
+++ b/docker/configs/server1-conf/gremlin-driver-settings.yaml
@@ -17,7 +17,7 @@
 hosts: [localhost]
 port: 8181
 serializer: {
-  className: org.apache.tinkerpop.gremlin.driver.ser.GraphSONMessageSerializerV1d0,
+  className: org.apache.tinkerpop.gremlin.util.ser.GraphSONMessageSerializerV1,
   config: {
     serializeResultToString: false,
     ioRegistries: [org.apache.hugegraph.io.HugeGraphIoRegistry]

--- a/docker/configs/server1-conf/gremlin-server.yaml
+++ b/docker/configs/server1-conf/gremlin-server.yaml
@@ -82,25 +82,25 @@ scriptEngines: {
   }
 }
 serializers:
-  - {className: org.apache.tinkerpop.gremlin.driver.ser.GraphBinaryMessageSerializerV1,
+  - {className: org.apache.tinkerpop.gremlin.util.ser.GraphBinaryMessageSerializerV1,
      config: {
        serializeResultToString: false,
        ioRegistries: [org.apache.hugegraph.io.HugeGraphIoRegistry]
      }
   }
-  - {className: org.apache.tinkerpop.gremlin.driver.ser.GraphSONMessageSerializerV1d0,
+  - {className: org.apache.tinkerpop.gremlin.util.ser.GraphSONMessageSerializerV1,
      config: {
        serializeResultToString: false,
        ioRegistries: [org.apache.hugegraph.io.HugeGraphIoRegistry]
      }
   }
-  - {className: org.apache.tinkerpop.gremlin.driver.ser.GraphSONMessageSerializerV2d0,
+  - {className: org.apache.tinkerpop.gremlin.util.ser.GraphSONMessageSerializerV2,
      config: {
        serializeResultToString: false,
        ioRegistries: [org.apache.hugegraph.io.HugeGraphIoRegistry]
      }
   }
-  - {className: org.apache.tinkerpop.gremlin.driver.ser.GraphSONMessageSerializerV3d0,
+  - {className: org.apache.tinkerpop.gremlin.util.ser.GraphSONMessageSerializerV3,
      config: {
        serializeResultToString: false,
        ioRegistries: [org.apache.hugegraph.io.HugeGraphIoRegistry]

--- a/docker/configs/server1-conf/remote-objects.yaml
+++ b/docker/configs/server1-conf/remote-objects.yaml
@@ -17,7 +17,7 @@
 hosts: [localhost]
 port: 8181
 serializer: {
-  className: org.apache.tinkerpop.gremlin.driver.ser.GraphSONMessageSerializerV1d0,
+  className: org.apache.tinkerpop.gremlin.util.ser.GraphSONMessageSerializerV1,
   config: {
     serializeResultToString: false,
     # The duplication of HugeGraphIoRegistry is meant to fix a bug in the

--- a/docker/configs/server1-conf/remote.yaml
+++ b/docker/configs/server1-conf/remote.yaml
@@ -17,7 +17,7 @@
 hosts: [localhost]
 port: 8181
 serializer: {
-  className: org.apache.tinkerpop.gremlin.driver.ser.GraphSONMessageSerializerV1d0,
+  className: org.apache.tinkerpop.gremlin.util.ser.GraphSONMessageSerializerV1,
   config: {
     serializeResultToString: false,
     ioRegistries: [org.apache.hugegraph.io.HugeGraphIoRegistry]

--- a/docker/configs/server2-conf/gremlin-driver-settings.yaml
+++ b/docker/configs/server2-conf/gremlin-driver-settings.yaml
@@ -17,7 +17,7 @@
 hosts: [localhost]
 port: 8182
 serializer: {
-  className: org.apache.tinkerpop.gremlin.driver.ser.GraphSONMessageSerializerV1d0,
+  className: org.apache.tinkerpop.gremlin.util.ser.GraphSONMessageSerializerV1,
   config: {
     serializeResultToString: false,
     ioRegistries: [org.apache.hugegraph.io.HugeGraphIoRegistry]

--- a/docker/configs/server2-conf/gremlin-server.yaml
+++ b/docker/configs/server2-conf/gremlin-server.yaml
@@ -82,25 +82,25 @@ scriptEngines: {
   }
 }
 serializers:
-  - {className: org.apache.tinkerpop.gremlin.driver.ser.GraphBinaryMessageSerializerV1,
+  - {className: org.apache.tinkerpop.gremlin.util.ser.GraphBinaryMessageSerializerV1,
      config: {
        serializeResultToString: false,
        ioRegistries: [org.apache.hugegraph.io.HugeGraphIoRegistry]
      }
   }
-  - {className: org.apache.tinkerpop.gremlin.driver.ser.GraphSONMessageSerializerV1d0,
+  - {className: org.apache.tinkerpop.gremlin.util.ser.GraphSONMessageSerializerV1,
      config: {
        serializeResultToString: false,
        ioRegistries: [org.apache.hugegraph.io.HugeGraphIoRegistry]
      }
   }
-  - {className: org.apache.tinkerpop.gremlin.driver.ser.GraphSONMessageSerializerV2d0,
+  - {className: org.apache.tinkerpop.gremlin.util.ser.GraphSONMessageSerializerV2,
      config: {
        serializeResultToString: false,
        ioRegistries: [org.apache.hugegraph.io.HugeGraphIoRegistry]
      }
   }
-  - {className: org.apache.tinkerpop.gremlin.driver.ser.GraphSONMessageSerializerV3d0,
+  - {className: org.apache.tinkerpop.gremlin.util.ser.GraphSONMessageSerializerV3,
      config: {
        serializeResultToString: false,
        ioRegistries: [org.apache.hugegraph.io.HugeGraphIoRegistry]

--- a/docker/configs/server2-conf/remote-objects.yaml
+++ b/docker/configs/server2-conf/remote-objects.yaml
@@ -17,7 +17,7 @@
 hosts: [localhost]
 port: 8182
 serializer: {
-  className: org.apache.tinkerpop.gremlin.driver.ser.GraphSONMessageSerializerV1d0,
+  className: org.apache.tinkerpop.gremlin.util.ser.GraphSONMessageSerializerV1,
   config: {
     serializeResultToString: false,
     # The duplication of HugeGraphIoRegistry is meant to fix a bug in the

--- a/docker/configs/server2-conf/remote.yaml
+++ b/docker/configs/server2-conf/remote.yaml
@@ -17,7 +17,7 @@
 hosts: [localhost]
 port: 8182
 serializer: {
-  className: org.apache.tinkerpop.gremlin.driver.ser.GraphSONMessageSerializerV1d0,
+  className: org.apache.tinkerpop.gremlin.util.ser.GraphSONMessageSerializerV1,
   config: {
     serializeResultToString: false,
     ioRegistries: [org.apache.hugegraph.io.HugeGraphIoRegistry]

--- a/docker/configs/server3-conf/gremlin-driver-settings.yaml
+++ b/docker/configs/server3-conf/gremlin-driver-settings.yaml
@@ -17,7 +17,7 @@
 hosts: [localhost]
 port: 8183
 serializer: {
-  className: org.apache.tinkerpop.gremlin.driver.ser.GraphSONMessageSerializerV1d0,
+  className: org.apache.tinkerpop.gremlin.util.ser.GraphSONMessageSerializerV1,
   config: {
     serializeResultToString: false,
     ioRegistries: [org.apache.hugegraph.io.HugeGraphIoRegistry]

--- a/docker/configs/server3-conf/gremlin-server.yaml
+++ b/docker/configs/server3-conf/gremlin-server.yaml
@@ -82,25 +82,25 @@ scriptEngines: {
   }
 }
 serializers:
-  - {className: org.apache.tinkerpop.gremlin.driver.ser.GraphBinaryMessageSerializerV1,
+  - {className: org.apache.tinkerpop.gremlin.util.ser.GraphBinaryMessageSerializerV1,
      config: {
        serializeResultToString: false,
        ioRegistries: [org.apache.hugegraph.io.HugeGraphIoRegistry]
      }
   }
-  - {className: org.apache.tinkerpop.gremlin.driver.ser.GraphSONMessageSerializerV1d0,
+  - {className: org.apache.tinkerpop.gremlin.util.ser.GraphSONMessageSerializerV1,
      config: {
        serializeResultToString: false,
        ioRegistries: [org.apache.hugegraph.io.HugeGraphIoRegistry]
      }
   }
-  - {className: org.apache.tinkerpop.gremlin.driver.ser.GraphSONMessageSerializerV2d0,
+  - {className: org.apache.tinkerpop.gremlin.util.ser.GraphSONMessageSerializerV2,
      config: {
        serializeResultToString: false,
        ioRegistries: [org.apache.hugegraph.io.HugeGraphIoRegistry]
      }
   }
-  - {className: org.apache.tinkerpop.gremlin.driver.ser.GraphSONMessageSerializerV3d0,
+  - {className: org.apache.tinkerpop.gremlin.util.ser.GraphSONMessageSerializerV3,
      config: {
        serializeResultToString: false,
        ioRegistries: [org.apache.hugegraph.io.HugeGraphIoRegistry]

--- a/docker/configs/server3-conf/remote-objects.yaml
+++ b/docker/configs/server3-conf/remote-objects.yaml
@@ -17,7 +17,7 @@
 hosts: [localhost]
 port: 8183
 serializer: {
-  className: org.apache.tinkerpop.gremlin.driver.ser.GraphSONMessageSerializerV1d0,
+  className: org.apache.tinkerpop.gremlin.util.ser.GraphSONMessageSerializerV1,
   config: {
     serializeResultToString: false,
     # The duplication of HugeGraphIoRegistry is meant to fix a bug in the

--- a/docker/configs/server3-conf/remote.yaml
+++ b/docker/configs/server3-conf/remote.yaml
@@ -17,7 +17,7 @@
 hosts: [localhost]
 port: 8183
 serializer: {
-  className: org.apache.tinkerpop.gremlin.driver.ser.GraphSONMessageSerializerV1d0,
+  className: org.apache.tinkerpop.gremlin.util.ser.GraphSONMessageSerializerV1,
   config: {
     serializeResultToString: false,
     ioRegistries: [org.apache.hugegraph.io.HugeGraphIoRegistry]

--- a/hugegraph-server/hugegraph-api/src/main/java/org/apache/hugegraph/api/cypher/CypherClient.java
+++ b/hugegraph-server/hugegraph-api/src/main/java/org/apache/hugegraph/api/cypher/CypherClient.java
@@ -35,8 +35,8 @@ import org.apache.tinkerpop.gremlin.driver.Client;
 import org.apache.tinkerpop.gremlin.driver.Cluster;
 import org.apache.tinkerpop.gremlin.driver.Result;
 import org.apache.tinkerpop.gremlin.driver.ResultSet;
-import org.apache.tinkerpop.gremlin.driver.Tokens;
-import org.apache.tinkerpop.gremlin.driver.message.RequestMessage;
+import org.apache.tinkerpop.gremlin.util.Tokens;
+import org.apache.tinkerpop.gremlin.util.message.RequestMessage;
 import org.slf4j.Logger;
 
 @ThreadSafe

--- a/hugegraph-server/hugegraph-api/src/main/java/org/apache/hugegraph/opencypher/CypherOpProcessor.java
+++ b/hugegraph-server/hugegraph-api/src/main/java/org/apache/hugegraph/opencypher/CypherOpProcessor.java
@@ -19,7 +19,7 @@ package org.apache.hugegraph.opencypher;
 import static java.util.Collections.emptyMap;
 import static java.util.Collections.singletonList;
 import static java.util.Optional.empty;
-import static org.apache.tinkerpop.gremlin.driver.message.ResponseStatusCode.SERVER_ERROR;
+import static org.apache.tinkerpop.gremlin.util.message.ResponseStatusCode.SERVER_ERROR;
 import static org.opencypher.gremlin.translation.StatementOption.EXPLAIN;
 import static org.slf4j.LoggerFactory.getLogger;
 
@@ -33,10 +33,10 @@ import java.util.concurrent.Future;
 import java.util.concurrent.FutureTask;
 import java.util.concurrent.TimeUnit;
 
-import org.apache.tinkerpop.gremlin.driver.Tokens;
-import org.apache.tinkerpop.gremlin.driver.message.RequestMessage;
-import org.apache.tinkerpop.gremlin.driver.message.ResponseMessage;
-import org.apache.tinkerpop.gremlin.driver.message.ResponseStatusCode;
+import org.apache.tinkerpop.gremlin.util.Tokens;
+import org.apache.tinkerpop.gremlin.util.message.RequestMessage;
+import org.apache.tinkerpop.gremlin.util.message.ResponseMessage;
+import org.apache.tinkerpop.gremlin.util.message.ResponseStatusCode;
 import org.apache.tinkerpop.gremlin.process.traversal.P;
 import org.apache.tinkerpop.gremlin.process.traversal.TraversalSource;
 import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.DefaultGraphTraversal;

--- a/hugegraph-server/hugegraph-core/src/main/java/org/apache/hugegraph/backend/query/Condition.java
+++ b/hugegraph-server/hugegraph-core/src/main/java/org/apache/hugegraph/backend/query/Condition.java
@@ -25,10 +25,10 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.function.BiFunction;
-import java.util.function.BiPredicate;
 
 import org.apache.commons.lang.ArrayUtils;
 import org.apache.hugegraph.backend.id.Id;
+import org.apache.tinkerpop.gremlin.process.traversal.PBiPredicate;
 import org.apache.hugegraph.backend.store.Shard;
 import org.apache.hugegraph.structure.HugeElement;
 import org.apache.hugegraph.structure.HugeProperty;
@@ -51,7 +51,7 @@ public abstract class Condition {
         NOT
     }
 
-    public enum RelationType implements BiPredicate<Object, Object> {
+    public enum RelationType implements PBiPredicate<Object, Object> {
 
         EQ("==", RelationType::equals),
 

--- a/hugegraph-server/hugegraph-core/src/main/java/org/apache/hugegraph/traversal/optimize/ConditionP.java
+++ b/hugegraph-server/hugegraph-core/src/main/java/org/apache/hugegraph/traversal/optimize/ConditionP.java
@@ -17,16 +17,15 @@
 
 package org.apache.hugegraph.traversal.optimize;
 
-import java.util.function.BiPredicate;
-
 import org.apache.hugegraph.backend.query.Condition;
 import org.apache.tinkerpop.gremlin.process.traversal.P;
+import org.apache.tinkerpop.gremlin.process.traversal.PBiPredicate;
 
 public class ConditionP extends P<Object> {
 
     private static final long serialVersionUID = 9094970577400072902L;
 
-    private ConditionP(final BiPredicate<Object, Object> predicate,
+    private ConditionP(final PBiPredicate<Object, Object> predicate,
                        Object value) {
         super(predicate, value);
     }

--- a/hugegraph-server/hugegraph-core/src/main/java/org/apache/hugegraph/traversal/optimize/TraversalUtil.java
+++ b/hugegraph-server/hugegraph-core/src/main/java/org/apache/hugegraph/traversal/optimize/TraversalUtil.java
@@ -24,7 +24,6 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.function.BiPredicate;
 import java.util.function.Function;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -56,6 +55,7 @@ import org.apache.tinkerpop.gremlin.process.traversal.Compare;
 import org.apache.tinkerpop.gremlin.process.traversal.Contains;
 import org.apache.tinkerpop.gremlin.process.traversal.Order;
 import org.apache.tinkerpop.gremlin.process.traversal.P;
+import org.apache.tinkerpop.gremlin.process.traversal.PBiPredicate;
 import org.apache.tinkerpop.gremlin.process.traversal.Step;
 import org.apache.tinkerpop.gremlin.process.traversal.Traversal;
 import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversal;
@@ -350,7 +350,7 @@ public final class TraversalUtil {
     public static Condition convHas2Condition(HasContainer has, HugeType type, HugeGraph graph) {
         P<?> p = has.getPredicate();
         E.checkArgument(p != null, "The predicate of has(%s) is null", has);
-        BiPredicate<?, ?> bp = p.getBiPredicate();
+        PBiPredicate<?, ?> bp = p.getBiPredicate();
         Condition condition;
         if (keyForContainsKeyOrValue(has.getKey())) {
             condition = convContains2Relation(graph, has);
@@ -423,7 +423,7 @@ public final class TraversalUtil {
                                                            HugeType type,
                                                            HasContainer has) {
         assert type.isGraph();
-        BiPredicate<?, ?> bp = has.getPredicate().getBiPredicate();
+        PBiPredicate<?, ?> bp = has.getPredicate().getBiPredicate();
         assert bp instanceof Compare;
 
         return isSysProp(has.getKey()) ?
@@ -434,7 +434,7 @@ public final class TraversalUtil {
     private static Condition.Relation convCompare2SyspropRelation(HugeGraph graph,
                                                                   HugeType type,
                                                                   HasContainer has) {
-        BiPredicate<?, ?> bp = has.getPredicate().getBiPredicate();
+        PBiPredicate<?, ?> bp = has.getPredicate().getBiPredicate();
         assert bp instanceof Compare;
 
         HugeKeys key = token2HugeKey(has.getKey());
@@ -462,7 +462,7 @@ public final class TraversalUtil {
     private static Condition.Relation convCompare2UserpropRelation(HugeGraph graph,
                                                                    HugeType type,
                                                                    HasContainer has) {
-        BiPredicate<?, ?> bp = has.getPredicate().getBiPredicate();
+        PBiPredicate<?, ?> bp = has.getPredicate().getBiPredicate();
         assert bp instanceof Compare;
 
         String key = has.getKey();
@@ -492,7 +492,7 @@ public final class TraversalUtil {
                                                        HugeType type,
                                                        HasContainer has) {
         assert type.isGraph();
-        BiPredicate<?, ?> bp = has.getPredicate().getBiPredicate();
+        PBiPredicate<?, ?> bp = has.getPredicate().getBiPredicate();
         assert bp instanceof Condition.RelationType;
 
         String key = has.getKey();
@@ -505,7 +505,7 @@ public final class TraversalUtil {
     public static Condition convIn2Relation(HugeGraph graph,
                                             HugeType type,
                                             HasContainer has) {
-        BiPredicate<?, ?> bp = has.getPredicate().getBiPredicate();
+        PBiPredicate<?, ?> bp = has.getPredicate().getBiPredicate();
         assert bp instanceof Contains;
         Collection<?> values = (Collection<?>) has.getValue();
 
@@ -548,7 +548,7 @@ public final class TraversalUtil {
     public static Condition convContains2Relation(HugeGraph graph,
                                                   HasContainer has) {
         // Convert contains-key or contains-value
-        BiPredicate<?, ?> bp = has.getPredicate().getBiPredicate();
+        PBiPredicate<?, ?> bp = has.getPredicate().getBiPredicate();
         E.checkArgument(bp == Compare.eq, "CONTAINS query with relation " +
                                           "'%s' is not supported", bp);
 

--- a/hugegraph-server/hugegraph-core/src/main/java/org/apache/hugegraph/version/CoreVersion.java
+++ b/hugegraph-server/hugegraph-core/src/main/java/org/apache/hugegraph/version/CoreVersion.java
@@ -31,7 +31,7 @@ public class CoreVersion {
     /**
      * Update it when the gremlin version changed, search "tinkerpop.version" in pom
      */
-    public static final String GREMLIN_VERSION = "3.5.1";
+    public static final String GREMLIN_VERSION = "3.7.2";
 
     static {
         // Check versions of the dependency packages

--- a/hugegraph-server/hugegraph-dist/src/assembly/static/conf/gremlin-driver-settings.yaml
+++ b/hugegraph-server/hugegraph-dist/src/assembly/static/conf/gremlin-driver-settings.yaml
@@ -17,7 +17,7 @@
 hosts: [localhost]
 port: 8182
 serializer: {
-  className: org.apache.tinkerpop.gremlin.driver.ser.GraphSONMessageSerializerV1d0,
+  className: org.apache.tinkerpop.gremlin.util.ser.GraphSONMessageSerializerV1,
   config: {
     serializeResultToString: false,
     ioRegistries: [org.apache.hugegraph.io.HugeGraphIoRegistry]

--- a/hugegraph-server/hugegraph-dist/src/assembly/static/conf/gremlin-server.yaml
+++ b/hugegraph-server/hugegraph-dist/src/assembly/static/conf/gremlin-server.yaml
@@ -82,25 +82,25 @@ scriptEngines: {
   }
 }
 serializers:
-  - {className: org.apache.tinkerpop.gremlin.driver.ser.GraphBinaryMessageSerializerV1,
+  - {className: org.apache.tinkerpop.gremlin.util.ser.GraphBinaryMessageSerializerV1,
      config: {
        serializeResultToString: false,
        ioRegistries: [org.apache.hugegraph.io.HugeGraphIoRegistry]
      }
   }
-  - {className: org.apache.tinkerpop.gremlin.driver.ser.GraphSONMessageSerializerV1d0,
+  - {className: org.apache.tinkerpop.gremlin.util.ser.GraphSONMessageSerializerV1,
      config: {
        serializeResultToString: false,
        ioRegistries: [org.apache.hugegraph.io.HugeGraphIoRegistry]
      }
   }
-  - {className: org.apache.tinkerpop.gremlin.driver.ser.GraphSONMessageSerializerV2d0,
+  - {className: org.apache.tinkerpop.gremlin.util.ser.GraphSONMessageSerializerV2,
      config: {
        serializeResultToString: false,
        ioRegistries: [org.apache.hugegraph.io.HugeGraphIoRegistry]
      }
   }
-  - {className: org.apache.tinkerpop.gremlin.driver.ser.GraphSONMessageSerializerV3d0,
+  - {className: org.apache.tinkerpop.gremlin.util.ser.GraphSONMessageSerializerV3,
      config: {
        serializeResultToString: false,
        ioRegistries: [org.apache.hugegraph.io.HugeGraphIoRegistry]

--- a/hugegraph-server/hugegraph-dist/src/assembly/static/conf/remote-objects.yaml
+++ b/hugegraph-server/hugegraph-dist/src/assembly/static/conf/remote-objects.yaml
@@ -17,7 +17,7 @@
 hosts: [localhost]
 port: 8182
 serializer: {
-  className: org.apache.tinkerpop.gremlin.driver.ser.GraphSONMessageSerializerV1d0,
+  className: org.apache.tinkerpop.gremlin.util.ser.GraphSONMessageSerializerV1,
   config: {
     serializeResultToString: false,
     # The duplication of HugeGraphIoRegistry is meant to fix a bug in the

--- a/hugegraph-server/hugegraph-dist/src/assembly/static/conf/remote.yaml
+++ b/hugegraph-server/hugegraph-dist/src/assembly/static/conf/remote.yaml
@@ -17,7 +17,7 @@
 hosts: [localhost]
 port: 8182
 serializer: {
-  className: org.apache.tinkerpop.gremlin.driver.ser.GraphSONMessageSerializerV1d0,
+  className: org.apache.tinkerpop.gremlin.util.ser.GraphSONMessageSerializerV1,
   config: {
     serializeResultToString: false,
     ioRegistries: [org.apache.hugegraph.io.HugeGraphIoRegistry]

--- a/hugegraph-server/hugegraph-dist/src/assembly/travis/conf-raft1/gremlin-server.yaml
+++ b/hugegraph-server/hugegraph-dist/src/assembly/travis/conf-raft1/gremlin-server.yaml
@@ -74,25 +74,25 @@ scriptEngines: {
   }
 }
 serializers:
-  - {className: org.apache.tinkerpop.gremlin.driver.ser.GraphBinaryMessageSerializerV1,
+  - {className: org.apache.tinkerpop.gremlin.util.ser.GraphBinaryMessageSerializerV1,
      config: {
        serializeResultToString: false,
        ioRegistries: [org.apache.hugegraph.io.HugeGraphIoRegistry]
      }
   }
-  - {className: org.apache.tinkerpop.gremlin.driver.ser.GraphSONMessageSerializerV1d0,
+  - {className: org.apache.tinkerpop.gremlin.util.ser.GraphSONMessageSerializerV1,
      config: {
        serializeResultToString: false,
        ioRegistries: [org.apache.hugegraph.io.HugeGraphIoRegistry]
      }
   }
-  - {className: org.apache.tinkerpop.gremlin.driver.ser.GraphSONMessageSerializerV2d0,
+  - {className: org.apache.tinkerpop.gremlin.util.ser.GraphSONMessageSerializerV2,
      config: {
        serializeResultToString: false,
        ioRegistries: [org.apache.hugegraph.io.HugeGraphIoRegistry]
      }
   }
-  - {className: org.apache.tinkerpop.gremlin.driver.ser.GraphSONMessageSerializerV3d0,
+  - {className: org.apache.tinkerpop.gremlin.util.ser.GraphSONMessageSerializerV3,
      config: {
        serializeResultToString: false,
        ioRegistries: [org.apache.hugegraph.io.HugeGraphIoRegistry]

--- a/hugegraph-server/hugegraph-dist/src/assembly/travis/conf-raft2/gremlin-server.yaml
+++ b/hugegraph-server/hugegraph-dist/src/assembly/travis/conf-raft2/gremlin-server.yaml
@@ -74,25 +74,25 @@ scriptEngines: {
   }
 }
 serializers:
-  - {className: org.apache.tinkerpop.gremlin.driver.ser.GraphBinaryMessageSerializerV1,
+  - {className: org.apache.tinkerpop.gremlin.util.ser.GraphBinaryMessageSerializerV1,
      config: {
        serializeResultToString: false,
        ioRegistries: [org.apache.hugegraph.io.HugeGraphIoRegistry]
      }
   }
-  - {className: org.apache.tinkerpop.gremlin.driver.ser.GraphSONMessageSerializerV1d0,
+  - {className: org.apache.tinkerpop.gremlin.util.ser.GraphSONMessageSerializerV1,
      config: {
        serializeResultToString: false,
        ioRegistries: [org.apache.hugegraph.io.HugeGraphIoRegistry]
      }
   }
-  - {className: org.apache.tinkerpop.gremlin.driver.ser.GraphSONMessageSerializerV2d0,
+  - {className: org.apache.tinkerpop.gremlin.util.ser.GraphSONMessageSerializerV2,
      config: {
        serializeResultToString: false,
        ioRegistries: [org.apache.hugegraph.io.HugeGraphIoRegistry]
      }
   }
-  - {className: org.apache.tinkerpop.gremlin.driver.ser.GraphSONMessageSerializerV3d0,
+  - {className: org.apache.tinkerpop.gremlin.util.ser.GraphSONMessageSerializerV3,
      config: {
        serializeResultToString: false,
        ioRegistries: [org.apache.hugegraph.io.HugeGraphIoRegistry]

--- a/hugegraph-server/hugegraph-dist/src/assembly/travis/conf-raft3/gremlin-server.yaml
+++ b/hugegraph-server/hugegraph-dist/src/assembly/travis/conf-raft3/gremlin-server.yaml
@@ -74,25 +74,25 @@ scriptEngines: {
   }
 }
 serializers:
-  - {className: org.apache.tinkerpop.gremlin.driver.ser.GraphBinaryMessageSerializerV1,
+  - {className: org.apache.tinkerpop.gremlin.util.ser.GraphBinaryMessageSerializerV1,
      config: {
        serializeResultToString: false,
        ioRegistries: [org.apache.hugegraph.io.HugeGraphIoRegistry]
      }
   }
-  - {className: org.apache.tinkerpop.gremlin.driver.ser.GraphSONMessageSerializerV1d0,
+  - {className: org.apache.tinkerpop.gremlin.util.ser.GraphSONMessageSerializerV1,
      config: {
        serializeResultToString: false,
        ioRegistries: [org.apache.hugegraph.io.HugeGraphIoRegistry]
      }
   }
-  - {className: org.apache.tinkerpop.gremlin.driver.ser.GraphSONMessageSerializerV2d0,
+  - {className: org.apache.tinkerpop.gremlin.util.ser.GraphSONMessageSerializerV2,
      config: {
        serializeResultToString: false,
        ioRegistries: [org.apache.hugegraph.io.HugeGraphIoRegistry]
      }
   }
-  - {className: org.apache.tinkerpop.gremlin.driver.ser.GraphSONMessageSerializerV3d0,
+  - {className: org.apache.tinkerpop.gremlin.util.ser.GraphSONMessageSerializerV3,
      config: {
        serializeResultToString: false,
        ioRegistries: [org.apache.hugegraph.io.HugeGraphIoRegistry]

--- a/hugegraph-server/hugegraph-test/pom.xml
+++ b/hugegraph-server/hugegraph-test/pom.xml
@@ -86,11 +86,6 @@
             <artifactId>gremlin-test</artifactId>
             <version>${tinkerpop.version}</version>
         </dependency>
-        <dependency>
-            <groupId>org.apache.tinkerpop</groupId>
-            <artifactId>gremlin-groovy-test</artifactId>
-            <version>3.2.11</version>
-        </dependency>
 
         <dependency>
             <groupId>org.glassfish.jersey.test-framework.providers</groupId>

--- a/hugegraph-server/hugegraph-test/pom.xml
+++ b/hugegraph-server/hugegraph-test/pom.xml
@@ -153,6 +153,12 @@
                     <execution>
                         <id>unit-test</id>
                         <configuration>
+                            <!--
+                            Java 17+ compatibility: allow reflection access to java.util internals
+                            for CollectionFactoryTest. Follows TinkerPop's approach for deep reflection.
+                            Reference: https://github.com/apache/tinkerpop/blob/384e9a730c735cd386812d463c6f6922da847988/pom.xml#L214
+                            -->
+                            <argLine>--add-opens java.base/java.util=ALL-UNNAMED</argLine>
                             <testSourceDirectory>${basedir}/src/main/java/
                             </testSourceDirectory>
                             <testClassesDirectory>${basedir}/target/classes/

--- a/hugegraph-server/pom.xml
+++ b/hugegraph-server/pom.xml
@@ -42,7 +42,7 @@
         <log4j.version>1.2.17</log4j.version>
         <log4j2.version>2.17.1</log4j2.version>
         <junit.version>4.13.1</junit.version>
-        <tinkerpop.version>3.5.1</tinkerpop.version>
+        <tinkerpop.version>3.7.2</tinkerpop.version>
         <commons.io.version>2.7</commons.io.version>
         <guava.version>25.1-jre</guava.version>
         <httpclient.version>4.5.13</httpclient.version>


### PR DESCRIPTION
## Purpose of the PR

- Relates to Java 17 migration effort

This PR upgrades Apache TinkerPop from 3.5.1 to 3.7.2 to enable Java 17 compatibility while maintaining Java 11 backward compatibility. TinkerPop 3.7.x is the first series that officially supports Java 17.

## Main Changes

1) Dependency upgrade
- Bump `tinkerpop.version` from `3.5.1` to `3.7.2` in `hugegraph-server/pom.xml`.
- Align internal version constant: update `GREMLIN_VERSION = "3.7.2"` in `hugegraph-server/hugegraph-core/src/main/java/org/apache/hugegraph/version/CoreVersion.java`.

2) API migration (TinkerPop 3.7 breaking changes)
- Switch predicate interfaces from `BiPredicate` to `PBiPredicate`:
  - `hugegraph-server/hugegraph-core/src/main/java/org/apache/hugegraph/backend/query/Condition.java`
  - `hugegraph-server/hugegraph-core/src/main/java/org/apache/hugegraph/traversal/optimize/ConditionP.java`
  - `hugegraph-server/hugegraph-core/src/main/java/org/apache/hugegraph/traversal/optimize/TraversalUtil.java`
- Update imports for driver message/types due to package relocation (`driver.*` → `util.*`):
  - `Tokens`, `RequestMessage`, `ResponseMessage`, `ResponseStatusCode`
  - Modified files:
    - `hugegraph-server/hugegraph-api/src/main/java/org/apache/hugegraph/api/cypher/CypherClient.java`
    - `hugegraph-server/hugegraph-api/src/main/java/org/apache/hugegraph/opencypher/CypherOpProcessor.java`

3) Gremlin Server configuration migration
- Serializer class names updated to 3.7 naming (removed `d0` suffix) and package migrated to `org.apache.tinkerpop.gremlin.util.ser.*`:
  - `hugegraph-server/hugegraph-dist/src/assembly/static/conf/gremlin-server.yaml`
  - `hugegraph-server/hugegraph-dist/src/assembly/static/conf/gremlin-driver-settings.yaml`
  - `hugegraph-server/hugegraph-dist/src/assembly/static/conf/remote.yaml`
  - `hugegraph-server/hugegraph-dist/src/assembly/static/conf/remote-objects.yaml`
  - Raft test configs:
    - `hugegraph-server/hugegraph-dist/src/assembly/travis/conf-raft1/gremlin-server.yaml`
    - `hugegraph-server/hugegraph-dist/src/assembly/travis/conf-raft2/gremlin-server.yaml`
    - `hugegraph-server/hugegraph-dist/src/assembly/travis/conf-raft3/gremlin-server.yaml`
- Docker multi-server cluster configs (server1/2/3) updated for consistency:
  - `docker/configs/server1-conf/*`
  - `docker/configs/server2-conf/*`
  - `docker/configs/server3-conf/*`

4) Test dependency cleanup (separate commit in this PR)
- Remove unused `org.apache.tinkerpop:gremlin-groovy-test:3.2.11` from `hugegraph-server/hugegraph-test/pom.xml` to avoid version drift and reduce potential conflicts.

## Verifying these changes

- [x] Already covered by existing tests.
  - Build and unit tests pass on Java 11.
  - Java 17 build/run will be verified in follow-up CI jobs as part of the migration.

## Does this PR potentially affect the following parts?

- [x] Dependencies (TinkerPop 3.5.1 → 3.7.2)
  - Follow-up release task: update/add license info and regenerate known dependencies if required by release process:
    - `install-dist/scripts/dependency/regenerate_known_dependencies.sh`
- [x] Modify configurations (Gremlin server/driver YAML files updated)
- [ ] The public API
- [ ] Other affects
- [ ] Nope

## Documentation Status

- [x] Doc - No Need
  - Internal dependency and configuration migration; no user-facing API change.
- [ ] Doc - TODO
- [ ] Doc - Done

