### PR TITLE
fix: migrate to LTS jdk11 in all Dockerfile

### DIFF
--- a/hugegraph-pd/Dockerfile
+++ b/hugegraph-pd/Dockerfile
@@ -28,7 +28,7 @@ RUN mvn package $MAVEN_ARGS -e -B -ntp -Dmaven.test.skip=true -Dmaven.javadoc.sk
 
 # 2nd stage: runtime env
 # Note: ZGC (The Z Garbage Collector) is only supported on ARM-Mac with java > 13
-FROM openjdk:11-slim
+FROM eclipse-temurin:11-jre
 
 COPY --from=build /pkg/hugegraph-pd/apache-hugegraph-pd-incubating-*/ /hugegraph-pd/
 LABEL maintainer="HugeGraph Docker Maintainers <dev@hugegraph.apache.org>"

--- a/hugegraph-server/Dockerfile
+++ b/hugegraph-server/Dockerfile
@@ -28,7 +28,7 @@ RUN mvn package $MAVEN_ARGS -e -B -ntp -Dmaven.test.skip=true -Dmaven.javadoc.sk
 
 # 2nd stage: runtime env
 # Note: ZGC (The Z Garbage Collector) is only supported on ARM-Mac with java > 13 
-FROM openjdk:11-slim
+FROM eclipse-temurin:11-jre
 
 COPY --from=build /pkg/hugegraph-server/apache-hugegraph-server-incubating-*/ /hugegraph-server/
 LABEL maintainer="HugeGraph Docker Maintainers <dev@hugegraph.apache.org>"

--- a/hugegraph-server/Dockerfile-hstore
+++ b/hugegraph-server/Dockerfile-hstore
@@ -28,7 +28,7 @@ RUN mvn package $MAVEN_ARGS -e -B -ntp -DskipTests -Dmaven.javadoc.skip=true && 
 
 # 2nd stage: runtime env
 # Note: ZGC (The Z Garbage Collector) is only supported on ARM-Mac with java > 13 
-FROM openjdk:11-slim
+FROM eclipse-temurin:11-jre
 
 COPY --from=build /pkg/hugegraph-server/apache-hugegraph-server-incubating-*/ /hugegraph-server/
 # remove hugegraph.properties and rename hstore.properties.template for default hstore backend

--- a/hugegraph-store/Dockerfile
+++ b/hugegraph-store/Dockerfile
@@ -28,7 +28,7 @@ RUN mvn package $MAVEN_ARGS -e -B -ntp -Dmaven.test.skip=true -Dmaven.javadoc.sk
 
 # 2nd stage: runtime env
 # Note: ZGC (The Z Garbage Collector) is only supported on ARM-Mac with java > 13
-FROM openjdk:11-slim
+FROM eclipse-temurin:11-jre
 
 COPY --from=build /pkg/hugegraph-store/apache-hugegraph-store-incubating-*/ /hugegraph-store/
 LABEL maintainer="HugeGraph Docker Maintainers <dev@hugegraph.apache.org>"


### PR DESCRIPTION
https://github.com/docker-library/openjdk/issues/505 openjdk:11-slim is no longer supported, need migrate to LTS version.

<img width="1605" height="288" alt="image" src="https://github.com/user-attachments/assets/63ece9ea-bd33-418b-a783-d2e614acdc53" />