### PR TITLE
doc: add comment for historical package names

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,10 +223,17 @@ Download pre-built packages from the [Download Page](https://hugegraph.apache.or
 
 ```bash
 # Download and extract
-# Note: historical releases <= 1.7.0 still use the "-incubating" package name
-wget https://downloads.apache.org/hugegraph/{version}/apache-hugegraph-{version}.tar.gz
-tar -xzf apache-hugegraph-{version}.tar.gz
-cd apache-hugegraph-{version}
+# For historical 1.7.0 and earlier releases, use the archive URL and
+# set PACKAGE=apache-hugegraph-incubating-{version} instead.
+BASE_URL="https://downloads.apache.org/hugegraph/{version}"
+PACKAGE="apache-hugegraph-{version}"
+# Historical alternative:
+# BASE_URL="https://archive.apache.org/dist/incubator/hugegraph/{version}"
+# PACKAGE="apache-hugegraph-incubating-{version}"
+
+wget ${BASE_URL}/${PACKAGE}.tar.gz
+tar -xzf ${PACKAGE}.tar.gz
+cd ${PACKAGE}
 
 # Initialize backend storage
 bin/init-store.sh

--- a/hugegraph-store/README.md
+++ b/hugegraph-store/README.md
@@ -104,12 +104,12 @@ From the project root:
 mvn install -pl hugegraph-struct -am -DskipTests
 
 # Build Store and all dependencies
-mvn clean package -pl hugegraph-store/hugegraph-store-dist -am -DskipTests
+mvn clean package -pl hugegraph-store/hg-store-dist -am -DskipTests
 ```
 
 The assembled distribution will be available at:
 ```
-hugegraph-store/apache-hugegraph-store-1.7.0/lib/hg-store-node-1.7.0.jar
+hugegraph-store/apache-hugegraph-store-<version>/lib/hg-store-node-<version>.jar
 ```
 
 ### Configuration
@@ -214,7 +214,8 @@ Start the Store server:
 
 ```bash
 # Replace {version} with your hugegraph version
-# Note: historical releases <= 1.7.0 still use the "-incubating" directory name
+# For historical 1.7.0 and earlier releases, use
+# apache-hugegraph-store-incubating-{version} instead.
 cd apache-hugegraph-store-{version}
 
 # Start Store node

--- a/hugegraph-store/docs/deployment-guide.md
+++ b/hugegraph-store/docs/deployment-guide.md
@@ -416,9 +416,9 @@ df -h
 
 ```bash
 # Extract PD distribution
-# Note: historical releases <= 1.7.0 still use the "-incubating" package/directory names
-tar -xzf apache-hugegraph-pd-1.7.0.tar.gz
-cd apache-hugegraph-pd-1.7.0
+# Note: use "-incubating" only for historical 1.7.0 and earlier package/directory names.
+tar -xzf apache-hugegraph-pd-incubating-1.7.0.tar.gz
+cd apache-hugegraph-pd-incubating-1.7.0
 
 # Edit configuration
 vi conf/application.yml
@@ -510,9 +510,9 @@ curl http://192.168.1.10:8620/v1/members
 
 ```bash
 # Extract Store distribution
-# Note: historical releases <= 1.7.0 still use the "-incubating" package/directory names
-tar -xzf apache-hugegraph-store-1.7.0.tar.gz
-cd apache-hugegraph-store-1.7.0
+# Note: use "-incubating" only for historical 1.7.0 and earlier package/directory names.
+tar -xzf apache-hugegraph-store-incubating-1.7.0.tar.gz
+cd apache-hugegraph-store-incubating-1.7.0
 
 # Edit configuration
 vi conf/application.yml
@@ -628,9 +628,9 @@ curl http://192.168.1.10:8620/v1/stores
 
 ```bash
 # Extract Server distribution
-# Note: historical releases <= 1.7.0 still use the "-incubating" package/directory names
-tar -xzf apache-hugegraph-1.7.0.tar.gz
-cd apache-hugegraph-1.7.0
+# Note: use "-incubating" only for historical 1.7.0 and earlier package/directory names.
+tar -xzf apache-hugegraph-incubating-1.7.0.tar.gz
+cd apache-hugegraph-incubating-1.7.0
 
 # Configure backend
 vi conf/graphs/hugegraph.properties

--- a/hugegraph-store/docs/development-guide.md
+++ b/hugegraph-store/docs/development-guide.md
@@ -58,7 +58,7 @@ git checkout 1.7-rebase
 2. Add new "Application" configuration:
    - Main class: `org.apache.hugegraph.store.node.StoreNodeApplication`
    - VM options: `-Xms4g -Xmx4g -Dconfig.file=conf/application.yml`
-   - Working directory: `hugegraph-store/apache-hugegraph-store-1.7.0`
+   - Working directory: `hugegraph-store/apache-hugegraph-store-<version>` (`apache-hugegraph-store-incubating-<version>` for historical 1.7.0 and earlier directories)
    - Use classpath of module: `hg-store-node`
 
 ### Build from Source
@@ -216,7 +216,9 @@ hg-store-grpc/
 
 **Start Server**:
 ```bash
-cd hugegraph-store/apache-hugegraph-store-1.7.0
+# Historical 1.7.0 and earlier directories use
+# apache-hugegraph-store-incubating-<version> instead.
+cd hugegraph-store/apache-hugegraph-store-<version>
 bin/start-hugegraph-store.sh
 ```
 

--- a/hugegraph-store/docs/operations-guide.md
+++ b/hugegraph-store/docs/operations-guide.md
@@ -593,8 +593,9 @@ curl http://192.168.1.10:8620/v1/partitionsAndStatus
 1. **Deploy New Store Node**:
    ```bash
    # Follow deployment guide
-   tar -xzf apache-hugegraph-store-1.7.0.tar.gz
-   cd apache-hugegraph-store-1.7.0
+   # Historical 1.7.0 packages still include the "-incubating" suffix
+   tar -xzf apache-hugegraph-store-incubating-1.7.0.tar.gz
+   cd apache-hugegraph-store-incubating-1.7.0
 
    # Configure and start
    vi conf/application.yml
@@ -670,14 +671,14 @@ curl http://192.168.1.10:8620/v1/partitionsAndStatus
 bin/stop-hugegraph-store.sh
 
 # Backup current version
-mv apache-hugegraph-store-1.7.0 apache-hugegraph-store-1.7.0-backup
+mv apache-hugegraph-store-incubating-1.7.0 apache-hugegraph-store-incubating-1.7.0-backup
 
-# Extract new version
+# Extract new version (newer releases no longer include "-incubating")
 tar -xzf apache-hugegraph-store-1.8.0.tar.gz
 cd apache-hugegraph-store-1.8.0
 
 # Copy configuration from backup
-cp ../apache-hugegraph-store-1.7.0-backup/conf/application.yml conf/
+cp ../apache-hugegraph-store-incubating-1.7.0-backup/conf/application.yml conf/
 
 # Start new version
 bin/start-hugegraph-store.sh
@@ -715,8 +716,8 @@ bin/stop-hugegraph-store.sh
 
 # Restore backup
 rm -rf apache-hugegraph-store-1.8.0
-mv apache-hugegraph-store-1.7.0-backup apache-hugegraph-store-1.7.0
-cd apache-hugegraph-store-1.7.0
+mv apache-hugegraph-store-incubating-1.7.0-backup apache-hugegraph-store-incubating-1.7.0
+cd apache-hugegraph-store-incubating-1.7.0
 
 # Restart old version
 bin/start-hugegraph-store.sh


### PR DESCRIPTION
Add notes to README, hugegraph-store/README, and hugegraph-store/docs/deployment-guide indicating that historical releases (<= 1.7.0) used the "-incubating" suffix in package and directory names.

