### PR TITLE
chore(ci): add automatic rerun controller for flaky workflows

### DIFF
--- a/.github/workflows/rerun-ci.yml
+++ b/.github/workflows/rerun-ci.yml
@@ -10,17 +10,17 @@ on:
     types:
       - completed
 
-permissions:
-  actions: write
-  contents: read
+permissions: {}
 
 env:
   MAX_RERUNS: '2'
   RETRY_DELAY_SECONDS: '180'
 
 jobs:
-  rerun-failed-jobs:
+  decide-rerun-action:
     runs-on: ubuntu-latest
+    outputs:
+      action: ${{ steps.decision.outputs.action }}
     steps:
       - name: Decide rerun action
         id: decision
@@ -67,13 +67,19 @@ jobs:
             echo "- Reason: $reason"
           } >> "$GITHUB_STEP_SUMMARY"
 
+  rerun-failed-jobs:
+    needs: decide-rerun-action
+    if: needs.decide-rerun-action.outputs.action == 'rerun'
+    permissions:
+      actions: write
+      contents: read
+    runs-on: ubuntu-latest
+    steps:
       - name: Wait before rerun
-        if: steps.decision.outputs.action == 'rerun'
         run: |
           sleep "$RETRY_DELAY_SECONDS"
 
       - name: Rerun failed jobs
-        if: steps.decision.outputs.action == 'rerun'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GH_REPO: ${{ github.repository }}

--- a/.github/workflows/rerun-ci.yml
+++ b/.github/workflows/rerun-ci.yml
@@ -1,0 +1,36 @@
+name: "Rerun CI"
+
+on:
+  workflow_run:
+    workflows:
+      - "HugeGraph-Server CI"
+      - "HugeGraph-Commons CI"
+      - "HugeGraph-PD & Store & Hstore CI"
+      - "Cluster Test CI"
+    types:
+      - completed
+
+permissions:
+  actions: write
+  contents: read
+
+jobs:
+  rerun-failed-jobs:
+    if: >-
+      github.event.workflow_run.conclusion == 'failure' &&
+      fromJSON(github.event.workflow_run.run_attempt) < 2
+    runs-on: ubuntu-latest
+    steps:
+      - name: Show rerun target
+        run: |
+          echo "Workflow: ${{ github.event.workflow_run.name }}"
+          echo "Run ID: ${{ github.event.workflow_run.id }}"
+          echo "Run attempt: ${{ github.event.workflow_run.run_attempt }}"
+          echo "Conclusion: ${{ github.event.workflow_run.conclusion }}"
+
+      - name: Rerun failed jobs
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+        run: |
+          gh run rerun ${{ github.event.workflow_run.id }} --failed

--- a/.github/workflows/rerun-ci.yml
+++ b/.github/workflows/rerun-ci.yml
@@ -9,26 +9,75 @@ on:
       - "Cluster Test CI"
     types:
       - completed
+    branches:
+      - master
+      - 'release-*'
+      - 'test-*'
 
 permissions:
   actions: write
   contents: read
 
+env:
+  MAX_RERUNS: '2'
+  RETRY_DELAY_SECONDS: '180'
+
 jobs:
   rerun-failed-jobs:
-    if: >-
-      github.event.workflow_run.conclusion == 'failure' &&
-      fromJSON(github.event.workflow_run.run_attempt) < 2
     runs-on: ubuntu-latest
     steps:
-      - name: Show rerun target
+      - name: Decide rerun action
+        id: decision
+        env:
+          WORKFLOW_NAME: ${{ github.event.workflow_run.name }}
+          RUN_ID: ${{ github.event.workflow_run.id }}
+          RUN_ATTEMPT: ${{ github.event.workflow_run.run_attempt }}
+          CONCLUSION: ${{ github.event.workflow_run.conclusion }}
+          EVENT_NAME: ${{ github.event.workflow_run.event }}
+          HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
         run: |
-          echo "Workflow: ${{ github.event.workflow_run.name }}"
-          echo "Run ID: ${{ github.event.workflow_run.id }}"
-          echo "Run attempt: ${{ github.event.workflow_run.run_attempt }}"
-          echo "Conclusion: ${{ github.event.workflow_run.conclusion }}"
+          set -euo pipefail
+
+          action="skip"
+          reason="non-failure"
+
+          if [[ "$CONCLUSION" == "failure" ]]; then
+            if [[ "$EVENT_NAME" != "push" && "$EVENT_NAME" != "pull_request" ]]; then
+              reason="unsupported event: $EVENT_NAME"
+            elif (( RUN_ATTEMPT > MAX_RERUNS )); then
+              reason="retry limit reached"
+            else
+              action="rerun"
+              reason="within retry limit"
+            fi
+          fi
+
+          {
+            echo "action=$action"
+            echo "reason=$reason"
+          } >> "$GITHUB_OUTPUT"
+
+          {
+            echo "### Rerun CI decision"
+            echo ""
+            echo "- Workflow: $WORKFLOW_NAME"
+            echo "- Source event: $EVENT_NAME"
+            echo "- Head branch: $HEAD_BRANCH"
+            echo "- Run ID: $RUN_ID"
+            echo "- Current attempt: $RUN_ATTEMPT"
+            echo "- Max automatic reruns: $MAX_RERUNS"
+            echo "- Delay seconds: $RETRY_DELAY_SECONDS"
+            echo "- Action: $action"
+            echo "- Reason: $reason"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Wait before rerun
+        if: steps.decision.outputs.action == 'rerun'
+        run: |
+          sleep "$RETRY_DELAY_SECONDS"
 
       - name: Rerun failed jobs
+        if: steps.decision.outputs.action == 'rerun'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GH_REPO: ${{ github.repository }}

--- a/.github/workflows/rerun-ci.yml
+++ b/.github/workflows/rerun-ci.yml
@@ -9,10 +9,6 @@ on:
       - "Cluster Test CI"
     types:
       - completed
-    branches:
-      - master
-      - 'release-*'
-      - 'test-*'
 
 permissions:
   actions: write

--- a/.github/workflows/rerun-ci.yml
+++ b/.github/workflows/rerun-ci.yml
@@ -14,7 +14,7 @@ permissions: {}
 
 env:
   MAX_RERUNS: '2'
-  RETRY_DELAY_SECONDS: '180'
+  RETRY_DELAY_SECONDS: '60'
 
 jobs:
   decide-rerun-action:

--- a/.github/workflows/rerun-ci.yml
+++ b/.github/workflows/rerun-ci.yml
@@ -14,7 +14,7 @@ permissions: {}
 
 env:
   MAX_RERUNS: '2'
-  RETRY_DELAY_SECONDS: '60'
+  RETRY_DELAY_SECONDS: '180'
 
 jobs:
   decide-rerun-action:


### PR DESCRIPTION
<!-- 
  Thank you very much for contributing to Apache HugeGraph, we are happy that you want to help us improve it!

  Here are some tips for you:
    1. If this is your first time, please read the [contributing guidelines](https://github.com/apache/hugegraph/blob/master/CONTRIBUTING.md)

    2. If a PR fix/close an issue, type the message "close xxx" (xxx is the link of related 
issue) in the content, GitHub will auto link it (Required)

    3. Name the PR title in "Google Commit Format", start with "feat | fix | perf | refactor | doc | chore", 
      such like: "feat(core): support the PageRank algorithm" or "fix: wrong break in the compute loop" (module is optional)
      skip it if you are unsure about which is the best component.

    4. One PR address one issue, better not to mix up multiple issues.

    5. Put an `x` in the `[ ]` to mark the item as CHECKED. `[x]` (or click it directly after 
published)
-->

## Purpose of the PR

- close #2983 <!-- or use "fix #xxx", "xxx" is the ID-link of related issue, e.g: close #1024 -->

Apache HugeGraph's four main CI pipelines occasionally fail on transient
issues that pass cleanly on retry, forcing manual "Re-run failed jobs"
clicks.
<!--
Please explain more context in this section, clarify why the changes are needed. 
e.g:
- If you propose a new API, clarify the use case for a new API.
- If you fix a bug, you can clarify why it is a bug, and should be associated with an issue.
-->

## Main Changes

Adds `.github/workflows/rerun-ci.yml`, a small controller that watches
the four main CI pipelines via `workflow_run` and automatically reruns
failed jobs at most once per original failure:

- Fires only when `conclusion == 'failure'` AND `run_attempt < 2` — no
  infinite loops.
- Uses `gh run rerun <id> --failed` to re-run only failed jobs, not the
  whole workflow.
- Least-privilege permissions: `actions: write`, `contents: read`.
- Scoped to HugeGraph-Server CI, HugeGraph-Commons CI, HugeGraph-PD &
  Store & Hstore CI, and Cluster Test CI — no effect on CodeQL / stale
  / license-checker / auto-pr-review.

<!-- Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. These change logs are helpful for better and faster reviews.)

For example:

- If you introduce a new feature, please show detailed design here or add the link of design documentation.
- If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
- If there is a discussion in the mailing list, please add the link. -->

## Verifying these changes

<!-- Please pick the proper options below -->

- [x] Trivial rework / code cleanup without any test coverage. (No Need)
- [ ] Already covered by existing tests, such as *(please modify tests here)*.
- [ ] Need tests and can be verified as follows:
    - xxx

Validated on my fork: controller correctly fires on failed runs, reruns
only the failed jobs, and does not re-trigger itself on the second
attempt.

## Does this PR potentially affect the following parts?

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ]  Dependencies ([add/update license](https://hugegraph.apache.org/docs/contribution-guidelines/contribute/#321-check-licenses) info & [regenerate_known_dependencies.sh](../install-dist/scripts/dependency/regenerate_known_dependencies.sh)) <!-- Don't forget to add/update the info in "LICENSE" & "NOTICE" files (both in root & dist module) -->
- [ ]  Modify configurations
- [ ]  The public API
- [ ]  Other affects (typed here)
- [ ]  Nope


## Documentation Status

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ]  `Doc - TODO` <!-- Your PR changes impact docs and you will update later -->
- [ ]  `Doc - Done` <!-- Related docs have been already added or updated -->
- [ ]  `Doc - No Need` <!-- Your PR changes don't impact/need docs -->
