### PR TITLE
doc: Remove references to removed hugegraph-style.xml

### DIFF
--- a/.serena/memories/code_style_and_conventions.md
+++ b/.serena/memories/code_style_and_conventions.md
@@ -1,9 +1,8 @@
 # Code Style and Conventions
 
 ## Code Style Configuration
-- **Import**: Use `hugegraph-style.xml` in your IDE (IntelliJ IDEA recommended)
-- **EditorConfig**: `.editorconfig` file defines style rules (validated in CI)
-- **Checkstyle**: `style/checkstyle.xml` defines additional rules
+- **EditorConfig**: `.editorconfig` file defines style rules
+- **Checkstyle**: `style/checkstyle.xml` defines additional rules and enforcement
 
 ## Core Style Rules (from .editorconfig)
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -182,7 +182,7 @@ mvn clean package -DskipTests -Dskip-assembly-hugegraph
 ## Development Workflow
 
 ### Code Style
-Import the code style configuration from `hugegraph-style.xml` in your IDE (IntelliJ IDEA recommended).
+Configure your IDE to use `.editorconfig` for code style and `style/checkstyle.xml` for Checkstyle rules
 
 ### Adding Dependencies
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -71,7 +71,7 @@ vim hugegraph-server/hugegraph-core/src/main/java/org/apache/hugegraph/HugeFacto
 # run test locally (optional)
 mvn test -Pcore-test,memory
 ```
-Note: To be consistent with the code style easily, if you use [IDEA](https://www.jetbrains.com/idea/) as your IDE, you can directly [import](https://www.jetbrains.com/help/idea/configuring-code-style.html) our code style [configuration file](./hugegraph-style.xml). 
+Note: Code style is defined by the `.editorconfig` file at the repository root. Checkstyle rules are defined in `style/checkstyle.xml`. Configure your IDE accordingly.
 
 ##### 3.2.1 Check licenses
 If we want to add new third-party dependencies to the `HugeGraph` project, we need to do the following things:

--- a/hugegraph-pd/docs/development.md
+++ b/hugegraph-pd/docs/development.md
@@ -63,9 +63,8 @@ cd hugegraph-pd
 #### Configure Code Style
 
 1. **File → Settings → Editor → Code Style**
-2. **Import Scheme → IntelliJ IDEA code style XML**
-3. Select `hugegraph-style.xml` from repository root
-4. **Apply** and **OK**
+2. Ensure **Enable EditorConfig support** is checked
+3. **Apply** and **OK**
 
 #### Enable Annotation Processing
 
@@ -277,9 +276,9 @@ ls -lh pd_data/raft/snapshot/
 
 HugeGraph PD follows Apache HugeGraph code style.
 
-**Import Code Style**:
+**IDE Configuration**:
 1. IntelliJ IDEA: **File → Settings → Editor → Code Style**
-2. **Import Scheme** → Select `hugegraph-style.xml` (in repository root)
+2. Ensure **Enable EditorConfig support** is checked
 
 **Key Style Rules**:
 - **Indentation**: 4 spaces (no tabs)

--- a/hugegraph-store/docs/development-guide.md
+++ b/hugegraph-store/docs/development-guide.md
@@ -48,9 +48,9 @@ git checkout 1.7-rebase
 
 **Code Style**:
 ```bash
-# Import code style
-# File → Settings → Editor → Code Style → Java
-# Import Scheme → hugegraph-style.xml
+# Configure IDE code style
+# Ensure EditorConfig support is enabled
+# Code style is defined in .editorconfig at repository root
 ```
 
 **Run Configuration**:
@@ -683,7 +683,7 @@ jmap -dump:format=b,file=heap.bin $(pgrep -f hugegraph-store)
 ### Code Style
 
 **Java**:
-- Follow Apache HugeGraph code style (import `hugegraph-style.xml`)
+- Follow Apache HugeGraph code style (configured via `.editorconfig`)
 - Use 4 spaces for indentation (no tabs)
 - Max line length: 120 characters
 - Braces on same line (K&R style)


### PR DESCRIPTION
## Purpose of the PR

close #2948 

`hugegraph-style.xml` has been removed from the repository, but multiple documentation files still referenced it. This PR removes those stale references and updates the documentation to use `.editorconfig` and the existing Checkstyle configuration.

## Main Changes

• Removed references to deleted `hugegraph-style.xml`  
• Updated documentation to reference `.editorconfig`  
• No functional or build changes  

## Verifying these changes

- [x] Trivial rework / documentation cleanup. (No Need)

## Does this PR potentially affect the following parts?

- [x] Nope

## Documentation Status

- [x] `Doc - Done`
