### PR TITLE
fix(server): normalize bool range predicates in gremlin filters

### DIFF
--- a/hugegraph-server/hugegraph-core/src/main/java/org/apache/hugegraph/backend/query/Condition.java
+++ b/hugegraph-server/hugegraph-core/src/main/java/org/apache/hugegraph/backend/query/Condition.java
@@ -233,16 +233,14 @@ public abstract class Condition {
         }
 
         private static int compareBoolean(Object first, Boolean second) {
-            if (first == null) {
-                first = false;
-            }
             if (first instanceof Boolean) {
                 return Boolean.compare((Boolean) first, second);
             }
 
             throw new IllegalArgumentException(String.format(
                     "Can't compare between %s(%s) and %s(%s)",
-                    first, first.getClass().getSimpleName(),
+                    first, first == null ? null :
+                           first.getClass().getSimpleName(),
                     second, second.getClass().getSimpleName()));
         }
 

--- a/hugegraph-server/hugegraph-core/src/main/java/org/apache/hugegraph/backend/query/Condition.java
+++ b/hugegraph-server/hugegraph-core/src/main/java/org/apache/hugegraph/backend/query/Condition.java
@@ -195,7 +195,7 @@ public abstract class Condition {
          *
          * @param first  is actual value, might be Number/Date or String, It is
          *               probably that the `first` is serialized to String.
-         * @param second is value in query condition, must be Number/Date
+         * @param second is value in query condition, must be Number/Date/Boolean
          * @return the value 0 if first is numerically equal to second;
          * a value less than 0 if first is numerically less than
          * second; and a value greater than 0 if first is
@@ -208,6 +208,8 @@ public abstract class Condition {
                                                  (Number) second);
             } else if (second instanceof Date) {
                 return compareDate(first, (Date) second);
+            } else if (second instanceof Boolean) {
+                return compareBoolean(first, (Boolean) second);
             }
 
             throw new IllegalArgumentException(String.format(
@@ -222,6 +224,20 @@ public abstract class Condition {
             }
             if (first instanceof Date) {
                 return ((Date) first).compareTo(second);
+            }
+
+            throw new IllegalArgumentException(String.format(
+                    "Can't compare between %s(%s) and %s(%s)",
+                    first, first.getClass().getSimpleName(),
+                    second, second.getClass().getSimpleName()));
+        }
+
+        private static int compareBoolean(Object first, Boolean second) {
+            if (first == null) {
+                first = false;
+            }
+            if (first instanceof Boolean) {
+                return Boolean.compare((Boolean) first, second);
             }
 
             throw new IllegalArgumentException(String.format(

--- a/hugegraph-server/hugegraph-core/src/main/java/org/apache/hugegraph/backend/query/ConditionQueryFlatten.java
+++ b/hugegraph-server/hugegraph-core/src/main/java/org/apache/hugegraph/backend/query/ConditionQueryFlatten.java
@@ -265,7 +265,7 @@ public final class ConditionQueryFlatten {
             cq.query(nonRelations);
             return ImmutableList.of(cq);
         }
-        return ImmutableList.of(query);
+        return ImmutableList.of();
     }
 
     private static Relations optimizeRelations(Relations relations) {

--- a/hugegraph-server/hugegraph-core/src/main/java/org/apache/hugegraph/backend/query/ConditionQueryFlatten.java
+++ b/hugegraph-server/hugegraph-core/src/main/java/org/apache/hugegraph/backend/query/ConditionQueryFlatten.java
@@ -427,9 +427,26 @@ public final class ConditionQueryFlatten {
         if (low == null || high == null) {
             return true;
         }
-        return compare(low, high) < 0 || compare(low, high) == 0 &&
-                                         low.relation() == Condition.RelationType.GTE &&
-                                         high.relation() == Condition.RelationType.LTE;
+        int compared = compare(low, high);
+        if (compared > 0) {
+            return false;
+        }
+        if (compared == 0) {
+            return low.relation() == Condition.RelationType.GTE &&
+                   high.relation() == Condition.RelationType.LTE;
+        }
+        return !emptyBooleanRange(low, high);
+    }
+
+    private static boolean emptyBooleanRange(Relation low, Relation high) {
+        if (!(low.value() instanceof Boolean) ||
+            !(high.value() instanceof Boolean)) {
+            return false;
+        }
+        return Boolean.FALSE.equals(low.value()) &&
+               Boolean.TRUE.equals(high.value()) &&
+               low.relation() == Condition.RelationType.GT &&
+               high.relation() == Condition.RelationType.LT;
     }
 
     private static boolean validEq(Relation eq, Relation low, Relation high) {

--- a/hugegraph-server/hugegraph-core/src/main/java/org/apache/hugegraph/backend/query/ConditionQueryFlatten.java
+++ b/hugegraph-server/hugegraph-core/src/main/java/org/apache/hugegraph/backend/query/ConditionQueryFlatten.java
@@ -507,6 +507,9 @@ public final class ConditionQueryFlatten {
             return NumericUtil.compareNumber(firstValue, (Number) secondValue);
         } else if (firstValue instanceof Date && secondValue instanceof Date) {
             return ((Date) firstValue).compareTo((Date) secondValue);
+        } else if (firstValue instanceof Boolean &&
+                   secondValue instanceof Boolean) {
+            return Boolean.compare((Boolean) firstValue, (Boolean) secondValue);
         } else {
             throw new IllegalArgumentException(String.format("Can't compare between %s and %s",
                                                              first, second));

--- a/hugegraph-server/hugegraph-core/src/main/java/org/apache/hugegraph/backend/query/ConditionQueryFlatten.java
+++ b/hugegraph-server/hugegraph-core/src/main/java/org/apache/hugegraph/backend/query/ConditionQueryFlatten.java
@@ -265,7 +265,7 @@ public final class ConditionQueryFlatten {
             cq.query(nonRelations);
             return ImmutableList.of(cq);
         }
-        return ImmutableList.of();
+        return ImmutableList.of(query);
     }
 
     private static Relations optimizeRelations(Relations relations) {

--- a/hugegraph-server/hugegraph-core/src/main/java/org/apache/hugegraph/backend/query/ConditionQueryFlatten.java
+++ b/hugegraph-server/hugegraph-core/src/main/java/org/apache/hugegraph/backend/query/ConditionQueryFlatten.java
@@ -115,12 +115,23 @@ public final class ConditionQueryFlatten {
                 }
             case AND:
                 Condition.And and = (Condition.And) condition;
-                return new Condition.And(flattenIn(and.left(), supportIn),
-                                         flattenIn(and.right(), supportIn));
+                Condition andLeft = flattenIn(and.left(), supportIn);
+                Condition andRight = flattenIn(and.right(), supportIn);
+                if (andLeft == null || andRight == null) {
+                    return null;
+                }
+                return new Condition.And(andLeft, andRight);
             case OR:
                 Condition.Or or = (Condition.Or) condition;
-                return new Condition.Or(flattenIn(or.left(), supportIn),
-                                        flattenIn(or.right(), supportIn));
+                Condition orLeft = flattenIn(or.left(), supportIn);
+                Condition orRight = flattenIn(or.right(), supportIn);
+                if (orLeft == null) {
+                    return orRight;
+                }
+                if (orRight == null) {
+                    return orLeft;
+                }
+                return new Condition.Or(orLeft, orRight);
             default:
                 throw new AssertionError(String.format("Wrong condition type: '%s'",
                                                        condition.type()));

--- a/hugegraph-server/hugegraph-core/src/main/java/org/apache/hugegraph/traversal/optimize/TraversalUtil.java
+++ b/hugegraph-server/hugegraph-core/src/main/java/org/apache/hugegraph/traversal/optimize/TraversalUtil.java
@@ -501,7 +501,7 @@ public final class TraversalUtil {
             case eq:
                 return Condition.eq(key, value);
             case neq:
-                return Condition.neq(key, value);
+                return Condition.eq(key, !value);
             case gt:
                 return value ? Condition.in(key, ImmutableList.of()) :
                        Condition.eq(key, true);

--- a/hugegraph-server/hugegraph-core/src/main/java/org/apache/hugegraph/traversal/optimize/TraversalUtil.java
+++ b/hugegraph-server/hugegraph-core/src/main/java/org/apache/hugegraph/traversal/optimize/TraversalUtil.java
@@ -46,6 +46,7 @@ import org.apache.hugegraph.schema.SchemaLabel;
 import org.apache.hugegraph.structure.HugeElement;
 import org.apache.hugegraph.structure.HugeProperty;
 import org.apache.hugegraph.type.HugeType;
+import org.apache.hugegraph.type.define.DataType;
 import org.apache.hugegraph.type.define.Directions;
 import org.apache.hugegraph.type.define.HugeKeys;
 import org.apache.hugegraph.util.CollectionUtil;
@@ -419,9 +420,9 @@ public final class TraversalUtil {
         return cond;
     }
 
-    private static Condition.Relation convCompare2Relation(HugeGraph graph,
-                                                           HugeType type,
-                                                           HasContainer has) {
+    private static Condition convCompare2Relation(HugeGraph graph,
+                                                  HugeType type,
+                                                  HasContainer has) {
         assert type.isGraph();
         BiPredicate<?, ?> bp = has.getPredicate().getBiPredicate();
         assert bp instanceof Compare;
@@ -459,9 +460,9 @@ public final class TraversalUtil {
         }
     }
 
-    private static Condition.Relation convCompare2UserpropRelation(HugeGraph graph,
-                                                                   HugeType type,
-                                                                   HasContainer has) {
+    private static Condition convCompare2UserpropRelation(HugeGraph graph,
+                                                          HugeType type,
+                                                          HasContainer has) {
         BiPredicate<?, ?> bp = has.getPredicate().getBiPredicate();
         assert bp instanceof Compare;
 
@@ -469,6 +470,11 @@ public final class TraversalUtil {
         PropertyKey pkey = graph.propertyKey(key);
         Id pkeyId = pkey.id();
         Object value = validPropertyValue(has.getValue(), pkey);
+        if (pkey.dataType() == DataType.BOOLEAN &&
+            value instanceof Boolean) {
+            return convCompare2BooleanUserpropRelation((Compare) bp, pkeyId,
+                                                       (Boolean) value);
+        }
 
         switch ((Compare) bp) {
             case eq:
@@ -486,6 +492,36 @@ public final class TraversalUtil {
             default:
                 throw newUnsupportedPredicate(has.getPredicate());
         }
+    }
+
+    private static Condition convCompare2BooleanUserpropRelation(Compare compare,
+                                                                 Id key,
+                                                                 Boolean value) {
+        switch (compare) {
+            case eq:
+                return Condition.eq(key, value);
+            case neq:
+                return Condition.neq(key, value);
+            case gt:
+                return value ? impossibleBooleanCondition(key) :
+                       Condition.eq(key, true);
+            case gte:
+                return value ? Condition.eq(key, true) :
+                       Condition.in(key, ImmutableList.of(false, true));
+            case lt:
+                return value ? Condition.eq(key, false) :
+                       impossibleBooleanCondition(key);
+            case lte:
+                return value ? Condition.in(key, ImmutableList.of(false, true)) :
+                       Condition.eq(key, false);
+            default:
+                throw new AssertionError(compare);
+        }
+    }
+
+    private static Condition impossibleBooleanCondition(Id key) {
+        return Condition.and(Condition.eq(key, false),
+                             Condition.eq(key, true));
     }
 
     private static Condition convRelationType2Relation(HugeGraph graph,

--- a/hugegraph-server/hugegraph-core/src/main/java/org/apache/hugegraph/traversal/optimize/TraversalUtil.java
+++ b/hugegraph-server/hugegraph-core/src/main/java/org/apache/hugegraph/traversal/optimize/TraversalUtil.java
@@ -503,25 +503,20 @@ public final class TraversalUtil {
             case neq:
                 return Condition.neq(key, value);
             case gt:
-                return value ? impossibleBooleanCondition(key) :
+                return value ? Condition.in(key, ImmutableList.of()) :
                        Condition.eq(key, true);
             case gte:
                 return value ? Condition.eq(key, true) :
                        Condition.in(key, ImmutableList.of(false, true));
             case lt:
                 return value ? Condition.eq(key, false) :
-                       impossibleBooleanCondition(key);
+                       Condition.in(key, ImmutableList.of());
             case lte:
                 return value ? Condition.in(key, ImmutableList.of(false, true)) :
                        Condition.eq(key, false);
             default:
                 throw new AssertionError(compare);
         }
-    }
-
-    private static Condition impossibleBooleanCondition(Id key) {
-        return Condition.and(Condition.eq(key, false),
-                             Condition.eq(key, true));
     }
 
     private static Condition convRelationType2Relation(HugeGraph graph,

--- a/hugegraph-server/hugegraph-test/src/main/java/org/apache/hugegraph/core/EdgeCoreTest.java
+++ b/hugegraph-server/hugegraph-test/src/main/java/org/apache/hugegraph/core/EdgeCoreTest.java
@@ -7221,11 +7221,11 @@ public class EdgeCoreTest extends BaseCoreTest {
         louise.addEdge("strike", sean, "id", 1,
                        "timestamp", current, "place", "park",
                        "tool", "shovel", "reason", "jeer",
-                       "hurt", false);
+                       "hurt", false, "arrested", false);
         louise.addEdge("strike", sean, "id", 2,
                        "timestamp", current + 1, "place", "street",
                        "tool", "shovel", "reason", "jeer",
-                       "hurt", true);
+                       "hurt", true, "arrested", true);
         louise.addEdge("strike", sean, "id", 3,
                        "timestamp", current + 2, "place", "mall",
                        "tool", "shovel", "reason", "jeer",

--- a/hugegraph-server/hugegraph-test/src/main/java/org/apache/hugegraph/core/EdgeCoreTest.java
+++ b/hugegraph-server/hugegraph-test/src/main/java/org/apache/hugegraph/core/EdgeCoreTest.java
@@ -7160,6 +7160,18 @@ public class EdgeCoreTest extends BaseCoreTest {
         Assert.assertEquals(1, matchEdges.size());
         Assert.assertEquals(1, (int) matchEdges.get(0).value("id"));
 
+        List<Edge> hasNeqTrueEdges = graph.traversal().E()
+                                          .has("arrested", P.neq(true))
+                                          .toList();
+        Assert.assertEquals(1, hasNeqTrueEdges.size());
+        Assert.assertEquals(1, (int) hasNeqTrueEdges.get(0).value("id"));
+
+        List<Edge> hasNeqFalseEdges = graph.traversal().E()
+                                           .has("arrested", P.neq(false))
+                                           .toList();
+        Assert.assertEquals(1, hasNeqFalseEdges.size());
+        Assert.assertEquals(2, (int) hasNeqFalseEdges.get(0).value("id"));
+
         List<Edge> hasLteFalseEdges = graph.traversal().E()
                                            .has("arrested", P.lte(false))
                                            .toList();
@@ -7256,6 +7268,12 @@ public class EdgeCoreTest extends BaseCoreTest {
                                          .toList();
         Assert.assertEquals(1, lteFalseEdges.size());
         Assert.assertEquals(1, (int) lteFalseEdges.get(0).value("id"));
+
+        List<Edge> neqTrueEdges = graph.traversal().E()
+                                       .has("hurt", P.neq(true))
+                                       .toList();
+        Assert.assertEquals(1, neqTrueEdges.size());
+        Assert.assertEquals(1, (int) neqTrueEdges.get(0).value("id"));
     }
 
     @Test

--- a/hugegraph-server/hugegraph-test/src/main/java/org/apache/hugegraph/core/EdgeCoreTest.java
+++ b/hugegraph-server/hugegraph-test/src/main/java/org/apache/hugegraph/core/EdgeCoreTest.java
@@ -7207,6 +7207,57 @@ public class EdgeCoreTest extends BaseCoreTest {
     }
 
     @Test
+    public void testQueryEdgeByBooleanRangePredicateWithoutNullableProperty() {
+        HugeGraph graph = graph();
+        initStrikeIndex();
+        graph.schema().indexLabel("strikeByHurt").onE("strike").secondary()
+             .by("hurt").create();
+
+        Vertex louise = graph.addVertex(T.label, "person", "name", "Louise",
+                                        "city", "Beijing", "age", 21);
+        Vertex sean = graph.addVertex(T.label, "person", "name", "Sean",
+                                      "city", "Beijing", "age", 23);
+        long current = System.currentTimeMillis();
+        louise.addEdge("strike", sean, "id", 1,
+                       "timestamp", current, "place", "park",
+                       "tool", "shovel", "reason", "jeer",
+                       "hurt", false);
+        louise.addEdge("strike", sean, "id", 2,
+                       "timestamp", current + 1, "place", "street",
+                       "tool", "shovel", "reason", "jeer",
+                       "hurt", true);
+        louise.addEdge("strike", sean, "id", 3,
+                       "timestamp", current + 2, "place", "mall",
+                       "tool", "shovel", "reason", "jeer");
+
+        List<Edge> gteFalseEdges = graph.traversal().E()
+                                        .has("hurt", P.gte(false))
+                                        .toList();
+        Assert.assertEquals(2, gteFalseEdges.size());
+        Set<Integer> gteFalseIds = new HashSet<>();
+        for (Edge edge : gteFalseEdges) {
+            gteFalseIds.add(edge.value("id"));
+        }
+        Assert.assertEquals(ImmutableSet.of(1, 2), gteFalseIds);
+
+        List<Edge> lteTrueEdges = graph.traversal().E()
+                                        .has("hurt", P.lte(true))
+                                        .toList();
+        Assert.assertEquals(2, lteTrueEdges.size());
+        Set<Integer> lteTrueIds = new HashSet<>();
+        for (Edge edge : lteTrueEdges) {
+            lteTrueIds.add(edge.value("id"));
+        }
+        Assert.assertEquals(ImmutableSet.of(1, 2), lteTrueIds);
+
+        List<Edge> lteFalseEdges = graph.traversal().E()
+                                         .has("hurt", P.lte(false))
+                                         .toList();
+        Assert.assertEquals(1, lteFalseEdges.size());
+        Assert.assertEquals(1, (int) lteFalseEdges.get(0).value("id"));
+    }
+
+    @Test
     public void testQueryEdgeByPage() {
         Assume.assumeTrue("Not support paging",
                           storeFeatures().supportsQueryByPage());

--- a/hugegraph-server/hugegraph-test/src/main/java/org/apache/hugegraph/core/EdgeCoreTest.java
+++ b/hugegraph-server/hugegraph-test/src/main/java/org/apache/hugegraph/core/EdgeCoreTest.java
@@ -7228,7 +7228,8 @@ public class EdgeCoreTest extends BaseCoreTest {
                        "hurt", true);
         louise.addEdge("strike", sean, "id", 3,
                        "timestamp", current + 2, "place", "mall",
-                       "tool", "shovel", "reason", "jeer");
+                       "tool", "shovel", "reason", "jeer",
+                       "arrested", false);
 
         List<Edge> gteFalseEdges = graph.traversal().E()
                                         .has("hurt", P.gte(false))

--- a/hugegraph-server/hugegraph-test/src/main/java/org/apache/hugegraph/core/EdgeCoreTest.java
+++ b/hugegraph-server/hugegraph-test/src/main/java/org/apache/hugegraph/core/EdgeCoreTest.java
@@ -7138,6 +7138,12 @@ public class EdgeCoreTest extends BaseCoreTest {
                        "tool", "shovel", "reason", "jeer",
                        "arrested", true);
 
+        List<Edge> hasLtEdges = graph.traversal().E()
+                                     .has("arrested", P.lt(true))
+                                     .toList();
+        Assert.assertEquals(1, hasLtEdges.size());
+        Assert.assertEquals(1, (int) hasLtEdges.get(0).value("id"));
+
         List<Edge> whereEdges = graph.traversal().E()
                                      .where(__.has("arrested", P.lt(true)))
                                      .toList();
@@ -7153,6 +7159,51 @@ public class EdgeCoreTest extends BaseCoreTest {
                                      .toList();
         Assert.assertEquals(1, matchEdges.size());
         Assert.assertEquals(1, (int) matchEdges.get(0).value("id"));
+
+        List<Edge> hasLteFalseEdges = graph.traversal().E()
+                                           .has("arrested", P.lte(false))
+                                           .toList();
+        Assert.assertEquals(1, hasLteFalseEdges.size());
+        Assert.assertEquals(1, (int) hasLteFalseEdges.get(0).value("id"));
+
+        List<Edge> hasGtFalseEdges = graph.traversal().E()
+                                          .has("arrested", P.gt(false))
+                                          .toList();
+        Assert.assertEquals(1, hasGtFalseEdges.size());
+        Assert.assertEquals(2, (int) hasGtFalseEdges.get(0).value("id"));
+
+        List<Edge> hasGteTrueEdges = graph.traversal().E()
+                                           .has("arrested", P.gte(true))
+                                           .toList();
+        Assert.assertEquals(1, hasGteTrueEdges.size());
+        Assert.assertEquals(2, (int) hasGteTrueEdges.get(0).value("id"));
+
+        List<Edge> hasGteFalseEdges = graph.traversal().E()
+                                            .has("arrested", P.gte(false))
+                                            .toList();
+        Assert.assertEquals(2, hasGteFalseEdges.size());
+        Set<Integer> gteFalseIds = new HashSet<>();
+        for (Edge edge : hasGteFalseEdges) {
+            gteFalseIds.add(edge.value("id"));
+        }
+        Assert.assertEquals(ImmutableSet.of(1, 2), gteFalseIds);
+
+        List<Edge> hasLteTrueEdges = graph.traversal().E()
+                                           .has("arrested", P.lte(true))
+                                           .toList();
+        Assert.assertEquals(2, hasLteTrueEdges.size());
+        Set<Integer> lteTrueIds = new HashSet<>();
+        for (Edge edge : hasLteTrueEdges) {
+            lteTrueIds.add(edge.value("id"));
+        }
+        Assert.assertEquals(ImmutableSet.of(1, 2), lteTrueIds);
+
+        Assert.assertEquals(0, graph.traversal().E()
+                                    .has("arrested", P.lt(false))
+                                    .toList().size());
+        Assert.assertEquals(0, graph.traversal().E()
+                                    .has("arrested", P.gt(true))
+                                    .toList().size());
     }
 
     @Test

--- a/hugegraph-server/hugegraph-test/src/main/java/org/apache/hugegraph/core/EdgeCoreTest.java
+++ b/hugegraph-server/hugegraph-test/src/main/java/org/apache/hugegraph/core/EdgeCoreTest.java
@@ -7118,6 +7118,48 @@ public class EdgeCoreTest extends BaseCoreTest {
     }
 
     @Test
+    public void testQueryEdgeByBooleanRangePredicate() {
+        HugeGraph graph = graph();
+        initStrikeIndex();
+
+        Vertex louise = graph.addVertex(T.label, "person", "name", "Louise",
+                                        "city", "Beijing", "age", 21);
+        Vertex sean = graph.addVertex(T.label, "person", "name", "Sean",
+                                      "city", "Beijing", "age", 23);
+        long current = System.currentTimeMillis();
+        louise.addEdge("strike", sean, "id", 1,
+                       "timestamp", current, "place", "park",
+                       "tool", "shovel", "reason", "jeer",
+                       "arrested", false);
+        louise.addEdge("strike", sean, "id", 2,
+                       "timestamp", current + 1, "place", "street",
+                       "tool", "shovel", "reason", "jeer",
+                       "arrested", true);
+
+        List<Edge> hasEdges = graph.traversal().E()
+                                   .has("arrested", P.lt(true))
+                                   .toList();
+        Assert.assertEquals(1, hasEdges.size());
+        Assert.assertEquals(1, (int) hasEdges.get(0).value("id"));
+
+        List<Edge> whereEdges = graph.traversal().E()
+                                     .where(__.has("arrested", P.lt(true)))
+                                     .toList();
+        Assert.assertEquals(1, whereEdges.size());
+        Assert.assertEquals(1, (int) whereEdges.get(0).value("id"));
+
+        List<Edge> matchEdges = graph.traversal().E()
+                                     .as("e")
+                                     .match(__.as("e")
+                                              .has("arrested", P.lt(true)))
+                                     .<Edge>select("e")
+                                     .dedup()
+                                     .toList();
+        Assert.assertEquals(1, matchEdges.size());
+        Assert.assertEquals(1, (int) matchEdges.get(0).value("id"));
+    }
+
+    @Test
     public void testQueryEdgeByPage() {
         Assume.assumeTrue("Not support paging",
                           storeFeatures().supportsQueryByPage());

--- a/hugegraph-server/hugegraph-test/src/main/java/org/apache/hugegraph/core/EdgeCoreTest.java
+++ b/hugegraph-server/hugegraph-test/src/main/java/org/apache/hugegraph/core/EdgeCoreTest.java
@@ -7121,6 +7121,8 @@ public class EdgeCoreTest extends BaseCoreTest {
     public void testQueryEdgeByBooleanRangePredicate() {
         HugeGraph graph = graph();
         initStrikeIndex();
+        graph.schema().indexLabel("strikeByArrested").onE("strike").secondary()
+             .by("arrested").create();
 
         Vertex louise = graph.addVertex(T.label, "person", "name", "Louise",
                                         "city", "Beijing", "age", 21);

--- a/hugegraph-server/hugegraph-test/src/main/java/org/apache/hugegraph/core/EdgeCoreTest.java
+++ b/hugegraph-server/hugegraph-test/src/main/java/org/apache/hugegraph/core/EdgeCoreTest.java
@@ -7121,8 +7121,6 @@ public class EdgeCoreTest extends BaseCoreTest {
     public void testQueryEdgeByBooleanRangePredicate() {
         HugeGraph graph = graph();
         initStrikeIndex();
-        graph.schema().indexLabel("strikeByArrested").onE("strike").secondary()
-             .by("arrested").create();
 
         Vertex louise = graph.addVertex(T.label, "person", "name", "Louise",
                                         "city", "Beijing", "age", 21);
@@ -7138,12 +7136,6 @@ public class EdgeCoreTest extends BaseCoreTest {
                        "tool", "shovel", "reason", "jeer",
                        "arrested", true);
 
-        List<Edge> hasEdges = graph.traversal().E()
-                                   .has("arrested", P.lt(true))
-                                   .toList();
-        Assert.assertEquals(1, hasEdges.size());
-        Assert.assertEquals(1, (int) hasEdges.get(0).value("id"));
-
         List<Edge> whereEdges = graph.traversal().E()
                                      .where(__.has("arrested", P.lt(true)))
                                      .toList();
@@ -7151,11 +7143,11 @@ public class EdgeCoreTest extends BaseCoreTest {
         Assert.assertEquals(1, (int) whereEdges.get(0).value("id"));
 
         List<Edge> matchEdges = graph.traversal().E()
-                                     .as("e")
-                                     .match(__.as("e")
-                                              .has("arrested", P.lt(true)))
-                                     .<Edge>select("e")
-                                     .dedup()
+                                     .match(__.as("start")
+                                              .where(__.has("arrested",
+                                                            P.lt(true)))
+                                              .as("matched"))
+                                     .<Edge>select("matched")
                                      .toList();
         Assert.assertEquals(1, matchEdges.size());
         Assert.assertEquals(1, (int) matchEdges.get(0).value("id"));

--- a/hugegraph-server/hugegraph-test/src/main/java/org/apache/hugegraph/core/VertexCoreTest.java
+++ b/hugegraph-server/hugegraph-test/src/main/java/org/apache/hugegraph/core/VertexCoreTest.java
@@ -6472,6 +6472,9 @@ public class VertexCoreTest extends BaseCoreTest {
 
     @Test
     public void testQueryVertexByBooleanNeqPredicate() {
+        Assume.assumeTrue("skip this test for hstore",
+                          !Objects.equals("hstore", System.getProperty("backend")));
+
         HugeGraph graph = graph();
         graph.schema().indexLabel("languageByDynamic").onV("language")
              .secondary().by("dynamic").create();

--- a/hugegraph-server/hugegraph-test/src/main/java/org/apache/hugegraph/core/VertexCoreTest.java
+++ b/hugegraph-server/hugegraph-test/src/main/java/org/apache/hugegraph/core/VertexCoreTest.java
@@ -6471,6 +6471,34 @@ public class VertexCoreTest extends BaseCoreTest {
     }
 
     @Test
+    public void testQueryVertexByBooleanNeqPredicate() {
+        HugeGraph graph = graph();
+        graph.schema().indexLabel("languageByDynamic").onV("language")
+             .secondary().by("dynamic").create();
+
+        graph.addVertex(T.label, "language", "name", "java",
+                        "dynamic", true);
+        graph.addVertex(T.label, "language", "name", "rust",
+                        "dynamic", false);
+        graph.addVertex(T.label, "language", "name", "c");
+        this.commitTx();
+
+        List<Vertex> neqTrueVertices = graph.traversal().V()
+                                             .hasLabel("language")
+                                             .has("dynamic", P.neq(true))
+                                             .toList();
+        Assert.assertEquals(1, neqTrueVertices.size());
+        Assert.assertEquals("rust", neqTrueVertices.get(0).value("name"));
+
+        List<Vertex> neqFalseVertices = graph.traversal().V()
+                                              .hasLabel("language")
+                                              .has("dynamic", P.neq(false))
+                                              .toList();
+        Assert.assertEquals(1, neqFalseVertices.size());
+        Assert.assertEquals("java", neqFalseVertices.get(0).value("name"));
+    }
+
+    @Test
     public void testQueryVertexBeforeAfterUpdateMultiPropertyWithIndex() {
         HugeGraph graph = graph();
         initPersonIndex(true);

--- a/hugegraph-server/hugegraph-test/src/main/java/org/apache/hugegraph/core/VertexCoreTest.java
+++ b/hugegraph-server/hugegraph-test/src/main/java/org/apache/hugegraph/core/VertexCoreTest.java
@@ -6472,10 +6472,10 @@ public class VertexCoreTest extends BaseCoreTest {
 
     @Test
     public void testQueryVertexByBooleanNeqPredicate() {
-        Assume.assumeTrue("skip this test for hstore",
-                          !Objects.equals("hstore", System.getProperty("backend")));
-
         HugeGraph graph = graph();
+        Assume.assumeFalse("skip this test for hstore",
+                           Objects.equals("hstore", graph.backend()));
+
         graph.schema().indexLabel("languageByDynamic").onV("language")
              .secondary().by("dynamic").create();
 

--- a/hugegraph-server/hugegraph-test/src/main/java/org/apache/hugegraph/core/VertexCoreTest.java
+++ b/hugegraph-server/hugegraph-test/src/main/java/org/apache/hugegraph/core/VertexCoreTest.java
@@ -6471,7 +6471,7 @@ public class VertexCoreTest extends BaseCoreTest {
     }
 
     @Test
-    public void testQueryVertexByBooleanNeqPredicate() {
+    public void testQueryVertexByBooleanPredicate() {
         HugeGraph graph = graph();
         Assume.assumeFalse("skip this test for hstore",
                            Objects.equals("hstore", graph.backend()));
@@ -6494,11 +6494,61 @@ public class VertexCoreTest extends BaseCoreTest {
         Assert.assertEquals("rust", neqTrueVertices.get(0).value("name"));
 
         List<Vertex> neqFalseVertices = graph.traversal().V()
-                                              .hasLabel("language")
-                                              .has("dynamic", P.neq(false))
-                                              .toList();
+                                               .hasLabel("language")
+                                               .has("dynamic", P.neq(false))
+                                               .toList();
         Assert.assertEquals(1, neqFalseVertices.size());
         Assert.assertEquals("java", neqFalseVertices.get(0).value("name"));
+
+        List<Vertex> hasLtVertices = graph.traversal().V()
+                                           .hasLabel("language")
+                                           .has("dynamic", P.lt(true))
+                                           .toList();
+        Assert.assertEquals(1, hasLtVertices.size());
+        Assert.assertEquals("rust", hasLtVertices.get(0).value("name"));
+
+        List<Vertex> whereLtVertices = graph.traversal().V()
+                                             .hasLabel("language")
+                                             .where(__.has("dynamic",
+                                                           P.lt(true)))
+                                             .toList();
+        Assert.assertEquals(1, whereLtVertices.size());
+        Assert.assertEquals("rust", whereLtVertices.get(0).value("name"));
+
+        List<Vertex> matchLtVertices = graph.traversal().V()
+                                             .hasLabel("language")
+                                             .match(__.as("start")
+                                                      .where(__.has("dynamic",
+                                                                    P.lt(true)))
+                                                      .as("matched"))
+                                             .<Vertex>select("matched")
+                                             .toList();
+        Assert.assertEquals(1, matchLtVertices.size());
+        Assert.assertEquals("rust", matchLtVertices.get(0).value("name"));
+
+        List<Vertex> compoundOrVertices = graph.traversal().V()
+                                                .hasLabel("language")
+                                                .has("dynamic",
+                                                     P.gt(true).or(P.eq(true)))
+                                                .toList();
+        Assert.assertEquals(1, compoundOrVertices.size());
+        Assert.assertEquals("java", compoundOrVertices.get(0).value("name"));
+
+        Assert.assertEquals(0, graph.traversal().V()
+                                    .hasLabel("language")
+                                    .has("dynamic", P.lt(false))
+                                    .toList().size());
+
+        List<Vertex> gteFalseVertices = graph.traversal().V()
+                                             .hasLabel("language")
+                                             .has("dynamic", P.gte(false))
+                                             .toList();
+        Assert.assertEquals(2, gteFalseVertices.size());
+        Set<String> gteFalseNames = new HashSet<>();
+        for (Vertex vertex : gteFalseVertices) {
+            gteFalseNames.add(vertex.value("name"));
+        }
+        Assert.assertEquals(ImmutableSet.of("java", "rust"), gteFalseNames);
     }
 
     @Test

--- a/hugegraph-server/hugegraph-test/src/main/java/org/apache/hugegraph/unit/core/ConditionQueryFlattenTest.java
+++ b/hugegraph-server/hugegraph-test/src/main/java/org/apache/hugegraph/unit/core/ConditionQueryFlattenTest.java
@@ -256,5 +256,48 @@ public class ConditionQueryFlattenTest extends BaseUnitTest {
         Collection<Condition> actual = queries.iterator().next().conditions();
         Assert.assertEquals(expect, actual);
     }
+
+    @Test
+    public void testFlattenWithBooleanRangeUpperBound() {
+        Id key = IdGenerator.of("c1");
+
+        ConditionQuery query = new ConditionQuery(HugeType.VERTEX);
+        query.query(Condition.lt(key, true));
+        query.query(Condition.lt(key, false));
+
+        List<ConditionQuery> queries = ConditionQueryFlatten.flatten(query);
+        Assert.assertEquals(1, queries.size());
+
+        Collection<Condition> actual = queries.iterator().next().conditions();
+        Assert.assertEquals(ImmutableList.of(Condition.lt(key, false)), actual);
+    }
+
+    @Test
+    public void testFlattenWithBooleanRangeWindow() {
+        Id key = IdGenerator.of("c1");
+
+        ConditionQuery query = new ConditionQuery(HugeType.VERTEX);
+        query.query(Condition.gte(key, false));
+        query.query(Condition.lt(key, true));
+
+        List<ConditionQuery> queries = ConditionQueryFlatten.flatten(query);
+        Assert.assertEquals(1, queries.size());
+
+        Collection<Condition> actual = queries.iterator().next().conditions();
+        Assert.assertEquals(ImmutableList.of(Condition.gte(key, false),
+                                             Condition.lt(key, true)), actual);
+    }
+
+    @Test
+    public void testFlattenWithConflictingBooleanRange() {
+        Id key = IdGenerator.of("c1");
+
+        ConditionQuery query = new ConditionQuery(HugeType.VERTEX);
+        query.query(Condition.gt(key, false));
+        query.query(Condition.lt(key, true));
+
+        List<ConditionQuery> queries = ConditionQueryFlatten.flatten(query);
+        Assert.assertEquals(0, queries.size());
+    }
 }
 

--- a/hugegraph-server/hugegraph-test/src/main/java/org/apache/hugegraph/unit/core/ConditionQueryFlattenTest.java
+++ b/hugegraph-server/hugegraph-test/src/main/java/org/apache/hugegraph/unit/core/ConditionQueryFlattenTest.java
@@ -293,11 +293,28 @@ public class ConditionQueryFlattenTest extends BaseUnitTest {
         Id key = IdGenerator.of("c1");
 
         ConditionQuery query = new ConditionQuery(HugeType.VERTEX);
-        query.query(Condition.gt(key, false));
-        query.query(Condition.lt(key, true));
+        query.query(Condition.gt(key, false).and(Condition.lt(key, true)));
 
         List<ConditionQuery> queries = ConditionQueryFlatten.flatten(query);
         Assert.assertEquals(0, queries.size());
+    }
+
+    @Test
+    public void testFlattenWithConflictingNumericRangeKeepsQuery() {
+        Id key = IdGenerator.of("c1");
+
+        Condition gt = Condition.gt(key, 10);
+        Condition eq = Condition.eq(key, 9);
+
+        ConditionQuery query = new ConditionQuery(HugeType.VERTEX);
+        query.query(gt);
+        query.query(eq);
+
+        List<ConditionQuery> queries = ConditionQueryFlatten.flatten(query);
+        Assert.assertEquals(1, queries.size());
+
+        Collection<Condition> actual = queries.iterator().next().conditions();
+        Assert.assertEquals(ImmutableList.of(gt, eq), actual);
     }
 }
 

--- a/hugegraph-server/hugegraph-test/src/main/java/org/apache/hugegraph/unit/core/ConditionQueryFlattenTest.java
+++ b/hugegraph-server/hugegraph-test/src/main/java/org/apache/hugegraph/unit/core/ConditionQueryFlattenTest.java
@@ -300,6 +300,48 @@ public class ConditionQueryFlattenTest extends BaseUnitTest {
     }
 
     @Test
+    public void testFlattenWithImpossibleInInsideAnd() {
+        Id key = IdGenerator.of("c1");
+
+        ConditionQuery query = new ConditionQuery(HugeType.VERTEX);
+        query.query(Condition.in(key, ImmutableList.of())
+                             .and(Condition.eq(key, true)));
+
+        List<ConditionQuery> queries = ConditionQueryFlatten.flatten(query);
+        Assert.assertEquals(0, queries.size());
+    }
+
+    @Test
+    public void testFlattenWithImpossibleInInsideOr() {
+        Id key = IdGenerator.of("c1");
+
+        ConditionQuery query = new ConditionQuery(HugeType.VERTEX);
+        Condition eq = Condition.eq(key, true);
+        query.query(Condition.in(key, ImmutableList.of()).or(eq));
+
+        List<ConditionQuery> queries = ConditionQueryFlatten.flatten(query);
+        Assert.assertEquals(1, queries.size());
+
+        Collection<Condition> actual = queries.iterator().next().conditions();
+        Assert.assertEquals(ImmutableList.of(eq), actual);
+    }
+
+    @Test
+    public void testFlattenWithImpossibleInInsideOrRight() {
+        Id key = IdGenerator.of("c1");
+
+        ConditionQuery query = new ConditionQuery(HugeType.VERTEX);
+        Condition eq = Condition.eq(key, true);
+        query.query(eq.or(Condition.in(key, ImmutableList.of())));
+
+        List<ConditionQuery> queries = ConditionQueryFlatten.flatten(query);
+        Assert.assertEquals(1, queries.size());
+
+        Collection<Condition> actual = queries.iterator().next().conditions();
+        Assert.assertEquals(ImmutableList.of(eq), actual);
+    }
+
+    @Test
     public void testFlattenWithConflictingNumericRangeKeepsQuery() {
         Id key = IdGenerator.of("c1");
 

--- a/hugegraph-server/hugegraph-test/src/main/java/org/apache/hugegraph/unit/core/ConditionQueryFlattenTest.java
+++ b/hugegraph-server/hugegraph-test/src/main/java/org/apache/hugegraph/unit/core/ConditionQueryFlattenTest.java
@@ -342,6 +342,26 @@ public class ConditionQueryFlattenTest extends BaseUnitTest {
     }
 
     @Test
+    public void testFlattenWithImpossibleInInsideNestedAndOverOr() {
+        Id leftKey = IdGenerator.of("c1");
+        Id rightKey = IdGenerator.of("c2");
+
+        Condition left = Condition.in(leftKey, ImmutableList.of())
+                                  .or(Condition.eq(leftKey, "a"));
+        Condition right = Condition.eq(rightKey, "b");
+
+        ConditionQuery query = new ConditionQuery(HugeType.VERTEX);
+        query.query(left.and(right));
+
+        List<ConditionQuery> queries = ConditionQueryFlatten.flatten(query);
+        Assert.assertEquals(1, queries.size());
+
+        Collection<Condition> actual = queries.iterator().next().conditions();
+        Assert.assertEquals(ImmutableList.of(Condition.eq(leftKey, "a"),
+                                             right), actual);
+    }
+
+    @Test
     public void testFlattenWithConflictingNumericRangeKeepsQuery() {
         Id key = IdGenerator.of("c1");
 

--- a/hugegraph-server/hugegraph-test/src/main/java/org/apache/hugegraph/unit/core/ConditionTest.java
+++ b/hugegraph-server/hugegraph-test/src/main/java/org/apache/hugegraph/unit/core/ConditionTest.java
@@ -317,6 +317,12 @@ public class ConditionTest extends BaseUnitTest {
             String err = "Can't compare between 1(Integer) and true(Boolean)";
             Assert.assertEquals(err, e.getMessage());
         });
+        Assert.assertThrows(IllegalArgumentException.class, () -> {
+            Condition.lt(HugeKeys.ID, true).test((Object) null);
+        }, e -> {
+            String err = "Can't compare between null(null) and true(Boolean)";
+            Assert.assertEquals(err, e.getMessage());
+        });
     }
 
     @Test

--- a/hugegraph-server/hugegraph-test/src/main/java/org/apache/hugegraph/unit/core/ConditionTest.java
+++ b/hugegraph-server/hugegraph-test/src/main/java/org/apache/hugegraph/unit/core/ConditionTest.java
@@ -294,6 +294,32 @@ public class ConditionTest extends BaseUnitTest {
     }
 
     @Test
+    public void testConditionBooleanRange() {
+        Condition lt = Condition.lt(HugeKeys.ID, true);
+        Assert.assertTrue(lt.test(false));
+        Assert.assertFalse(lt.test(true));
+
+        Condition lte = Condition.lte(HugeKeys.ID, false);
+        Assert.assertTrue(lte.test(false));
+        Assert.assertFalse(lte.test(true));
+
+        Condition gt = Condition.gt(HugeKeys.ID, false);
+        Assert.assertTrue(gt.test(true));
+        Assert.assertFalse(gt.test(false));
+
+        Condition gte = Condition.gte(HugeKeys.ID, true);
+        Assert.assertTrue(gte.test(true));
+        Assert.assertFalse(gte.test(false));
+
+        Assert.assertThrows(IllegalArgumentException.class, () -> {
+            Condition.lt(HugeKeys.ID, true).test(1);
+        }, e -> {
+            String err = "Can't compare between 1(Integer) and true(Boolean)";
+            Assert.assertEquals(err, e.getMessage());
+        });
+    }
+
+    @Test
     public void testConditionNeq() {
         Condition c1 = Condition.neq(HugeKeys.ID, 123);
         Assert.assertTrue(c1.test(124));

--- a/hugegraph-struct/src/main/java/org/apache/hugegraph/query/Condition.java
+++ b/hugegraph-struct/src/main/java/org/apache/hugegraph/query/Condition.java
@@ -475,16 +475,14 @@ public abstract class Condition {
         }
 
         private static int compareBoolean(Object first, Boolean second) {
-            if (first == null) {
-                first = false;
-            }
             if (first instanceof Boolean) {
                 return Boolean.compare((Boolean) first, second);
             }
 
             throw new IllegalArgumentException(String.format(
                     "Can't compare between %s(%s) and %s(%s)",
-                    first, first.getClass().getSimpleName(),
+                    first, first == null ? null :
+                           first.getClass().getSimpleName(),
                     second, second.getClass().getSimpleName()));
         }
 

--- a/hugegraph-struct/src/main/java/org/apache/hugegraph/query/Condition.java
+++ b/hugegraph-struct/src/main/java/org/apache/hugegraph/query/Condition.java
@@ -437,7 +437,7 @@ public abstract class Condition {
          *
          * @param first  is actual value, might be Number/Date or String, It is
          *               probably that the `first` is serialized to String.
-         * @param second is value in query condition, must be Number/Date
+         * @param second is value in query condition, must be Number/Date/Boolean
          * @return the value 0 if first is numerically equal to second;
          * a value less than 0 if first is numerically less than
          * second; and a value greater than 0 if first is
@@ -450,6 +450,8 @@ public abstract class Condition {
                         (Number) second);
             } else if (second instanceof Date) {
                 return compareDate(first, (Date) second);
+            } else if (second instanceof Boolean) {
+                return compareBoolean(first, (Boolean) second);
             }
 
             throw new IllegalArgumentException(String.format(
@@ -464,6 +466,20 @@ public abstract class Condition {
             }
             if (first instanceof Date) {
                 return ((Date) first).compareTo(second);
+            }
+
+            throw new IllegalArgumentException(String.format(
+                    "Can't compare between %s(%s) and %s(%s)",
+                    first, first.getClass().getSimpleName(),
+                    second, second.getClass().getSimpleName()));
+        }
+
+        private static int compareBoolean(Object first, Boolean second) {
+            if (first == null) {
+                first = false;
+            }
+            if (first instanceof Boolean) {
+                return Boolean.compare((Boolean) first, second);
             }
 
             throw new IllegalArgumentException(String.format(

--- a/hugegraph-struct/src/test/java/org/apache/hugegraph/query/ConditionTest.java
+++ b/hugegraph-struct/src/test/java/org/apache/hugegraph/query/ConditionTest.java
@@ -46,5 +46,11 @@ public class ConditionTest {
                 () -> Condition.lt(HugeKeys.ID, true).test(1));
         Assert.assertEquals("Can't compare between 1(Integer) and true(Boolean)",
                             exception.getMessage());
+
+        exception = Assert.assertThrows(IllegalArgumentException.class,
+                                        () -> Condition.lt(HugeKeys.ID, true)
+                                                       .test((Object) null));
+        Assert.assertEquals("Can't compare between null(null) and true(Boolean)",
+                            exception.getMessage());
     }
 }

--- a/hugegraph-struct/src/test/java/org/apache/hugegraph/query/ConditionTest.java
+++ b/hugegraph-struct/src/test/java/org/apache/hugegraph/query/ConditionTest.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hugegraph.query;
+
+import org.apache.hugegraph.type.define.HugeKeys;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class ConditionTest {
+
+    @Test
+    public void testConditionBooleanRange() {
+        Condition lt = Condition.lt(HugeKeys.ID, true);
+        Assert.assertTrue(lt.test(false));
+        Assert.assertFalse(lt.test(true));
+
+        Condition lte = Condition.lte(HugeKeys.ID, false);
+        Assert.assertTrue(lte.test(false));
+        Assert.assertFalse(lte.test(true));
+
+        Condition gt = Condition.gt(HugeKeys.ID, false);
+        Assert.assertTrue(gt.test(true));
+        Assert.assertFalse(gt.test(false));
+
+        Condition gte = Condition.gte(HugeKeys.ID, true);
+        Assert.assertTrue(gte.test(true));
+        Assert.assertFalse(gte.test(false));
+
+        IllegalArgumentException exception = Assert.assertThrows(
+                IllegalArgumentException.class,
+                () -> Condition.lt(HugeKeys.ID, true).test(1));
+        Assert.assertEquals("Can't compare between 1(Integer) and true(Boolean)",
+                            exception.getMessage());
+    }
+}


### PR DESCRIPTION
<!-- 
  Thank you very much for contributing to Apache HugeGraph, we are happy that you want to help us improve it!

  Here are some tips for you:
    1. If this is your first time, please read the [contributing guidelines](https://github.com/apache/hugegraph/blob/master/CONTRIBUTING.md)

    2. If a PR fix/close an issue, type the message "close xxx" (xxx is the link of related 
issue) in the content, GitHub will auto link it (Required)

    3. Name the PR title in "Google Commit Format", start with "feat | fix | perf | refactor | doc | chore", 
      such like: "feat(core): support the PageRank algorithm" or "fix: wrong break in the compute loop" (module is optional)
      skip it if you are unsure about which is the best component.

    4. One PR address one issue, better not to mix up multiple issues.

    5. Put an `x` in the `[ ]` to mark the item as CHECKED. `[x]` (or click it directly after 
published)
-->

## Purpose of the PR

- fix #2934 <!-- or use "fix #xxx", "xxx" is the ID-link of related issue, e.g: close #1024 -->

This PR fixes HugeGraph's inconsistent handling of boolean range predicates and unifies the internal ordering semantics as false < true. Previously, filter-step queries such as where(__.has("xxx", P.lt(true))) were pushed down through HugeGraph's condition/query pipeline and incorrectly treated as numeric-style range conditions, while equivalent match() queries could still return results normally. As a result, semantically equivalent traversals behaved differently.
<!--
Please explain more context in this section, clarify why the changes are needed. 
e.g:
- If you propose a new API, clarify the use case for a new API.
- If you fix a bug, you can clarify why it is a bug, and should be associated with an issue.
-->

## Main Changes

The fix has two parts. First, boolean support is added to backend condition comparison and range-flattening logic so gt/gte/lt/lte can be evaluated consistently. Second, runtime Gremlin boolean range predicates are normalized into equivalent eq/in/empty conditions before query planning, so they are no longer misclassified as ordinary numeric range queries that require a range index. This preserves the intended boolean ordering semantics while making has(), where(), and match() behave consistently for boolean range predicates.

<!-- Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. These change logs are helpful for better and faster reviews.)

For example:

- If you introduce a new feature, please show detailed design here or add the link of design documentation.
- If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
- If there is a discussion in the mailing list, please add the link. -->

## Verifying these changes

Regression coverage was also added for:

- low-level boolean lt/lte/gt/gte comparison semantics
- boolean range merge and conflicting-range flattening
- end-to-end consistency across has(), where(), and match()
- empty-result edge cases such as lt(false) and gt(true)

<!-- Please pick the proper options below -->

- [ ] Trivial rework / code cleanup without any test coverage. (No Need)
- [ ] Already covered by existing tests, such as *(please modify tests here)*.
- [x] Need tests and can be verified as follows:
    - mvn -Drat.skip=true -P core-test,memory -pl hugegraph-server/hugegraph-test,hugegraph-struct -am -DfailIfNoTests=false '-Dtest=ConditionTest,ConditionQueryFlattenTest,EdgeCoreTest#testQueryEdgeByBooleanRangePredicate' clean test




## Does this PR potentially affect the following parts?

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ]  Dependencies ([add/update license](https://hugegraph.apache.org/docs/contribution-guidelines/contribute/#321-check-licenses) info & [regenerate_known_dependencies.sh](../install-dist/scripts/dependency/regenerate_known_dependencies.sh)) <!-- Don't forget to add/update the info in "LICENSE" & "NOTICE" files (both in root & dist module) -->
- [ ]  Modify configurations
- [ ]  The public API
- [ ]  Other affects (typed here)
- [x]  Nope


## Documentation Status

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ]  `Doc - TODO` <!-- Your PR changes impact docs and you will update later -->
- [ ]  `Doc - Done` <!-- Related docs have been already added or updated -->
- [x]  `Doc - No Need` <!-- Your PR changes don't impact/need docs -->
