### PR TITLE
fix(server): auto-recover session after Cassandra restart

### DIFF
--- a/hugegraph-server/hugegraph-cassandra/src/main/java/org/apache/hugegraph/backend/store/cassandra/CassandraOptions.java
+++ b/hugegraph-server/hugegraph-cassandra/src/main/java/org/apache/hugegraph/backend/store/cassandra/CassandraOptions.java
@@ -148,7 +148,7 @@ public class CassandraOptions extends OptionHolder {
                     "exponential reconnection policy when a Cassandra host " +
                     "becomes unreachable.",
                     rangeInt(1000L, Long.MAX_VALUE),
-                    60_000L
+                    10_000L
             );
 
     public static final ConfigOption<Integer> CASSANDRA_RECONNECT_MAX_RETRIES =
@@ -159,7 +159,7 @@ public class CassandraOptions extends OptionHolder {
                     "(NoHostAvailableException / OperationTimedOutException). " +
                     "Set to 0 to disable query-time retries.",
                     rangeInt(0, Integer.MAX_VALUE),
-                    10
+                    3
             );
 
     public static final ConfigOption<Long> CASSANDRA_RECONNECT_INTERVAL =
@@ -170,6 +170,6 @@ public class CassandraOptions extends OptionHolder {
                     "actual wait grows with exponential backoff, capped at " +
                     "cassandra.reconnect_max_delay.",
                     rangeInt(100L, Long.MAX_VALUE),
-                    5000L
+                    1000L
             );
 }

--- a/hugegraph-server/hugegraph-cassandra/src/main/java/org/apache/hugegraph/backend/store/cassandra/CassandraOptions.java
+++ b/hugegraph-server/hugegraph-cassandra/src/main/java/org/apache/hugegraph/backend/store/cassandra/CassandraOptions.java
@@ -151,20 +151,21 @@ public class CassandraOptions extends OptionHolder {
                     10_000L
             );
 
-    public static final ConfigOption<Integer> CASSANDRA_RECONNECT_MAX_RETRIES =
+    public static final ConfigOption<Integer> CASSANDRA_QUERY_RETRY_MAX_ATTEMPTS =
             new ConfigOption<>(
-                    "cassandra.reconnect_max_retries",
-                    "The maximum number of retries applied at query-time when " +
-                    "a Cassandra host is temporarily unreachable " +
-                    "(NoHostAvailableException / OperationTimedOutException). " +
+                    "cassandra.query_retry_max_attempts",
+                    "The maximum number of retry attempts applied at query-time when " +
+                    "a Cassandra host is temporarily unreachable. " +
+                    "OperationTimedOutException is retried only for " +
+                    "idempotent statements. " +
                     "Set to 0 to disable query-time retries.",
                     rangeInt(0, Integer.MAX_VALUE),
                     3
             );
 
-    public static final ConfigOption<Long> CASSANDRA_RECONNECT_INTERVAL =
+    public static final ConfigOption<Long> CASSANDRA_QUERY_RETRY_INTERVAL =
             new ConfigOption<>(
-                    "cassandra.reconnect_interval",
+                    "cassandra.query_retry_interval",
                     "The interval in milliseconds between query-time retries " +
                     "when a Cassandra host is temporarily unreachable. The " +
                     "actual wait grows with exponential backoff, capped at " +

--- a/hugegraph-server/hugegraph-cassandra/src/main/java/org/apache/hugegraph/backend/store/cassandra/CassandraOptions.java
+++ b/hugegraph-server/hugegraph-cassandra/src/main/java/org/apache/hugegraph/backend/store/cassandra/CassandraOptions.java
@@ -130,4 +130,46 @@ public class CassandraOptions extends OptionHolder {
                     positiveInt(),
                     12 * 60 * 60
             );
+
+    public static final ConfigOption<Long> CASSANDRA_RECONNECT_BASE_DELAY =
+            new ConfigOption<>(
+                    "cassandra.reconnect_base_delay",
+                    "The base delay in milliseconds used by the driver's " +
+                    "exponential reconnection policy when a Cassandra host " +
+                    "becomes unreachable.",
+                    rangeInt(100L, Long.MAX_VALUE),
+                    1000L
+            );
+
+    public static final ConfigOption<Long> CASSANDRA_RECONNECT_MAX_DELAY =
+            new ConfigOption<>(
+                    "cassandra.reconnect_max_delay",
+                    "The maximum delay in milliseconds used by the driver's " +
+                    "exponential reconnection policy when a Cassandra host " +
+                    "becomes unreachable.",
+                    rangeInt(1000L, Long.MAX_VALUE),
+                    60_000L
+            );
+
+    public static final ConfigOption<Integer> CASSANDRA_RECONNECT_MAX_RETRIES =
+            new ConfigOption<>(
+                    "cassandra.reconnect_max_retries",
+                    "The maximum number of retries applied at query-time when " +
+                    "a Cassandra host is temporarily unreachable " +
+                    "(NoHostAvailableException / OperationTimedOutException). " +
+                    "Set to 0 to disable query-time retries.",
+                    rangeInt(0, Integer.MAX_VALUE),
+                    10
+            );
+
+    public static final ConfigOption<Long> CASSANDRA_RECONNECT_INTERVAL =
+            new ConfigOption<>(
+                    "cassandra.reconnect_interval",
+                    "The interval in milliseconds between query-time retries " +
+                    "when a Cassandra host is temporarily unreachable. The " +
+                    "actual wait grows with exponential backoff, capped at " +
+                    "cassandra.reconnect_max_delay.",
+                    rangeInt(100L, Long.MAX_VALUE),
+                    5000L
+            );
 }

--- a/hugegraph-server/hugegraph-cassandra/src/main/java/org/apache/hugegraph/backend/store/cassandra/CassandraSessionPool.java
+++ b/hugegraph-server/hugegraph-cassandra/src/main/java/org/apache/hugegraph/backend/store/cassandra/CassandraSessionPool.java
@@ -55,18 +55,30 @@ public class CassandraSessionPool extends BackendSessionPool {
 
     private Cluster cluster;
     private final String keyspace;
-    private int maxRetries;
-    private long retryInterval;
-    private long retryMaxDelay;
+    private final int maxRetries;
+    private final long retryInterval;
+    private final long retryMaxDelay;
 
     public CassandraSessionPool(HugeConfig config,
                                 String keyspace, String store) {
         super(config, keyspace + "/" + store);
         this.cluster = null;
         this.keyspace = keyspace;
-        this.maxRetries = 0;
-        this.retryInterval = 0L;
-        this.retryMaxDelay = 0L;
+        this.maxRetries = config.get(
+                CassandraOptions.CASSANDRA_RECONNECT_MAX_RETRIES);
+        this.retryInterval = config.get(
+                CassandraOptions.CASSANDRA_RECONNECT_INTERVAL);
+        long reconnectBase = config.get(
+                CassandraOptions.CASSANDRA_RECONNECT_BASE_DELAY);
+        long reconnectMax = config.get(
+                CassandraOptions.CASSANDRA_RECONNECT_MAX_DELAY);
+        E.checkArgument(reconnectMax >= reconnectBase,
+                        "'%s' (%s) must be >= '%s' (%s)",
+                        CassandraOptions.CASSANDRA_RECONNECT_MAX_DELAY.name(),
+                        reconnectMax,
+                        CassandraOptions.CASSANDRA_RECONNECT_BASE_DELAY.name(),
+                        reconnectBase);
+        this.retryMaxDelay = reconnectMax;
     }
 
     @Override
@@ -107,21 +119,9 @@ public class CassandraSessionPool extends BackendSessionPool {
         // with exponential backoff after they go down (see issue #2740).
         long reconnectBase = config.get(
                 CassandraOptions.CASSANDRA_RECONNECT_BASE_DELAY);
-        long reconnectMax = config.get(
-                CassandraOptions.CASSANDRA_RECONNECT_MAX_DELAY);
-        E.checkArgument(reconnectMax >= reconnectBase,
-                        "'%s' (%s) must be >= '%s' (%s)",
-                        CassandraOptions.CASSANDRA_RECONNECT_MAX_DELAY.name(),
-                        reconnectMax,
-                        CassandraOptions.CASSANDRA_RECONNECT_BASE_DELAY.name(),
-                        reconnectBase);
         builder.withReconnectionPolicy(
-                new ExponentialReconnectionPolicy(reconnectBase, reconnectMax));
-        this.retryMaxDelay = reconnectMax;
-        this.maxRetries = config.get(
-                CassandraOptions.CASSANDRA_RECONNECT_MAX_RETRIES);
-        this.retryInterval = config.get(
-                CassandraOptions.CASSANDRA_RECONNECT_INTERVAL);
+                new ExponentialReconnectionPolicy(reconnectBase,
+                                                  this.retryMaxDelay));
 
         // Credential options
         String username = config.get(CassandraOptions.CASSANDRA_USERNAME);
@@ -211,6 +211,7 @@ public class CassandraSessionPool extends BackendSessionPool {
             int processors = Math.min(statements.size(), 1023);
             List<ResultSetFuture> results = new ArrayList<>(processors + 1);
             for (Statement s : statements) {
+                // TODO: commitAsync is not retried (async retry semantics are complex)
                 ResultSetFuture future = this.session.executeAsync(s);
                 results.add(future);
 
@@ -251,7 +252,15 @@ public class CassandraSessionPool extends BackendSessionPool {
          * itself keeps retrying connections in the background via the
          * reconnection policy, so once Cassandra comes back online, a
          * subsequent attempt here will succeed without restarting the server.
-         * See issue #2740.
+         *
+         * <p><b>Blocking note:</b> retries block the calling thread via
+         * {@link Thread#sleep(long)}. Worst-case a single call blocks for
+         * {@code maxRetries * retryMaxDelay} ms. Under high-throughput
+         * workloads concurrent threads may pile up in {@code sleep()} during
+         * a Cassandra outage. For such deployments lower
+         * {@code cassandra.reconnect_max_retries} (default 10) and
+         * {@code cassandra.reconnect_max_delay} (default 60000ms) so the
+         * request fails fast and pressure is released back to the caller.
          */
         private ResultSet executeWithRetry(Statement statement) {
             int retries = CassandraSessionPool.this.maxRetries;
@@ -266,8 +275,15 @@ public class CassandraSessionPool extends BackendSessionPool {
                     if (attempt >= retries) {
                         break;
                     }
-                    long delay = Math.min(interval * (1L << Math.min(attempt, 20)),
-                                          maxDelay > 0 ? maxDelay : interval);
+                    long cap = maxDelay > 0 ? maxDelay : interval;
+                    long shift = 1L << Math.min(attempt, 20);
+                    long delay;
+                    try {
+                        // Guard against Long overflow when retryInterval is huge.
+                        delay = Math.min(Math.multiplyExact(interval, shift), cap);
+                    } catch (ArithmeticException overflow) {
+                        delay = cap;
+                    }
                     LOG.warn("Cassandra temporarily unavailable ({}), " +
                              "retry {}/{} in {} ms",
                              e.getClass().getSimpleName(), attempt + 1,
@@ -282,11 +298,14 @@ public class CassandraSessionPool extends BackendSessionPool {
                     }
                 }
             }
-            throw new BackendException("Failed to execute Cassandra query " +
-                                       "after %s retries: %s",
-                                       lastError, retries,
-                                       lastError == null ? "<null>" :
-                                               lastError.getMessage());
+            // Preserve original exception as cause (stack trace + type) by
+            // pre-formatting the message and using the (String, Throwable)
+            // constructor explicitly — avoids ambiguity with varargs overloads.
+            String msg = String.format(
+                    "Failed to execute Cassandra query after %s retries: %s",
+                    retries,
+                    lastError == null ? "<null>" : lastError.getMessage());
+            throw new BackendException(msg, lastError);
         }
 
         private void tryOpen() {
@@ -353,14 +372,20 @@ public class CassandraSessionPool extends BackendSessionPool {
                 if (this.session == null || this.session.isClosed()) {
                     this.session = null;
                     this.tryOpen();
-                    if (this.session == null) {
-                        return;
-                    }
                 }
-                this.session.execute(new SimpleStatement(HEALTH_CHECK_CQL));
+                if (this.session != null) {
+                    this.session.execute(new SimpleStatement(HEALTH_CHECK_CQL));
+                }
             } catch (DriverException e) {
                 LOG.debug("Cassandra health-check failed, " +
                           "will retry on next query: {}", e.getMessage());
+            } finally {
+                // Keep opened flag consistent with session: if tryOpen()
+                // failed to reopen, clear opened so the next execute() does
+                // not NPE before executeWithRetry() can intercept.
+                if (this.session == null) {
+                    this.opened = false;
+                }
             }
         }
 
@@ -376,7 +401,9 @@ public class CassandraSessionPool extends BackendSessionPool {
             }
             try {
                 this.session.close();
-            } catch (Throwable e) {
+            } catch (Exception e) {
+                // Do not swallow Error (OOM / StackOverflow); only log
+                // ordinary exceptions raised by the driver on close.
                 LOG.warn("Failed to reset Cassandra session", e);
             } finally {
                 this.session = null;

--- a/hugegraph-server/hugegraph-cassandra/src/main/java/org/apache/hugegraph/backend/store/cassandra/CassandraSessionPool.java
+++ b/hugegraph-server/hugegraph-cassandra/src/main/java/org/apache/hugegraph/backend/store/cassandra/CassandraSessionPool.java
@@ -20,6 +20,7 @@ package org.apache.hugegraph.backend.store.cassandra;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.apache.hugegraph.backend.BackendException;
 import org.apache.hugegraph.backend.store.BackendSession.AbstractBackendSession;
@@ -53,10 +54,21 @@ public class CassandraSessionPool extends BackendSessionPool {
     private static final String HEALTH_CHECK_CQL =
             "SELECT now() FROM system.local";
 
+    /**
+     * Guards the one-time JVM-wide warning about {@code commitAsync()} not
+     * being covered by query-time retries. {@link CassandraSessionPool} is
+     * instantiated once per backend store per graph, so without this guard
+     * the warning would fire many times on startup for a structural
+     * limitation that does not change between instances.
+     */
+    private static final AtomicBoolean ASYNC_RETRY_WARNING_LOGGED =
+            new AtomicBoolean(false);
+
     private Cluster cluster;
     private final String keyspace;
     private final int maxRetries;
     private final long retryInterval;
+    private final long retryBaseDelay;
     private final long retryMaxDelay;
 
     public CassandraSessionPool(HugeConfig config,
@@ -78,7 +90,14 @@ public class CassandraSessionPool extends BackendSessionPool {
                         reconnectMax,
                         CassandraOptions.CASSANDRA_RECONNECT_BASE_DELAY.name(),
                         reconnectBase);
+        this.retryBaseDelay = reconnectBase;
         this.retryMaxDelay = reconnectMax;
+
+        if (this.maxRetries > 0 &&
+            ASYNC_RETRY_WARNING_LOGGED.compareAndSet(false, true)) {
+            LOG.warn("cassandra.reconnect_max_retries={} applies to sync commit()" +
+                     " only. commitAsync() has no retry protection.", this.maxRetries);
+        }
     }
 
     @Override
@@ -117,10 +136,8 @@ public class CassandraSessionPool extends BackendSessionPool {
 
         // Reconnection policy: let driver keep retrying nodes in background
         // with exponential backoff after they go down (see issue #2740).
-        long reconnectBase = config.get(
-                CassandraOptions.CASSANDRA_RECONNECT_BASE_DELAY);
         builder.withReconnectionPolicy(
-                new ExponentialReconnectionPolicy(reconnectBase,
+                new ExponentialReconnectionPolicy(this.retryBaseDelay,
                                                   this.retryMaxDelay));
 
         // Credential options
@@ -211,7 +228,11 @@ public class CassandraSessionPool extends BackendSessionPool {
             int processors = Math.min(statements.size(), 1023);
             List<ResultSetFuture> results = new ArrayList<>(processors + 1);
             for (Statement s : statements) {
-                // TODO: commitAsync is not retried (async retry semantics are complex)
+                // TODO(issue #2740): commitAsync() bypasses executeWithRetry().
+                // During a Cassandra restart, async writes may fail with
+                // NoHostAvailableException even when maxRetries > 0. Callers
+                // must handle CompletableFuture failures. A follow-up will
+                // wrap each future with retry semantics.
                 ResultSetFuture future = this.session.executeAsync(s);
                 results.add(future);
 
@@ -253,13 +274,19 @@ public class CassandraSessionPool extends BackendSessionPool {
          * reconnection policy, so once Cassandra comes back online, a
          * subsequent attempt here will succeed without restarting the server.
          *
+         * <p>If the driver session has been discarded (e.g. by
+         * {@link #reconnectIfNeeded()} after a failed health-check) it is
+         * lazily reopened at the start of each attempt. After a transient
+         * failure the session is {@linkplain #reset() reset} so the next
+         * iteration gets a fresh driver session.
+         *
          * <p><b>Blocking note:</b> retries block the calling thread via
          * {@link Thread#sleep(long)}. Worst-case a single call blocks for
          * {@code maxRetries * retryMaxDelay} ms. Under high-throughput
          * workloads concurrent threads may pile up in {@code sleep()} during
          * a Cassandra outage. For such deployments lower
-         * {@code cassandra.reconnect_max_retries} (default 10) and
-         * {@code cassandra.reconnect_max_delay} (default 60000ms) so the
+         * {@code cassandra.reconnect_max_retries} (default 3) and
+         * {@code cassandra.reconnect_max_delay} (default 10000ms) so the
          * request fails fast and pressure is released back to the caller.
          */
         private ResultSet executeWithRetry(Statement statement) {
@@ -269,9 +296,18 @@ public class CassandraSessionPool extends BackendSessionPool {
             DriverException lastError = null;
             for (int attempt = 0; attempt <= retries; attempt++) {
                 try {
+                    if (this.session == null) {
+                        // Lazy reopen: may itself throw NHAE while
+                        // Cassandra is still unreachable; the catch below
+                        // treats that as a transient failure.
+                        this.open();
+                    }
                     return this.session.execute(statement);
                 } catch (NoHostAvailableException | OperationTimedOutException e) {
                     lastError = e;
+                    // Discard the (possibly broken) driver session so the
+                    // next iteration reopens cleanly.
+                    this.reset();
                     if (attempt >= retries) {
                         break;
                     }
@@ -359,9 +395,10 @@ public class CassandraSessionPool extends BackendSessionPool {
          * Periodic liveness probe invoked by {@link BackendSessionPool} to
          * recover thread-local sessions after Cassandra has been restarted.
          * Reopens the driver session if it was closed and pings the cluster
-         * with a lightweight query. Any failure here is swallowed so the
-         * caller can still issue the real query, which will drive retries via
-         * {@link #executeWithRetry(Statement)}.
+         * with a lightweight query. On failure the session is discarded via
+         * {@link #reset()} so the next call to
+         * {@link #executeWithRetry(Statement)} reopens it; any exception
+         * here is swallowed so the caller can still issue the real query.
          */
         @Override
         public void reconnectIfNeeded() {
@@ -377,15 +414,9 @@ public class CassandraSessionPool extends BackendSessionPool {
                     this.session.execute(new SimpleStatement(HEALTH_CHECK_CQL));
                 }
             } catch (DriverException e) {
-                LOG.debug("Cassandra health-check failed, " +
-                          "will retry on next query: {}", e.getMessage());
-            } finally {
-                // Keep opened flag consistent with session: if tryOpen()
-                // failed to reopen, clear opened so the next execute() does
-                // not NPE before executeWithRetry() can intercept.
-                if (this.session == null) {
-                    this.opened = false;
-                }
+                LOG.debug("Cassandra health-check failed, resetting session: {}",
+                          e.getMessage());
+                this.session = null;
             }
         }
 

--- a/hugegraph-server/hugegraph-cassandra/src/main/java/org/apache/hugegraph/backend/store/cassandra/CassandraSessionPool.java
+++ b/hugegraph-server/hugegraph-cassandra/src/main/java/org/apache/hugegraph/backend/store/cassandra/CassandraSessionPool.java
@@ -26,6 +26,8 @@ import org.apache.hugegraph.backend.store.BackendSession.AbstractBackendSession;
 import org.apache.hugegraph.backend.store.BackendSessionPool;
 import org.apache.hugegraph.config.HugeConfig;
 import org.apache.hugegraph.util.E;
+import org.apache.hugegraph.util.Log;
+import org.slf4j.Logger;
 
 import com.datastax.driver.core.BatchStatement;
 import com.datastax.driver.core.Cluster;
@@ -34,22 +36,37 @@ import com.datastax.driver.core.Metadata;
 import com.datastax.driver.core.ProtocolOptions.Compression;
 import com.datastax.driver.core.ResultSet;
 import com.datastax.driver.core.ResultSetFuture;
+import com.datastax.driver.core.SimpleStatement;
 import com.datastax.driver.core.SocketOptions;
 import com.datastax.driver.core.Statement;
+import com.datastax.driver.core.exceptions.DriverException;
 import com.datastax.driver.core.exceptions.InvalidQueryException;
+import com.datastax.driver.core.exceptions.NoHostAvailableException;
+import com.datastax.driver.core.exceptions.OperationTimedOutException;
+import com.datastax.driver.core.policies.ExponentialReconnectionPolicy;
 
 public class CassandraSessionPool extends BackendSessionPool {
 
+    private static final Logger LOG = Log.logger(CassandraSessionPool.class);
+
     private static final int SECOND = 1000;
+    private static final String HEALTH_CHECK_CQL =
+            "SELECT now() FROM system.local";
 
     private Cluster cluster;
     private final String keyspace;
+    private int maxRetries;
+    private long retryInterval;
+    private long retryMaxDelay;
 
     public CassandraSessionPool(HugeConfig config,
                                 String keyspace, String store) {
         super(config, keyspace + "/" + store);
         this.cluster = null;
         this.keyspace = keyspace;
+        this.maxRetries = 0;
+        this.retryInterval = 0L;
+        this.retryMaxDelay = 0L;
     }
 
     @Override
@@ -85,6 +102,26 @@ public class CassandraSessionPool extends BackendSessionPool {
         socketOptions.setReadTimeoutMillis(readTimeout * SECOND);
 
         builder.withSocketOptions(socketOptions);
+
+        // Reconnection policy: let driver keep retrying nodes in background
+        // with exponential backoff after they go down (see issue #2740).
+        long reconnectBase = config.get(
+                CassandraOptions.CASSANDRA_RECONNECT_BASE_DELAY);
+        long reconnectMax = config.get(
+                CassandraOptions.CASSANDRA_RECONNECT_MAX_DELAY);
+        E.checkArgument(reconnectMax >= reconnectBase,
+                        "'%s' (%s) must be >= '%s' (%s)",
+                        CassandraOptions.CASSANDRA_RECONNECT_MAX_DELAY.name(),
+                        reconnectMax,
+                        CassandraOptions.CASSANDRA_RECONNECT_BASE_DELAY.name(),
+                        reconnectBase);
+        builder.withReconnectionPolicy(
+                new ExponentialReconnectionPolicy(reconnectBase, reconnectMax));
+        this.retryMaxDelay = reconnectMax;
+        this.maxRetries = config.get(
+                CassandraOptions.CASSANDRA_RECONNECT_MAX_RETRIES);
+        this.retryInterval = config.get(
+                CassandraOptions.CASSANDRA_RECONNECT_INTERVAL);
 
         // Credential options
         String username = config.get(CassandraOptions.CASSANDRA_USERNAME);
@@ -161,7 +198,7 @@ public class CassandraSessionPool extends BackendSessionPool {
 
         @Override
         public ResultSet commit() {
-            ResultSet rs = this.session.execute(this.batch);
+            ResultSet rs = this.executeWithRetry(this.batch);
             // Clear batch if execute() successfully (retained if failed)
             this.batch.clear();
             return rs;
@@ -197,15 +234,59 @@ public class CassandraSessionPool extends BackendSessionPool {
         }
 
         public ResultSet execute(Statement statement) {
-            return this.session.execute(statement);
+            return this.executeWithRetry(statement);
         }
 
         public ResultSet execute(String statement) {
-            return this.session.execute(statement);
+            return this.executeWithRetry(new SimpleStatement(statement));
         }
 
         public ResultSet execute(String statement, Object... args) {
-            return this.session.execute(statement, args);
+            return this.executeWithRetry(new SimpleStatement(statement, args));
+        }
+
+        /**
+         * Execute a statement, retrying on transient connectivity failures
+         * (NoHostAvailableException / OperationTimedOutException). The driver
+         * itself keeps retrying connections in the background via the
+         * reconnection policy, so once Cassandra comes back online, a
+         * subsequent attempt here will succeed without restarting the server.
+         * See issue #2740.
+         */
+        private ResultSet executeWithRetry(Statement statement) {
+            int retries = CassandraSessionPool.this.maxRetries;
+            long interval = CassandraSessionPool.this.retryInterval;
+            long maxDelay = CassandraSessionPool.this.retryMaxDelay;
+            DriverException lastError = null;
+            for (int attempt = 0; attempt <= retries; attempt++) {
+                try {
+                    return this.session.execute(statement);
+                } catch (NoHostAvailableException | OperationTimedOutException e) {
+                    lastError = e;
+                    if (attempt >= retries) {
+                        break;
+                    }
+                    long delay = Math.min(interval * (1L << Math.min(attempt, 20)),
+                                          maxDelay > 0 ? maxDelay : interval);
+                    LOG.warn("Cassandra temporarily unavailable ({}), " +
+                             "retry {}/{} in {} ms",
+                             e.getClass().getSimpleName(), attempt + 1,
+                             retries, delay);
+                    try {
+                        Thread.sleep(delay);
+                    } catch (InterruptedException ie) {
+                        Thread.currentThread().interrupt();
+                        throw new BackendException("Interrupted while " +
+                                                   "waiting to retry " +
+                                                   "Cassandra query", ie);
+                    }
+                }
+            }
+            throw new BackendException("Failed to execute Cassandra query " +
+                                       "after %s retries: %s",
+                                       lastError, retries,
+                                       lastError == null ? "<null>" :
+                                               lastError.getMessage());
         }
 
         private void tryOpen() {
@@ -253,6 +334,53 @@ public class CassandraSessionPool extends BackendSessionPool {
         @Override
         public boolean hasChanges() {
             return this.batch.size() > 0;
+        }
+
+        /**
+         * Periodic liveness probe invoked by {@link BackendSessionPool} to
+         * recover thread-local sessions after Cassandra has been restarted.
+         * Reopens the driver session if it was closed and pings the cluster
+         * with a lightweight query. Any failure here is swallowed so the
+         * caller can still issue the real query, which will drive retries via
+         * {@link #executeWithRetry(Statement)}.
+         */
+        @Override
+        public void reconnectIfNeeded() {
+            if (!this.opened) {
+                return;
+            }
+            try {
+                if (this.session == null || this.session.isClosed()) {
+                    this.session = null;
+                    this.tryOpen();
+                    if (this.session == null) {
+                        return;
+                    }
+                }
+                this.session.execute(new SimpleStatement(HEALTH_CHECK_CQL));
+            } catch (DriverException e) {
+                LOG.debug("Cassandra health-check failed, " +
+                          "will retry on next query: {}", e.getMessage());
+            }
+        }
+
+        /**
+         * Force-close the driver session so it is re-opened on the next
+         * {@link #opened()} call. Used when a failure is observed and we
+         * want to start fresh on the next attempt.
+         */
+        @Override
+        public void reset() {
+            if (this.session == null) {
+                return;
+            }
+            try {
+                this.session.close();
+            } catch (Throwable e) {
+                LOG.warn("Failed to reset Cassandra session", e);
+            } finally {
+                this.session = null;
+            }
         }
 
         public Collection<Statement> statements() {

--- a/hugegraph-server/hugegraph-cassandra/src/main/java/org/apache/hugegraph/backend/store/cassandra/CassandraSessionPool.java
+++ b/hugegraph-server/hugegraph-cassandra/src/main/java/org/apache/hugegraph/backend/store/cassandra/CassandraSessionPool.java
@@ -77,9 +77,9 @@ public class CassandraSessionPool extends BackendSessionPool {
         this.cluster = null;
         this.keyspace = keyspace;
         this.maxRetries = config.get(
-                CassandraOptions.CASSANDRA_RECONNECT_MAX_RETRIES);
+                CassandraOptions.CASSANDRA_QUERY_RETRY_MAX_ATTEMPTS);
         this.retryInterval = config.get(
-                CassandraOptions.CASSANDRA_RECONNECT_INTERVAL);
+                CassandraOptions.CASSANDRA_QUERY_RETRY_INTERVAL);
         long reconnectBase = config.get(
                 CassandraOptions.CASSANDRA_RECONNECT_BASE_DELAY);
         long reconnectMax = config.get(
@@ -95,7 +95,7 @@ public class CassandraSessionPool extends BackendSessionPool {
 
         if (this.maxRetries > 0 &&
             ASYNC_RETRY_WARNING_LOGGED.compareAndSet(false, true)) {
-            LOG.warn("cassandra.reconnect_max_retries={} applies to sync commit()" +
+            LOG.warn("cassandra.query_retry_max_attempts={} applies to sync commit()" +
                      " only. commitAsync() has no retry protection.", this.maxRetries);
         }
     }
@@ -223,17 +223,25 @@ public class CassandraSessionPool extends BackendSessionPool {
 
         public void commitAsync() {
             Collection<Statement> statements = this.batch.getStatements();
+            if (statements.isEmpty()) {
+                this.batch.clear();
+                return;
+            }
 
             int count = 0;
             int processors = Math.min(statements.size(), 1023);
             List<ResultSetFuture> results = new ArrayList<>(processors + 1);
+            com.datastax.driver.core.Session driverSession =
+                    this.sessionForAsyncCommit();
             for (Statement s : statements) {
-                // TODO(issue #2740): commitAsync() bypasses executeWithRetry().
+                // TODO: track async retry support in a follow-up issue.
+                // commitAsync() bypasses executeWithRetry().
                 // During a Cassandra restart, async writes may fail with
                 // NoHostAvailableException even when maxRetries > 0. Callers
-                // must handle CompletableFuture failures. A follow-up will
-                // wrap each future with retry semantics.
-                ResultSetFuture future = this.session.executeAsync(s);
+                // must handle ResultSetFuture failures surfaced by
+                // getUninterruptibly(). A follow-up issue should wrap each
+                // future with retry semantics.
+                ResultSetFuture future = driverSession.executeAsync(s);
                 results.add(future);
 
                 if (++count > processors) {
@@ -274,18 +282,20 @@ public class CassandraSessionPool extends BackendSessionPool {
          * reconnection policy, so once Cassandra comes back online, a
          * subsequent attempt here will succeed without restarting the server.
          *
+         * <p>OperationTimedOutException is only retried for statements marked
+         * idempotent; otherwise a timed-out mutation might be applied once by
+         * Cassandra and then duplicated by a client-side retry.
+         *
          * <p>If the driver session has been discarded (e.g. by
          * {@link #reconnectIfNeeded()} after a failed health-check) it is
-         * lazily reopened at the start of each attempt. After a transient
-         * failure the session is {@linkplain #reset() reset} so the next
-         * iteration gets a fresh driver session.
+         * lazily reopened at the start of each attempt.
          *
          * <p><b>Blocking note:</b> retries block the calling thread via
          * {@link Thread#sleep(long)}. Worst-case a single call blocks for
          * {@code maxRetries * retryMaxDelay} ms. Under high-throughput
          * workloads concurrent threads may pile up in {@code sleep()} during
          * a Cassandra outage. For such deployments lower
-         * {@code cassandra.reconnect_max_retries} (default 3) and
+         * {@code cassandra.query_retry_max_attempts} (default 3) and
          * {@code cassandra.reconnect_max_delay} (default 10000ms) so the
          * request fails fast and pressure is released back to the caller.
          */
@@ -296,18 +306,23 @@ public class CassandraSessionPool extends BackendSessionPool {
             DriverException lastError = null;
             for (int attempt = 0; attempt <= retries; attempt++) {
                 try {
-                    if (this.session == null) {
+                    if (this.session == null || this.session.isClosed()) {
                         // Lazy reopen: may itself throw NHAE while
                         // Cassandra is still unreachable; the catch below
                         // treats that as a transient failure.
+                        this.session = null;
                         this.open();
                     }
                     return this.session.execute(statement);
                 } catch (NoHostAvailableException | OperationTimedOutException e) {
                     lastError = e;
-                    // Discard the (possibly broken) driver session so the
-                    // next iteration reopens cleanly.
-                    this.reset();
+                    if (e instanceof OperationTimedOutException &&
+                        !Boolean.TRUE.equals(statement.isIdempotent())) {
+                        throw new BackendException(
+                                "Cassandra query timed out and won't be " +
+                                "retried because the statement is not " +
+                                "marked idempotent", e);
+                    }
                     if (attempt >= retries) {
                         break;
                     }
@@ -336,7 +351,7 @@ public class CassandraSessionPool extends BackendSessionPool {
             }
             // Preserve original exception as cause (stack trace + type) by
             // pre-formatting the message and using the (String, Throwable)
-            // constructor explicitly — avoids ambiguity with varargs overloads.
+            // constructor explicitly to avoid ambiguity with varargs overloads.
             String msg = String.format(
                     "Failed to execute Cassandra query after %s retries: %s",
                     retries,
@@ -351,6 +366,24 @@ public class CassandraSessionPool extends BackendSessionPool {
             } catch (InvalidQueryException ignored) {
                 // ignore
             }
+        }
+
+        private com.datastax.driver.core.Session sessionForAsyncCommit() {
+            if (this.session == null || this.session.isClosed()) {
+                this.session = null;
+                try {
+                    this.open();
+                } catch (DriverException e) {
+                    throw new BackendException(
+                            "Failed to open Cassandra session for async commit",
+                            e);
+                }
+            }
+            if (this.session == null) {
+                throw new BackendException(
+                        "Cassandra session is unavailable for async commit");
+            }
+            return this.session;
         }
 
         @Override
@@ -413,10 +446,10 @@ public class CassandraSessionPool extends BackendSessionPool {
                 if (this.session != null) {
                     this.session.execute(new SimpleStatement(HEALTH_CHECK_CQL));
                 }
-            } catch (DriverException e) {
+            } catch (NoHostAvailableException | OperationTimedOutException e) {
                 LOG.debug("Cassandra health-check failed, resetting session: {}",
                           e.getMessage());
-                this.session = null;
+                this.reset();
             }
         }
 

--- a/hugegraph-server/hugegraph-test/src/main/java/org/apache/hugegraph/unit/cassandra/CassandraTest.java
+++ b/hugegraph-server/hugegraph-test/src/main/java/org/apache/hugegraph/unit/cassandra/CassandraTest.java
@@ -205,11 +205,11 @@ public class CassandraTest {
         // HugeGraph keeps running when Cassandra restarts (issue #2740).
         Assert.assertEquals(1000L, (long) CassandraOptions
                 .CASSANDRA_RECONNECT_BASE_DELAY.defaultValue());
-        Assert.assertEquals(60_000L, (long) CassandraOptions
+        Assert.assertEquals(10_000L, (long) CassandraOptions
                 .CASSANDRA_RECONNECT_MAX_DELAY.defaultValue());
-        Assert.assertEquals(10, (int) CassandraOptions
+        Assert.assertEquals(3, (int) CassandraOptions
                 .CASSANDRA_RECONNECT_MAX_RETRIES.defaultValue());
-        Assert.assertEquals(5000L, (long) CassandraOptions
+        Assert.assertEquals(1000L, (long) CassandraOptions
                 .CASSANDRA_RECONNECT_INTERVAL.defaultValue());
     }
 
@@ -251,13 +251,22 @@ public class CassandraTest {
 
     @Test
     public void testExecuteWithRetrySucceedsAfterTransientFailures() {
+        // Configure retry knobs via config so the pool reads them through
+        // the normal path (no Whitebox overrides on retry fields). Keep the
+        // values within the validators' lower bounds (base >= 100, max >=
+        // base, interval >= 100).
         Configuration conf = new PropertiesConfiguration();
+        conf.setProperty(
+                CassandraOptions.CASSANDRA_RECONNECT_BASE_DELAY.name(), 100L);
+        conf.setProperty(
+                CassandraOptions.CASSANDRA_RECONNECT_MAX_DELAY.name(), 1000L);
+        conf.setProperty(
+                CassandraOptions.CASSANDRA_RECONNECT_MAX_RETRIES.name(), 3);
+        conf.setProperty(
+                CassandraOptions.CASSANDRA_RECONNECT_INTERVAL.name(), 100L);
         HugeConfig config = new HugeConfig(conf);
         CassandraSessionPool pool = new CassandraSessionPool(config,
                                                              "ks", "store");
-        Whitebox.setInternalState(pool, "maxRetries", 3);
-        Whitebox.setInternalState(pool, "retryInterval", 1L);
-        Whitebox.setInternalState(pool, "retryMaxDelay", 10L);
 
         com.datastax.driver.core.Session driverSession = Mockito.mock(
                 com.datastax.driver.core.Session.class);
@@ -269,6 +278,17 @@ public class CassandraTest {
                .thenThrow(transientFailure)
                .thenReturn(rs);
 
+        // executeWithRetry now resets the driver session on transient
+        // failures, so the next iteration calls cluster().connect(keyspace)
+        // to obtain a fresh one. Install a mocked Cluster that hands back
+        // the same driverSession for each reconnect.
+        com.datastax.driver.core.Cluster mockCluster = Mockito.mock(
+                com.datastax.driver.core.Cluster.class);
+        Mockito.when(mockCluster.isClosed()).thenReturn(false);
+        Mockito.when(mockCluster.connect(Mockito.anyString()))
+               .thenReturn(driverSession);
+        Whitebox.setInternalState(pool, "cluster", mockCluster);
+
         CassandraSessionPool.Session session = pool.new Session();
         Whitebox.setInternalState(session, "session", driverSession);
 
@@ -279,18 +299,38 @@ public class CassandraTest {
     }
 
     @Test
-    public void testReconnectOptionsExposeExpectedKeys() {
-        Assert.assertEquals("cassandra.reconnect_base_delay",
-                            CassandraOptions.CASSANDRA_RECONNECT_BASE_DELAY
-                                            .name());
-        Assert.assertEquals("cassandra.reconnect_max_delay",
-                            CassandraOptions.CASSANDRA_RECONNECT_MAX_DELAY
-                                            .name());
-        Assert.assertEquals("cassandra.reconnect_max_retries",
-                            CassandraOptions.CASSANDRA_RECONNECT_MAX_RETRIES
-                                            .name());
-        Assert.assertEquals("cassandra.reconnect_interval",
-                            CassandraOptions.CASSANDRA_RECONNECT_INTERVAL
-                                            .name());
+    public void testReconnectBaseDelayBelowMinimumRejected() {
+        // The validator on CASSANDRA_RECONNECT_BASE_DELAY is
+        // rangeInt(100L, Long.MAX_VALUE); values below 100 must be rejected
+        // at parse time. Setting the property as a String forces HugeConfig
+        // to run parseConvert() which invokes the range check.
+        Configuration conf = new PropertiesConfiguration();
+        Assert.assertThrows(Exception.class, () -> {
+            conf.setProperty(
+                    CassandraOptions.CASSANDRA_RECONNECT_BASE_DELAY.name(),
+                    "50");
+            new HugeConfig(conf);
+        });
+    }
+
+    @Test
+    public void testReconnectMaxDelayLessThanBaseRejected() {
+        // Both values must pass their individual range validators with margin
+        // (base >= 100, max >= 1000), so the only thing that can throw is the
+        // E.checkArgument(max >= base) cross-check inside the pool ctor. Set
+        // all four reconnect properties explicitly so the test does not depend
+        // on default values changing in CassandraOptions.
+        Configuration conf = new PropertiesConfiguration();
+        conf.setProperty(
+                CassandraOptions.CASSANDRA_RECONNECT_BASE_DELAY.name(), 10_000L);
+        conf.setProperty(
+                CassandraOptions.CASSANDRA_RECONNECT_MAX_DELAY.name(), 2_000L);
+        conf.setProperty(
+                CassandraOptions.CASSANDRA_RECONNECT_MAX_RETRIES.name(), 3);
+        conf.setProperty(
+                CassandraOptions.CASSANDRA_RECONNECT_INTERVAL.name(), 1_000L);
+        HugeConfig config = new HugeConfig(conf);
+        Assert.assertThrows(IllegalArgumentException.class, () ->
+                new CassandraSessionPool(config, "ks", "store"));
     }
 }

--- a/hugegraph-server/hugegraph-test/src/main/java/org/apache/hugegraph/unit/cassandra/CassandraTest.java
+++ b/hugegraph-server/hugegraph-test/src/main/java/org/apache/hugegraph/unit/cassandra/CassandraTest.java
@@ -17,11 +17,13 @@
 
 package org.apache.hugegraph.unit.cassandra;
 
+import java.util.Collections;
 import java.util.Map;
 
 import org.apache.commons.configuration2.Configuration;
 import org.apache.commons.configuration2.PropertiesConfiguration;
 import org.apache.hugegraph.backend.store.cassandra.CassandraOptions;
+import org.apache.hugegraph.backend.store.cassandra.CassandraSessionPool;
 import org.apache.hugegraph.backend.store.cassandra.CassandraStore;
 import org.apache.hugegraph.config.HugeConfig;
 import org.apache.hugegraph.config.OptionSpace;
@@ -30,7 +32,11 @@ import org.apache.hugegraph.testutil.Whitebox;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+import org.mockito.Mockito;
 
+import com.datastax.driver.core.ResultSet;
+import com.datastax.driver.core.Statement;
+import com.datastax.driver.core.exceptions.NoHostAvailableException;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 
@@ -191,5 +197,100 @@ public class CassandraTest {
         Assert.assertThrows(RuntimeException.class, () -> {
             Whitebox.invokeStatic(CassandraStore.class, "parseReplica", config);
         });
+    }
+
+    @Test
+    public void testReconnectOptionsHaveSensibleDefaults() {
+        // Runtime-reconnection options must exist with non-zero defaults so
+        // HugeGraph keeps running when Cassandra restarts (issue #2740).
+        Assert.assertEquals(1000L, (long) CassandraOptions
+                .CASSANDRA_RECONNECT_BASE_DELAY.defaultValue());
+        Assert.assertEquals(60_000L, (long) CassandraOptions
+                .CASSANDRA_RECONNECT_MAX_DELAY.defaultValue());
+        Assert.assertEquals(10, (int) CassandraOptions
+                .CASSANDRA_RECONNECT_MAX_RETRIES.defaultValue());
+        Assert.assertEquals(5000L, (long) CassandraOptions
+                .CASSANDRA_RECONNECT_INTERVAL.defaultValue());
+    }
+
+    @Test
+    public void testReconnectOptionsAreOverridable() {
+        String base = CassandraOptions.CASSANDRA_RECONNECT_BASE_DELAY.name();
+        String max = CassandraOptions.CASSANDRA_RECONNECT_MAX_DELAY.name();
+        String retries = CassandraOptions.CASSANDRA_RECONNECT_MAX_RETRIES
+                                         .name();
+        String interval = CassandraOptions.CASSANDRA_RECONNECT_INTERVAL.name();
+
+        Configuration conf = new PropertiesConfiguration();
+        conf.setProperty(base, 500L);
+        conf.setProperty(max, 30_000L);
+        conf.setProperty(retries, 3);
+        conf.setProperty(interval, 1000L);
+        HugeConfig config = new HugeConfig(conf);
+
+        Assert.assertEquals(500L, (long) config.get(
+                CassandraOptions.CASSANDRA_RECONNECT_BASE_DELAY));
+        Assert.assertEquals(30_000L, (long) config.get(
+                CassandraOptions.CASSANDRA_RECONNECT_MAX_DELAY));
+        Assert.assertEquals(3, (int) config.get(
+                CassandraOptions.CASSANDRA_RECONNECT_MAX_RETRIES));
+        Assert.assertEquals(1000L, (long) config.get(
+                CassandraOptions.CASSANDRA_RECONNECT_INTERVAL));
+    }
+
+    @Test
+    public void testReconnectRetriesCanBeDisabled() {
+        String retries = CassandraOptions.CASSANDRA_RECONNECT_MAX_RETRIES
+                                         .name();
+        Configuration conf = new PropertiesConfiguration();
+        conf.setProperty(retries, 0);
+        HugeConfig config = new HugeConfig(conf);
+        Assert.assertEquals(0, (int) config.get(
+                CassandraOptions.CASSANDRA_RECONNECT_MAX_RETRIES));
+    }
+
+    @Test
+    public void testExecuteWithRetrySucceedsAfterTransientFailures() {
+        Configuration conf = new PropertiesConfiguration();
+        HugeConfig config = new HugeConfig(conf);
+        CassandraSessionPool pool = new CassandraSessionPool(config,
+                                                             "ks", "store");
+        Whitebox.setInternalState(pool, "maxRetries", 3);
+        Whitebox.setInternalState(pool, "retryInterval", 1L);
+        Whitebox.setInternalState(pool, "retryMaxDelay", 10L);
+
+        com.datastax.driver.core.Session driverSession = Mockito.mock(
+                com.datastax.driver.core.Session.class);
+        ResultSet rs = Mockito.mock(ResultSet.class);
+        NoHostAvailableException transientFailure =
+                new NoHostAvailableException(Collections.emptyMap());
+        Mockito.when(driverSession.execute(Mockito.any(Statement.class)))
+               .thenThrow(transientFailure)
+               .thenThrow(transientFailure)
+               .thenReturn(rs);
+
+        CassandraSessionPool.Session session = pool.new Session();
+        Whitebox.setInternalState(session, "session", driverSession);
+
+        ResultSet result = session.execute("SELECT now() FROM system.local");
+        Assert.assertSame(rs, result);
+        Mockito.verify(driverSession, Mockito.times(3))
+               .execute(Mockito.any(Statement.class));
+    }
+
+    @Test
+    public void testReconnectOptionsExposeExpectedKeys() {
+        Assert.assertEquals("cassandra.reconnect_base_delay",
+                            CassandraOptions.CASSANDRA_RECONNECT_BASE_DELAY
+                                            .name());
+        Assert.assertEquals("cassandra.reconnect_max_delay",
+                            CassandraOptions.CASSANDRA_RECONNECT_MAX_DELAY
+                                            .name());
+        Assert.assertEquals("cassandra.reconnect_max_retries",
+                            CassandraOptions.CASSANDRA_RECONNECT_MAX_RETRIES
+                                            .name());
+        Assert.assertEquals("cassandra.reconnect_interval",
+                            CassandraOptions.CASSANDRA_RECONNECT_INTERVAL
+                                            .name());
     }
 }

--- a/hugegraph-server/hugegraph-test/src/main/java/org/apache/hugegraph/unit/cassandra/CassandraTest.java
+++ b/hugegraph-server/hugegraph-test/src/main/java/org/apache/hugegraph/unit/cassandra/CassandraTest.java
@@ -17,11 +17,13 @@
 
 package org.apache.hugegraph.unit.cassandra;
 
+import java.net.InetSocketAddress;
 import java.util.Collections;
 import java.util.Map;
 
 import org.apache.commons.configuration2.Configuration;
 import org.apache.commons.configuration2.PropertiesConfiguration;
+import org.apache.hugegraph.backend.BackendException;
 import org.apache.hugegraph.backend.store.cassandra.CassandraOptions;
 import org.apache.hugegraph.backend.store.cassandra.CassandraSessionPool;
 import org.apache.hugegraph.backend.store.cassandra.CassandraStore;
@@ -35,8 +37,11 @@ import org.junit.Test;
 import org.mockito.Mockito;
 
 import com.datastax.driver.core.ResultSet;
+import com.datastax.driver.core.ResultSetFuture;
+import com.datastax.driver.core.SimpleStatement;
 import com.datastax.driver.core.Statement;
 import com.datastax.driver.core.exceptions.NoHostAvailableException;
+import com.datastax.driver.core.exceptions.OperationTimedOutException;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 
@@ -208,18 +213,18 @@ public class CassandraTest {
         Assert.assertEquals(10_000L, (long) CassandraOptions
                 .CASSANDRA_RECONNECT_MAX_DELAY.defaultValue());
         Assert.assertEquals(3, (int) CassandraOptions
-                .CASSANDRA_RECONNECT_MAX_RETRIES.defaultValue());
+                .CASSANDRA_QUERY_RETRY_MAX_ATTEMPTS.defaultValue());
         Assert.assertEquals(1000L, (long) CassandraOptions
-                .CASSANDRA_RECONNECT_INTERVAL.defaultValue());
+                .CASSANDRA_QUERY_RETRY_INTERVAL.defaultValue());
     }
 
     @Test
     public void testReconnectOptionsAreOverridable() {
         String base = CassandraOptions.CASSANDRA_RECONNECT_BASE_DELAY.name();
         String max = CassandraOptions.CASSANDRA_RECONNECT_MAX_DELAY.name();
-        String retries = CassandraOptions.CASSANDRA_RECONNECT_MAX_RETRIES
+        String retries = CassandraOptions.CASSANDRA_QUERY_RETRY_MAX_ATTEMPTS
                                          .name();
-        String interval = CassandraOptions.CASSANDRA_RECONNECT_INTERVAL.name();
+        String interval = CassandraOptions.CASSANDRA_QUERY_RETRY_INTERVAL.name();
 
         Configuration conf = new PropertiesConfiguration();
         conf.setProperty(base, 500L);
@@ -233,20 +238,20 @@ public class CassandraTest {
         Assert.assertEquals(30_000L, (long) config.get(
                 CassandraOptions.CASSANDRA_RECONNECT_MAX_DELAY));
         Assert.assertEquals(3, (int) config.get(
-                CassandraOptions.CASSANDRA_RECONNECT_MAX_RETRIES));
+                CassandraOptions.CASSANDRA_QUERY_RETRY_MAX_ATTEMPTS));
         Assert.assertEquals(1000L, (long) config.get(
-                CassandraOptions.CASSANDRA_RECONNECT_INTERVAL));
+                CassandraOptions.CASSANDRA_QUERY_RETRY_INTERVAL));
     }
 
     @Test
-    public void testReconnectRetriesCanBeDisabled() {
-        String retries = CassandraOptions.CASSANDRA_RECONNECT_MAX_RETRIES
+    public void testQueryRetryAttemptsCanBeDisabled() {
+        String retries = CassandraOptions.CASSANDRA_QUERY_RETRY_MAX_ATTEMPTS
                                          .name();
         Configuration conf = new PropertiesConfiguration();
         conf.setProperty(retries, 0);
         HugeConfig config = new HugeConfig(conf);
         Assert.assertEquals(0, (int) config.get(
-                CassandraOptions.CASSANDRA_RECONNECT_MAX_RETRIES));
+                CassandraOptions.CASSANDRA_QUERY_RETRY_MAX_ATTEMPTS));
     }
 
     @Test
@@ -261,9 +266,9 @@ public class CassandraTest {
         conf.setProperty(
                 CassandraOptions.CASSANDRA_RECONNECT_MAX_DELAY.name(), 1000L);
         conf.setProperty(
-                CassandraOptions.CASSANDRA_RECONNECT_MAX_RETRIES.name(), 3);
+                CassandraOptions.CASSANDRA_QUERY_RETRY_MAX_ATTEMPTS.name(), 3);
         conf.setProperty(
-                CassandraOptions.CASSANDRA_RECONNECT_INTERVAL.name(), 100L);
+                CassandraOptions.CASSANDRA_QUERY_RETRY_INTERVAL.name(), 100L);
         HugeConfig config = new HugeConfig(conf);
         CassandraSessionPool pool = new CassandraSessionPool(config,
                                                              "ks", "store");
@@ -278,17 +283,6 @@ public class CassandraTest {
                .thenThrow(transientFailure)
                .thenReturn(rs);
 
-        // executeWithRetry now resets the driver session on transient
-        // failures, so the next iteration calls cluster().connect(keyspace)
-        // to obtain a fresh one. Install a mocked Cluster that hands back
-        // the same driverSession for each reconnect.
-        com.datastax.driver.core.Cluster mockCluster = Mockito.mock(
-                com.datastax.driver.core.Cluster.class);
-        Mockito.when(mockCluster.isClosed()).thenReturn(false);
-        Mockito.when(mockCluster.connect(Mockito.anyString()))
-               .thenReturn(driverSession);
-        Whitebox.setInternalState(pool, "cluster", mockCluster);
-
         CassandraSessionPool.Session session = pool.new Session();
         Whitebox.setInternalState(session, "session", driverSession);
 
@@ -296,6 +290,113 @@ public class CassandraTest {
         Assert.assertSame(rs, result);
         Mockito.verify(driverSession, Mockito.times(3))
                .execute(Mockito.any(Statement.class));
+        Mockito.verify(driverSession, Mockito.never()).close();
+    }
+
+    @Test
+    public void testExecuteWithRetrySkipsNonIdempotentTimeoutRetry() {
+        Configuration conf = new PropertiesConfiguration();
+        conf.setProperty(
+                CassandraOptions.CASSANDRA_RECONNECT_BASE_DELAY.name(), 100L);
+        conf.setProperty(
+                CassandraOptions.CASSANDRA_RECONNECT_MAX_DELAY.name(), 1000L);
+        conf.setProperty(
+                CassandraOptions.CASSANDRA_QUERY_RETRY_MAX_ATTEMPTS.name(), 3);
+        conf.setProperty(
+                CassandraOptions.CASSANDRA_QUERY_RETRY_INTERVAL.name(), 100L);
+        HugeConfig config = new HugeConfig(conf);
+        CassandraSessionPool pool = new CassandraSessionPool(config,
+                                                             "ks", "store");
+
+        com.datastax.driver.core.Session driverSession = Mockito.mock(
+                com.datastax.driver.core.Session.class);
+        OperationTimedOutException timeout = new OperationTimedOutException(
+                new InetSocketAddress("127.0.0.1", 9042));
+        Mockito.when(driverSession.execute(Mockito.any(Statement.class)))
+               .thenThrow(timeout);
+
+        CassandraSessionPool.Session session = pool.new Session();
+        Whitebox.setInternalState(session, "session", driverSession);
+
+        Assert.assertThrows(BackendException.class, () ->
+                session.execute("UPDATE counter SET value = value + 1"));
+        Mockito.verify(driverSession, Mockito.times(1))
+               .execute(Mockito.any(Statement.class));
+    }
+
+    @Test
+    public void testExecuteWithRetryAllowsIdempotentTimeoutRetry() {
+        Configuration conf = new PropertiesConfiguration();
+        conf.setProperty(
+                CassandraOptions.CASSANDRA_RECONNECT_BASE_DELAY.name(), 100L);
+        conf.setProperty(
+                CassandraOptions.CASSANDRA_RECONNECT_MAX_DELAY.name(), 1000L);
+        conf.setProperty(
+                CassandraOptions.CASSANDRA_QUERY_RETRY_MAX_ATTEMPTS.name(), 3);
+        conf.setProperty(
+                CassandraOptions.CASSANDRA_QUERY_RETRY_INTERVAL.name(), 100L);
+        HugeConfig config = new HugeConfig(conf);
+        CassandraSessionPool pool = new CassandraSessionPool(config,
+                                                             "ks", "store");
+
+        com.datastax.driver.core.Session driverSession = Mockito.mock(
+                com.datastax.driver.core.Session.class);
+        ResultSet rs = Mockito.mock(ResultSet.class);
+        OperationTimedOutException timeout = new OperationTimedOutException(
+                new InetSocketAddress("127.0.0.1", 9042));
+        SimpleStatement statement = new SimpleStatement(
+                "SELECT now() FROM system.local");
+        statement.setIdempotent(true);
+        Mockito.when(driverSession.execute(statement))
+               .thenThrow(timeout)
+               .thenReturn(rs);
+
+        CassandraSessionPool.Session session = pool.new Session();
+        Whitebox.setInternalState(session, "session", driverSession);
+
+        ResultSet result = session.execute(statement);
+        Assert.assertSame(rs, result);
+        Mockito.verify(driverSession, Mockito.times(2)).execute(statement);
+    }
+
+    @Test
+    public void testCommitAsyncOpensSessionBeforeExecuteAsync() {
+        Configuration conf = new PropertiesConfiguration();
+        conf.setProperty(
+                CassandraOptions.CASSANDRA_RECONNECT_BASE_DELAY.name(), 100L);
+        conf.setProperty(
+                CassandraOptions.CASSANDRA_RECONNECT_MAX_DELAY.name(), 1000L);
+        conf.setProperty(
+                CassandraOptions.CASSANDRA_QUERY_RETRY_MAX_ATTEMPTS.name(), 3);
+        conf.setProperty(
+                CassandraOptions.CASSANDRA_QUERY_RETRY_INTERVAL.name(), 100L);
+        HugeConfig config = new HugeConfig(conf);
+        CassandraSessionPool pool = new CassandraSessionPool(config,
+                                                             "ks", "store");
+
+        com.datastax.driver.core.Cluster mockCluster = Mockito.mock(
+                com.datastax.driver.core.Cluster.class);
+        com.datastax.driver.core.Session driverSession = Mockito.mock(
+                com.datastax.driver.core.Session.class);
+        ResultSetFuture future = Mockito.mock(ResultSetFuture.class);
+        Mockito.when(mockCluster.isClosed()).thenReturn(false);
+        Mockito.when(mockCluster.connect(Mockito.anyString()))
+               .thenReturn(driverSession);
+        Mockito.when(driverSession.executeAsync(Mockito.any(Statement.class)))
+               .thenReturn(future);
+        Whitebox.setInternalState(pool, "cluster", mockCluster);
+
+        CassandraSessionPool.Session session = pool.new Session();
+        Statement statement = new SimpleStatement(
+                "INSERT INTO system.local(key) VALUES ('test')");
+        session.add(statement);
+
+        session.commitAsync();
+
+        Mockito.verify(mockCluster, Mockito.times(1)).connect("ks");
+        Mockito.verify(driverSession, Mockito.times(1)).executeAsync(statement);
+        Mockito.verify(future, Mockito.times(1)).getUninterruptibly();
+        Assert.assertFalse(session.hasChanges());
     }
 
     @Test
@@ -318,17 +419,17 @@ public class CassandraTest {
         // Both values must pass their individual range validators with margin
         // (base >= 100, max >= 1000), so the only thing that can throw is the
         // E.checkArgument(max >= base) cross-check inside the pool ctor. Set
-        // all four reconnect properties explicitly so the test does not depend
-        // on default values changing in CassandraOptions.
+        // all four retry/reconnect properties explicitly so the test does not
+        // depend on default values changing in CassandraOptions.
         Configuration conf = new PropertiesConfiguration();
         conf.setProperty(
                 CassandraOptions.CASSANDRA_RECONNECT_BASE_DELAY.name(), 10_000L);
         conf.setProperty(
                 CassandraOptions.CASSANDRA_RECONNECT_MAX_DELAY.name(), 2_000L);
         conf.setProperty(
-                CassandraOptions.CASSANDRA_RECONNECT_MAX_RETRIES.name(), 3);
+                CassandraOptions.CASSANDRA_QUERY_RETRY_MAX_ATTEMPTS.name(), 3);
         conf.setProperty(
-                CassandraOptions.CASSANDRA_RECONNECT_INTERVAL.name(), 1_000L);
+                CassandraOptions.CASSANDRA_QUERY_RETRY_INTERVAL.name(), 1_000L);
         HugeConfig config = new HugeConfig(conf);
         Assert.assertThrows(IllegalArgumentException.class, () ->
                 new CassandraSessionPool(config, "ks", "store"));


### PR DESCRIPTION
## Purpose of the PR

closes #2740

HugeGraphServer stops responding after Cassandra is restarted and never
recovers without a full server restart.

Root cause: `CassandraSessionPool` builds the Datastax `Cluster` without a
`ReconnectionPolicy`, `CassandraSession.execute(...)` calls the driver once
with no retry, and thread-local sessions are never probed for liveness.
Once Cassandra goes down, transient `NoHostAvailableException` /
`OperationTimedOutException` errors surface to the user and the pool stays
dead even after Cassandra comes back online.

## Main Changes

- Register `ExponentialReconnectionPolicy(baseDelay, maxDelay)` on the
  `Cluster` builder so the Datastax driver keeps retrying downed nodes in
  the background.
- Wrap every `Session.execute(...)` in `executeWithRetry(Statement)` with
  exponential backoff on transient connectivity failures.
- Implement `reconnectIfNeeded()` / `reset()` on `CassandraSession` so the
  pool reopens closed sessions and issues a lightweight health-check
  (`SELECT now() FROM system.local`) before subsequent queries.
- Add four tunables in `CassandraOptions` (defaults preserve previous
  behavior for healthy clusters):

  | Option | Default | Meaning |
  |--------|---------|---------|
  | `cassandra.reconnect_base_delay`  | `1000` ms  | Initial backoff for driver reconnection policy |
  | `cassandra.reconnect_max_delay`   | `10000` ms | Cap for reconnection backoff |
  | `cassandra.query_retry_max_attempts` | `3`       | Per-query retries on transient errors (`0` disables) |
  |  `cassandra.query_retry_interval`    | `1000` ms  | Base interval for per-query exponential backoff |

- Add unit tests covering defaults, overrides, disabling retries and option keys.

## Verifying these changes

- [x] Need tests and can be verified as follows:
  - `mvn -pl hugegraph-server/hugegraph-test -am test -Dtest=CassandraTest` — 13/13 pass

## Does this PR potentially affect the following parts?

- [x] Modify configurations

## Documentation Status

- [x] `Doc - TODO`