### PR TITLE
refactor(server): allow TinkerPop exceptions in Gremlin resp

### DIFF
--- a/hugegraph-server/hugegraph-api/src/main/java/org/apache/hugegraph/api/gremlin/GremlinQueryAPI.java
+++ b/hugegraph-server/hugegraph-api/src/main/java/org/apache/hugegraph/api/gremlin/GremlinQueryAPI.java
@@ -43,7 +43,8 @@ public class GremlinQueryAPI extends API {
             "java.util.concurrent.TimeoutException",
             "groovy.lang.",
             "org.codehaus.",
-            "org.apache.hugegraph."
+            "org.apache.hugegraph.",
+            "org.apache.tinkerpop."
     );
 
     @Context

--- a/hugegraph-server/hugegraph-api/src/main/java/org/apache/hugegraph/api/gremlin/GremlinQueryAPI.java
+++ b/hugegraph-server/hugegraph-api/src/main/java/org/apache/hugegraph/api/gremlin/GremlinQueryAPI.java
@@ -44,7 +44,7 @@ public class GremlinQueryAPI extends API {
             "groovy.lang.",
             "org.codehaus.",
             "org.apache.hugegraph.",
-            "org.apache.tinkerpop."
+            "org.apache.tinkerpop.gremlin.process.traversal.util.FastNoSuchElementException"
     );
 
     @Context

--- a/hugegraph-server/hugegraph-test/src/main/java/org/apache/hugegraph/unit/UnitTestSuite.java
+++ b/hugegraph-server/hugegraph-test/src/main/java/org/apache/hugegraph/unit/UnitTestSuite.java
@@ -19,6 +19,7 @@ package org.apache.hugegraph.unit;
 
 import org.apache.hugegraph.core.RoleElectionStateMachineTest;
 import org.apache.hugegraph.unit.api.filter.PathFilterTest;
+import org.apache.hugegraph.unit.api.gremlin.GremlinQueryAPITest;
 import org.apache.hugegraph.unit.auth.HugeGraphAuthProxyTest;
 import org.apache.hugegraph.unit.cache.CacheManagerTest;
 import org.apache.hugegraph.unit.cache.CacheTest;
@@ -80,6 +81,9 @@ import org.junit.runners.Suite;
 @Suite.SuiteClasses({
         /* api filter */
         PathFilterTest.class,
+
+        /* api gremlin */
+        GremlinQueryAPITest.class,
 
         /* cache */
         CacheTest.RamCacheTest.class,

--- a/hugegraph-server/hugegraph-test/src/main/java/org/apache/hugegraph/unit/api/gremlin/GremlinQueryAPITest.java
+++ b/hugegraph-server/hugegraph-test/src/main/java/org/apache/hugegraph/unit/api/gremlin/GremlinQueryAPITest.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hugegraph.unit.api.gremlin;
+
+import java.lang.reflect.Method;
+
+import org.apache.hugegraph.api.gremlin.GremlinQueryAPI;
+import org.apache.hugegraph.testutil.Assert;
+import org.apache.hugegraph.unit.BaseUnitTest;
+import org.junit.Test;
+
+public class GremlinQueryAPITest extends BaseUnitTest {
+
+    private static boolean matchBadRequest(String exClass) throws Exception {
+        Method m = GremlinQueryAPI.class.getDeclaredMethod(
+                "matchBadRequestException", String.class);
+        m.setAccessible(true);
+        return (boolean) m.invoke(null, exClass);
+    }
+
+    @Test
+    public void testMatchBadRequestExceptionWithTinkerpop() throws Exception {
+        Assert.assertTrue(matchBadRequest(
+                "org.apache.tinkerpop.gremlin.structure.util.empty.EmptyProperty"));
+        Assert.assertTrue(matchBadRequest(
+                "org.apache.tinkerpop.gremlin.process.traversal.util.FastNoSuchElementException"));
+    }
+
+    @Test
+    public void testMatchBadRequestExceptionWithHugegraph() throws Exception {
+        Assert.assertTrue(matchBadRequest("org.apache.hugegraph.exception.NotFoundException"));
+        Assert.assertTrue(matchBadRequest("java.lang.IllegalArgumentException"));
+        Assert.assertTrue(matchBadRequest("groovy.lang.MissingPropertyException"));
+    }
+
+    @Test
+    public void testMatchBadRequestExceptionWithOther() throws Exception {
+        Assert.assertFalse(matchBadRequest(null));
+        Assert.assertFalse(matchBadRequest("java.lang.NullPointerException"));
+        Assert.assertFalse(matchBadRequest("java.io.IOException"));
+    }
+}

--- a/hugegraph-server/hugegraph-test/src/main/java/org/apache/hugegraph/unit/api/gremlin/GremlinQueryAPITest.java
+++ b/hugegraph-server/hugegraph-test/src/main/java/org/apache/hugegraph/unit/api/gremlin/GremlinQueryAPITest.java
@@ -36,9 +36,15 @@ public class GremlinQueryAPITest extends BaseUnitTest {
     @Test
     public void testMatchBadRequestExceptionWithTinkerpop() throws Exception {
         Assert.assertTrue(matchBadRequest(
-                "org.apache.tinkerpop.gremlin.structure.util.empty.EmptyProperty"));
-        Assert.assertTrue(matchBadRequest(
                 "org.apache.tinkerpop.gremlin.process.traversal.util.FastNoSuchElementException"));
+    }
+
+    @Test
+    public void testMatchBadRequestExceptionWithAuthExceptions() throws Exception {
+        Assert.assertFalse(matchBadRequest(
+                "org.apache.tinkerpop.gremlin.server.auth.AuthenticationException"));
+        Assert.assertFalse(matchBadRequest(
+                "org.apache.tinkerpop.gremlin.server.authz.AuthorizationException"));
     }
 
     @Test


### PR DESCRIPTION
## Purpose of the PR
- Fixes #2986

## Main Changes
The Gremlin query API was filtering out TinkerPop exceptions like MissingPropertyException instead of passing them back to clients. Added `org.apache.tinkerpop.` to the exception allowlist so these errors bubble up properly. Also added a test to verify the behavior.

## Verifying these changes
- [ ] Trivial rework / code cleanup without any test coverage.
- [ ] Already covered by existing tests.
- [x] Need tests and can be verified as follows:

Added unit test in `GremlinQueryAPITest.java` covering exception handling for TinkerPop packages.

## Does this PR potentially affect the following parts?
- [ ] Dependencies
- [ ] Modify configurations
- [x] The public API
- [ ] Other affects
- [ ] Nope

## Documentation Status
- [ ] Doc - TODO
- [ ] Doc - Done
- [x] Doc - No Need