### PR TITLE
fix(docker): skip partition wait for standalone rocksdb mode

### DIFF
--- a/hugegraph-server/hugegraph-dist/docker/docker-entrypoint.sh
+++ b/hugegraph-server/hugegraph-dist/docker/docker-entrypoint.sh
@@ -84,7 +84,7 @@ fi
 ./bin/start-hugegraph.sh -j "${JAVA_OPTS:-}" -t 120
 
 # Post-startup cluster stabilization check (hstore only — rocksdb has no partitions)
-ACTUAL_BACKEND=$(grep -E '^\s*backend\s*=' "${GRAPH_CONF}" | sed 's/.*=\s*//' | tr -d ' ')
+ACTUAL_BACKEND=$(grep -E '^[[:space:]]*backend[[:space:]]*=' "${GRAPH_CONF}" | head -n 1 | sed 's/.*=//' | tr -d '[:space:]' || true)
 if [[ "${ACTUAL_BACKEND}" == "hstore" ]]; then
     STORE_REST="${STORE_REST:-store:8520}"
     export STORE_REST

--- a/hugegraph-server/hugegraph-dist/docker/docker-entrypoint.sh
+++ b/hugegraph-server/hugegraph-dist/docker/docker-entrypoint.sh
@@ -81,12 +81,14 @@ else
     log "HugeGraph initialization already done. Skipping re-init..."
 fi
 
-STORE_REST="${STORE_REST:-store:8520}"
-export STORE_REST
-
 ./bin/start-hugegraph.sh -j "${JAVA_OPTS:-}" -t 120
 
-# Post-startup cluster stabilization check
-./bin/wait-partition.sh || log "WARN: partitions not assigned yet"
+# Post-startup cluster stabilization check (hstore only — rocksdb has no partitions)
+ACTUAL_BACKEND=$(grep -E '^\s*backend\s*=' "${GRAPH_CONF}" | sed 's/.*=\s*//' | tr -d ' ')
+if [[ "${ACTUAL_BACKEND}" == "hstore" ]]; then
+    STORE_REST="${STORE_REST:-store:8520}"
+    export STORE_REST
+    ./bin/wait-partition.sh || log "WARN: partitions not assigned yet"
+fi
 
 tail -f /dev/null


### PR DESCRIPTION
## Summary

Fixes #2999

- Standalone Docker image (`hugegraph-server/Dockerfile`, default `rocksdb` backend) gets stuck printing `Waiting for partition assignment...` for 120s after startup
- Root cause: `wait-partition.sh` was called unconditionally in `docker-entrypoint.sh` — it polls `http://store:8520` which only exists in distributed `hstore` mode
- Fix: read the actual `backend` value from `hugegraph.properties` and only run `wait-partition.sh` when `backend=hstore`

## Test plan

- [x] Built patched image, ran standalone container — no more "Waiting for partition" messages
- [x] Verified API responds normally (`/versions`, `/graphs`)
- [ ] Verify distributed mode (docker-compose with hstore) still works correctly with the guard