### PR TITLE
fix(query): handle conflicting edge label conditions safely

### DIFF
--- a/hugegraph-server/hugegraph-core/src/main/java/org/apache/hugegraph/backend/query/ConditionQuery.java
+++ b/hugegraph-server/hugegraph-core/src/main/java/org/apache/hugegraph/backend/query/ConditionQuery.java
@@ -288,11 +288,13 @@ public class ConditionQuery extends IdQuery {
             return value;
         }
 
+        boolean initialized = false;
         Set<Object> intersectValues = InsertionOrderUtil.newSet();
         for (Object value : valuesEQ) {
             List<Object> valueAsList = ImmutableList.of(value);
-            if (intersectValues.isEmpty()) {
+            if (!initialized) {
                 intersectValues.addAll(valueAsList);
+                initialized = true;
             } else {
                 CollectionUtil.intersectWithModify(intersectValues,
                                                    valueAsList);
@@ -301,8 +303,9 @@ public class ConditionQuery extends IdQuery {
         for (Object value : valuesIN) {
             @SuppressWarnings("unchecked")
             List<Object> valueAsList = (List<Object>) value;
-            if (intersectValues.isEmpty()) {
+            if (!initialized) {
                 intersectValues.addAll(valueAsList);
+                initialized = true;
             } else {
                 CollectionUtil.intersectWithModify(intersectValues,
                                                    valueAsList);

--- a/hugegraph-server/hugegraph-test/src/main/java/org/apache/hugegraph/core/EdgeCoreTest.java
+++ b/hugegraph-server/hugegraph-test/src/main/java/org/apache/hugegraph/core/EdgeCoreTest.java
@@ -4647,6 +4647,30 @@ public class EdgeCoreTest extends BaseCoreTest {
     }
 
     @Test
+    public void testQueryInEdgesOfVertexByConflictingLabels() {
+        HugeGraph graph = graph();
+        init18Edges();
+
+        long direct = graph.traversal().V().inE("created")
+                           .hasLabel("created", "look")
+                           .hasLabel("authored")
+                           .count().next();
+        Assert.assertEquals(0L, direct);
+
+        long matched = graph.traversal().V()
+                            .match(__.as("start1")
+                                     .repeat(__.inE("created"))
+                                     .times(1)
+                                     .as("m1"))
+                            .select("m1")
+                            .hasLabel("created", "look")
+                            .hasLabel("authored")
+                            .count().next();
+        Assert.assertEquals(0L, matched);
+        Assert.assertEquals(matched, direct);
+    }
+
+    @Test
     public void testQueryInEdgesOfVertexBySortkey() {
         HugeGraph graph = graph();
         init18Edges();

--- a/hugegraph-server/hugegraph-test/src/main/java/org/apache/hugegraph/core/EdgeCoreTest.java
+++ b/hugegraph-server/hugegraph-test/src/main/java/org/apache/hugegraph/core/EdgeCoreTest.java
@@ -4659,8 +4659,7 @@ public class EdgeCoreTest extends BaseCoreTest {
 
         long matched = graph.traversal().V()
                             .match(__.as("start1")
-                                     .repeat(__.inE("created"))
-                                     .times(1)
+                                     .inE("created")
                                      .as("m1"))
                             .select("m1")
                             .hasLabel("created", "look")

--- a/hugegraph-server/hugegraph-test/src/main/java/org/apache/hugegraph/unit/core/QueryTest.java
+++ b/hugegraph-server/hugegraph-test/src/main/java/org/apache/hugegraph/unit/core/QueryTest.java
@@ -77,6 +77,25 @@ public class QueryTest {
     }
 
     @Test
+    public void testConditionWithMultipleMatchedInValues() {
+        Id label1 = IdGenerator.of(1);
+        Id label2 = IdGenerator.of(2);
+        Id label3 = IdGenerator.of(3);
+        Id label4 = IdGenerator.of(4);
+
+        ConditionQuery query = new ConditionQuery(HugeType.EDGE);
+        query.query(Condition.in(HugeKeys.LABEL,
+                                 ImmutableList.of(label1, label2, label3)));
+        query.query(Condition.in(HugeKeys.LABEL,
+                                 ImmutableList.of(label1, label2, label4)));
+
+        Assert.assertThrows(IllegalStateException.class,
+                            () -> query.condition(HugeKeys.LABEL),
+                            e -> Assert.assertContains("Illegal key 'LABEL'",
+                                                       e.getMessage()));
+    }
+
+    @Test
     public void testToString() {
         Query query = new Query(HugeType.VERTEX);
         Assert.assertEquals("`Query * from VERTEX`", query.toString());

--- a/hugegraph-server/hugegraph-test/src/main/java/org/apache/hugegraph/unit/core/QueryTest.java
+++ b/hugegraph-server/hugegraph-test/src/main/java/org/apache/hugegraph/unit/core/QueryTest.java
@@ -17,8 +17,10 @@
 
 package org.apache.hugegraph.unit.core;
 
+import org.apache.hugegraph.backend.id.Id;
 import org.apache.hugegraph.backend.id.IdGenerator;
 import org.apache.hugegraph.backend.query.Aggregate.AggregateFunc;
+import org.apache.hugegraph.backend.query.Condition;
 import org.apache.hugegraph.backend.query.ConditionQuery;
 import org.apache.hugegraph.backend.query.IdPrefixQuery;
 import org.apache.hugegraph.backend.query.IdQuery;
@@ -30,6 +32,7 @@ import org.apache.hugegraph.type.HugeType;
 import org.apache.hugegraph.type.define.HugeKeys;
 import org.junit.Test;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 
@@ -43,6 +46,34 @@ public class QueryTest {
         query.order(HugeKeys.NAME, Order.ASC);
         Assert.assertEquals(ImmutableMap.of(HugeKeys.NAME, Order.ASC),
                             query.orders());
+    }
+
+    @Test
+    public void testConditionWithEqAndIn() {
+        Id label1 = IdGenerator.of(1);
+        Id label2 = IdGenerator.of(2);
+
+        ConditionQuery query = new ConditionQuery(HugeType.EDGE);
+        query.eq(HugeKeys.LABEL, label1);
+        query.query(Condition.in(HugeKeys.LABEL,
+                                 ImmutableList.of(label1, label2)));
+
+        Assert.assertEquals(label1, query.condition(HugeKeys.LABEL));
+    }
+
+    @Test
+    public void testConditionWithConflictingEqAndIn() {
+        Id label1 = IdGenerator.of(1);
+        Id label2 = IdGenerator.of(2);
+        Id label3 = IdGenerator.of(3);
+
+        ConditionQuery query = new ConditionQuery(HugeType.EDGE);
+        query.eq(HugeKeys.LABEL, label1);
+        query.eq(HugeKeys.LABEL, label2);
+        query.query(Condition.in(HugeKeys.LABEL,
+                                 ImmutableList.of(label1, label3)));
+
+        Assert.assertNull(query.condition(HugeKeys.LABEL));
     }
 
     @Test


### PR DESCRIPTION
<!-- 
  Thank you very much for contributing to Apache HugeGraph, we are happy that you want to help us improve it!

  Here are some tips for you:
    1. If this is your first time, please read the [contributing guidelines](https://github.com/apache/hugegraph/blob/master/CONTRIBUTING.md)

    2. If a PR fix/close an issue, type the message "close xxx" (xxx is the link of related 
issue) in the content, GitHub will auto link it (Required)

    3. Name the PR title in "Google Commit Format", start with "feat | fix | perf | refactor | doc | chore", 
      such like: "feat(core): support the PageRank algorithm" or "fix: wrong break in the compute loop" (module is optional)
      skip it if you are unsure about which is the best component.

    4. One PR address one issue, better not to mix up multiple issues.

    5. Put an `x` in the `[ ]` to mark the item as CHECKED. `[x]` (or click it directly after 
published)
-->

## Purpose of the PR

- fix #2933 <!-- or use "fix #xxx", "xxx" is the ID-link of related issue, e.g: close #1024 -->

<!--
Please explain more context in this section, clarify why the changes are needed. 
e.g:
- If you propose a new API, clarify the use case for a new API.
- If you fix a bug, you can clarify why it is a bug, and should be associated with an issue.
-->

HugeGraph may read `LABEL` from `ConditionQuery` before the query is flattened when optimizing edge traversals. For contradictory label conditions such as:

```gremlin
g.V().inE("created").hasLabel("created", "look").hasLabel("authored")

```
the previous intersection logic used an empty set to mean both "not initialized yet" and "already intersected to empty". As a result, a later IN condition could repopulate the candidate labels and trigger:

Illegal key 'LABEL' with more than one value

instead of returning an empty result.


## Main Changes

Update ConditionQuery.condition(Object key) to track whether the intersection has been initialized independently.

This keeps an empty intersection empty, so conflicting label predicates now fall back safely and produce no matches, while the existing protection for true multi-value results is preserved.

<!-- Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. These change logs are helpful for better and faster reviews.)

For example:

- If you introduce a new feature, please show detailed design here or add the link of design documentation.
- If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
- If there is a discussion in the mailing list, please add the link. -->

## Verifying these changes

Added regression coverage for both the low-level query behavior and the traversal scenario from the issue:

QueryTest#testConditionWithEqAndIn
QueryTest#testConditionWithConflictingEqAndIn
EdgeCoreTest#testQueryInEdgesOfVertexByConflictingLabels
The edge traversal test also compares the direct traversal with an equivalent match()-based query and verifies that both return 0 instead of throwing an exception.

<!-- Please pick the proper options below -->

- [ ] Trivial rework / code cleanup without any test coverage. (No Need)
- [ ] Already covered by existing tests, such as *(please modify tests here)*.
- [x] Need tests and can be verified as follows:
    - mvn -pl hugegraph-server/hugegraph-test -am -P core-test,memory -DfailIfNoTests=false -Dtest='QueryTest#testConditionWithEqAndIn+testConditionWithConflictingEqAndIn' test
    - mvn -pl hugegraph-server/hugegraph-test -am -P core-test,memory -DfailIfNoTests=false -Dtest='EdgeCoreTest#testQueryInEdgesOfVertexByConflictingLabels' test

## Does this PR potentially affect the following parts?

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ]  Dependencies ([add/update license](https://hugegraph.apache.org/docs/contribution-guidelines/contribute/#321-check-licenses) info & [regenerate_known_dependencies.sh](../install-dist/scripts/dependency/regenerate_known_dependencies.sh)) <!-- Don't forget to add/update the info in "LICENSE" & "NOTICE" files (both in root & dist module) -->
- [ ]  Modify configurations
- [ ]  The public API
- [ ]  Other affects (typed here)
- [x]  Nope


## Documentation Status

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ]  `Doc - TODO` <!-- Your PR changes impact docs and you will update later -->
- [ ]  `Doc - Done` <!-- Related docs have been already added or updated -->
- [x]  `Doc - No Need` <!-- Your PR changes don't impact/need docs -->
