### PR TITLE
chore(docker): remove tmp volume mounts after image update

### DIFF
--- a/docker/docker-compose-3pd-3store-3server.yml
+++ b/docker/docker-compose-3pd-3store-3server.yml
@@ -30,13 +30,11 @@ volumes:
   hg-store2-data:
 
 # ── Shared service defaults ──────────────────────────────────────────
-# TODO: remove volume mounts below once images are published with new entrypoints
 x-pd-common: &pd-common
   image: hugegraph/pd:${HUGEGRAPH_VERSION:-latest}
   pull_policy: missing
   restart: unless-stopped
   networks: [hg-net]
-  entrypoint: ["/hugegraph-pd/docker-entrypoint.sh"]
   healthcheck:
     test: ["CMD-SHELL", "curl -fsS http://localhost:8620/v1/health >/dev/null || exit 1"]
     interval: 15s
@@ -53,7 +51,6 @@ x-store-common: &store-common
     pd0: { condition: service_healthy }
     pd1: { condition: service_healthy }
     pd2: { condition: service_healthy }
-  entrypoint: ["/hugegraph-store/docker-entrypoint.sh"]
   healthcheck:
     test: ["CMD-SHELL", "curl -fsS http://localhost:8520/v1/health >/dev/null || exit 1"]
     interval: 15s
@@ -70,7 +67,6 @@ x-server-common: &server-common
     store0: { condition: service_healthy }
     store1: { condition: service_healthy }
     store2: { condition: service_healthy }
-  entrypoint: ["/hugegraph-server/docker-entrypoint.sh"]
   environment:
     STORE_REST: store0:8520
     HG_SERVER_BACKEND: hstore
@@ -103,7 +99,6 @@ services:
     ports: ["8620:8620", "8686:8686"]
     volumes:
       - hg-pd0-data:/hugegraph-pd/pd_data
-      - ../hugegraph-pd/hg-pd-dist/docker/docker-entrypoint.sh:/hugegraph-pd/docker-entrypoint.sh
 
   pd1:
     <<: *pd-common
@@ -122,7 +117,6 @@ services:
     ports: ["8621:8620", "8687:8686"]
     volumes:
       - hg-pd1-data:/hugegraph-pd/pd_data
-      - ../hugegraph-pd/hg-pd-dist/docker/docker-entrypoint.sh:/hugegraph-pd/docker-entrypoint.sh
 
   pd2:
     <<: *pd-common
@@ -141,7 +135,6 @@ services:
     ports: ["8622:8620", "8688:8686"]
     volumes:
       - hg-pd2-data:/hugegraph-pd/pd_data
-      - ../hugegraph-pd/hg-pd-dist/docker/docker-entrypoint.sh:/hugegraph-pd/docker-entrypoint.sh
 
   # --- Store cluster (3 nodes) ---
   store0:
@@ -158,7 +151,6 @@ services:
     ports: ["8500:8500", "8510:8510", "8520:8520"]
     volumes:
       - hg-store0-data:/hugegraph-store/storage
-      - ../hugegraph-store/hg-store-dist/docker/docker-entrypoint.sh:/hugegraph-store/docker-entrypoint.sh
 
   store1:
     <<: *store-common
@@ -174,7 +166,6 @@ services:
     ports: ["8501:8500", "8511:8510", "8521:8520"]
     volumes:
       - hg-store1-data:/hugegraph-store/storage
-      - ../hugegraph-store/hg-store-dist/docker/docker-entrypoint.sh:/hugegraph-store/docker-entrypoint.sh
 
   store2:
     <<: *store-common
@@ -190,7 +181,6 @@ services:
     ports: ["8502:8500", "8512:8510", "8522:8520"]
     volumes:
       - hg-store2-data:/hugegraph-store/storage
-      - ../hugegraph-store/hg-store-dist/docker/docker-entrypoint.sh:/hugegraph-store/docker-entrypoint.sh
 
   # --- Server cluster (3 nodes) ---
   server0:
@@ -198,27 +188,15 @@ services:
     container_name: hg-server0
     hostname: server0
     ports: ["8080:8080"]
-    volumes:
-      - ../hugegraph-server/hugegraph-dist/docker/docker-entrypoint.sh:/hugegraph-server/docker-entrypoint.sh
-      - ../hugegraph-server/hugegraph-dist/src/assembly/static/bin/wait-storage.sh:/hugegraph-server/bin/wait-storage.sh
-      - ../hugegraph-server/hugegraph-dist/src/assembly/static/bin/wait-partition.sh:/hugegraph-server/bin/wait-partition.sh
 
   server1:
     <<: *server-common
     container_name: hg-server1
     hostname: server1
     ports: ["8081:8080"]
-    volumes:
-      - ../hugegraph-server/hugegraph-dist/docker/docker-entrypoint.sh:/hugegraph-server/docker-entrypoint.sh
-      - ../hugegraph-server/hugegraph-dist/src/assembly/static/bin/wait-storage.sh:/hugegraph-server/bin/wait-storage.sh
-      - ../hugegraph-server/hugegraph-dist/src/assembly/static/bin/wait-partition.sh:/hugegraph-server/bin/wait-partition.sh
 
   server2:
     <<: *server-common
     container_name: hg-server2
     hostname: server2
     ports: ["8082:8080"]
-    volumes:
-      - ../hugegraph-server/hugegraph-dist/docker/docker-entrypoint.sh:/hugegraph-server/docker-entrypoint.sh
-      - ../hugegraph-server/hugegraph-dist/src/assembly/static/bin/wait-storage.sh:/hugegraph-server/bin/wait-storage.sh
-      - ../hugegraph-server/hugegraph-dist/src/assembly/static/bin/wait-partition.sh:/hugegraph-server/bin/wait-partition.sh

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -14,7 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-# TODO: remove volume mounts below once images are published with new entrypoints
 name: hugegraph-single
 
 networks:
@@ -34,9 +33,6 @@ services:
     hostname: pd
     restart: unless-stopped
     networks: [hg-net]
-
-    entrypoint: ["/hugegraph-pd/docker-entrypoint.sh"]
-
     environment:
       HG_PD_GRPC_HOST: pd
       HG_PD_GRPC_PORT: "8686"
@@ -45,21 +41,16 @@ services:
       HG_PD_RAFT_PEERS_LIST: pd:8610
       HG_PD_INITIAL_STORE_LIST: store:8500
       HG_PD_DATA_PATH: /hugegraph-pd/pd_data
-
     ports:
       - "8620:8620"
-
     volumes:
       - hg-pd-data:/hugegraph-pd/pd_data
-      - ../hugegraph-pd/hg-pd-dist/docker/docker-entrypoint.sh:/hugegraph-pd/docker-entrypoint.sh
-
     healthcheck:
       test: ["CMD-SHELL", "curl -fsS http://localhost:8620/v1/health >/dev/null || exit 1"]
       interval: 10s
       timeout: 5s
       retries: 12
       start_period: 30s
-
 
   store:
     image: hugegraph/store:${HUGEGRAPH_VERSION:-latest}
@@ -68,13 +59,9 @@ services:
     hostname: store
     restart: unless-stopped
     networks: [hg-net]
-
-    entrypoint: ["/hugegraph-store/docker-entrypoint.sh"]
-
     depends_on:
       pd:
         condition: service_healthy
-
     environment:
       HG_STORE_PD_ADDRESS: pd:8686
       HG_STORE_GRPC_HOST: store
@@ -82,21 +69,16 @@ services:
       HG_STORE_REST_PORT: "8520"
       HG_STORE_RAFT_ADDRESS: store:8510
       HG_STORE_DATA_PATH: /hugegraph-store/storage
-
     ports:
       - "8520:8520"
-
     volumes:
       - hg-store-data:/hugegraph-store/storage
-      - ../hugegraph-store/hg-store-dist/docker/docker-entrypoint.sh:/hugegraph-store/docker-entrypoint.sh
-
     healthcheck:
       test: ["CMD-SHELL", "curl -fsS http://localhost:8520/v1/health >/dev/null || exit 1"]
       interval: 10s
       timeout: 10s
       retries: 30
       start_period: 60s
-
 
   server:
     image: hugegraph/server:${HUGEGRAPH_VERSION:-latest}
@@ -105,25 +87,14 @@ services:
     hostname: server
     restart: unless-stopped
     networks: [hg-net]
-
-    entrypoint: ["/hugegraph-server/docker-entrypoint.sh"]
-
     depends_on:
       store:
         condition: service_healthy
-
     environment:
       HG_SERVER_BACKEND: hstore
       HG_SERVER_PD_PEERS: pd:8686
-
     ports:
       - "8080:8080"
-
-    volumes:
-      - ../hugegraph-server/hugegraph-dist/docker/docker-entrypoint.sh:/hugegraph-server/docker-entrypoint.sh
-      - ../hugegraph-server/hugegraph-dist/src/assembly/static/bin/wait-storage.sh:/hugegraph-server/bin/wait-storage.sh
-      - ../hugegraph-server/hugegraph-dist/src/assembly/static/bin/wait-partition.sh:/hugegraph-server/bin/wait-partition.sh
-
     healthcheck:
       test: ["CMD-SHELL", "curl -fsS http://localhost:8080/versions >/dev/null || exit 1"]
       interval: 10s


### PR DESCRIPTION
## Purpose of the PR

Follow-up cleanup for #2952 — removes temporary entrypoint volume mounts from compose files now that updated Docker images have been published to Docker Hub with the new entrypoints baked in.

## Main Changes

- Removed `entrypoint:` overrides from `docker/docker-compose.yml` and `docker/docker-compose-3pd-3store-3server.yml`
- Removed script volume mounts for `docker-entrypoint.sh`, `wait-storage.sh`, and `wait-partition.sh` from all services
- Removed TODO comment that was tracking this cleanup

## Verifying these changes

- [x] Trivial rework / code cleanup without any test coverage. (No Need)

## Does this PR potentially affect the following parts?

- [ ] Dependencies
- [ ] Modify configurations
- [ ] The public API
- [ ] Other affects
- [x] Nope

## Documentation Status

- [x] `Doc - No Need`