### PR TITLE
fix: use slim docker image

### DIFF
--- a/hugegraph-pd/Dockerfile
+++ b/hugegraph-pd/Dockerfile
@@ -28,7 +28,7 @@ RUN mvn package $MAVEN_ARGS -e -B -ntp -Dmaven.test.skip=true -Dmaven.javadoc.sk
 
 # 2nd stage: runtime env
 # Note: ZGC (The Z Garbage Collector) is only supported on ARM-Mac with java > 13
-FROM eclipse-temurin:11-jre
+FROM eclipse-temurin:11-jre-jammy
 
 COPY --from=build /pkg/hugegraph-pd/apache-hugegraph-pd-incubating-*/ /hugegraph-pd/
 LABEL maintainer="HugeGraph Docker Maintainers <dev@hugegraph.apache.org>"

--- a/hugegraph-server/Dockerfile
+++ b/hugegraph-server/Dockerfile
@@ -28,7 +28,7 @@ RUN mvn package $MAVEN_ARGS -e -B -ntp -Dmaven.test.skip=true -Dmaven.javadoc.sk
 
 # 2nd stage: runtime env
 # Note: ZGC (The Z Garbage Collector) is only supported on ARM-Mac with java > 13 
-FROM eclipse-temurin:11-jre
+FROM eclipse-temurin:11-jre-jammy
 
 COPY --from=build /pkg/hugegraph-server/apache-hugegraph-server-incubating-*/ /hugegraph-server/
 LABEL maintainer="HugeGraph Docker Maintainers <dev@hugegraph.apache.org>"

--- a/hugegraph-server/Dockerfile-hstore
+++ b/hugegraph-server/Dockerfile-hstore
@@ -28,7 +28,7 @@ RUN mvn package $MAVEN_ARGS -e -B -ntp -DskipTests -Dmaven.javadoc.skip=true && 
 
 # 2nd stage: runtime env
 # Note: ZGC (The Z Garbage Collector) is only supported on ARM-Mac with java > 13 
-FROM eclipse-temurin:11-jre
+FROM eclipse-temurin:11-jre-jammy
 
 COPY --from=build /pkg/hugegraph-server/apache-hugegraph-server-incubating-*/ /hugegraph-server/
 # remove hugegraph.properties and rename hstore.properties.template for default hstore backend

--- a/hugegraph-store/Dockerfile
+++ b/hugegraph-store/Dockerfile
@@ -28,7 +28,7 @@ RUN mvn package $MAVEN_ARGS -e -B -ntp -Dmaven.test.skip=true -Dmaven.javadoc.sk
 
 # 2nd stage: runtime env
 # Note: ZGC (The Z Garbage Collector) is only supported on ARM-Mac with java > 13
-FROM eclipse-temurin:11-jre
+FROM eclipse-temurin:11-jre-jammy
 
 COPY --from=build /pkg/hugegraph-store/apache-hugegraph-store-incubating-*/ /hugegraph-store/
 LABEL maintainer="HugeGraph Docker Maintainers <dev@hugegraph.apache.org>"


### PR DESCRIPTION
Use slim docker image to reduce image size.
After comparision, `jammy` is better than `alpine` since `jammy` support more platforms.

```bash
 docker manifest inspect eclipse-temurin:11-jre-alpine              12:07:07
{
   "schemaVersion": 2,
   "mediaType": "application/vnd.oci.image.index.v1+json",
   "manifests": [
      {
         "mediaType": "application/vnd.oci.image.manifest.v1+json",
         "size": 1943,
         "digest": "sha256:6cde7e6ae3c23c3636f3fb4b92836d1323c13929d9ee27da1885cc231c086101",
         "platform": {
            "architecture": "amd64",
            "os": "linux"
         }
      },
      {
         "mediaType": "application/vnd.oci.image.manifest.v1+json",
         "size": 840,
         "digest": "sha256:5eb97410da75fced84bb8bbb4b2f6166c6d99f7fe42fe04ec23356e46e703f0c",
         "platform": {
            "architecture": "unknown",
            "os": "unknown"
         }
      }
   ]
}
```

```bash
docker manifest inspect eclipse-temurin:11-jre-jammy                                                                                                                                                            35s 12:07:33
{
   "schemaVersion": 2,
   "mediaType": "application/vnd.oci.image.index.v1+json",
   "manifests": [
      {
         "mediaType": "application/vnd.oci.image.manifest.v1+json",
         "size": 1940,
         "digest": "sha256:66954426decc542a63c58421445028b5af5471063eac45bc7d845fa772db3e56",
         "platform": {
            "architecture": "amd64",
            "os": "linux"
         }
      },
      {
         "mediaType": "application/vnd.oci.image.manifest.v1+json",
         "size": 841,
         "digest": "sha256:fd5e03e50a0632b8a7d6dc4f9e0002a42a765a755a86942e9040c08041e3aa99",
         "platform": {
            "architecture": "unknown",
            "os": "unknown"
         }
      },
      {
         "mediaType": "application/vnd.oci.image.manifest.v1+json",
         "size": 1942,
         "digest": "sha256:ec3df5adcc48428b02d3a7db2602bffbdfc3e92ba6db3e7fd0d593d547f99b14",
         "platform": {
            "architecture": "arm",
            "os": "linux",
            "variant": "v7"
         }
      },
      {
         "mediaType": "application/vnd.oci.image.manifest.v1+json",
         "size": 841,
         "digest": "sha256:eef2bf4429aab5bf7282f04202ec2810ca353dfa8a1e814f0e5bda48ecba26ee",
         "platform": {
            "architecture": "unknown",
            "os": "unknown"
         }
      },
      {
         "mediaType": "application/vnd.oci.image.manifest.v1+json",
         "size": 1942,
         "digest": "sha256:8b10cc32983ca2268c98a237d5b09c672f814c88735e4a2d22c4d220304524dd",
         "platform": {
            "architecture": "arm64",
            "os": "linux",
            "variant": "v8"
         }
      },
      {
         "mediaType": "application/vnd.oci.image.manifest.v1+json",
         "size": 841,
         "digest": "sha256:4cb00bc050e369334f5c0f0f5f201ea94c8b96f1000b0a0a71e3fd80f62414b5",
         "platform": {
            "architecture": "unknown",
            "os": "unknown"
         }
      },
      {
         "mediaType": "application/vnd.oci.image.manifest.v1+json",
         "size": 1942,
         "digest": "sha256:0ffc1282d59f492a1a6538be841de55864d65e548a9973955ea5160049bbd26e",
         "platform": {
            "architecture": "ppc64le",
            "os": "linux"
         }
      },
      {
         "mediaType": "application/vnd.oci.image.manifest.v1+json",
         "size": 841,
         "digest": "sha256:ecd671c19b239bb1d3453b9ea41e59bf6cf41c917567eed76208f520982cccb0",
         "platform": {
            "architecture": "unknown",
            "os": "unknown"
         }
      },
      {
         "mediaType": "application/vnd.oci.image.manifest.v1+json",
         "size": 1940,
         "digest": "sha256:38c37dd186bb4491241971d8b4fa765191c2e9e83e73fc9077dff17cfb73f4a7",
         "platform": {
            "architecture": "s390x",
            "os": "linux"
         }
      },
      {
         "mediaType": "application/vnd.oci.image.manifest.v1+json",
         "size": 841,
         "digest": "sha256:f5b0f953c4178ec4e51fd311dfafa3a1f1ff2e29412735adb28ca71d249d1fc8",
         "platform": {
            "architecture": "unknown",
            "os": "unknown"
         }
      }
   ]
}