### PR TITLE
fix(server): fix check_port port extraction for schemeless URLs

### DIFF
--- a/hugegraph-pd/hg-pd-dist/src/assembly/static/bin/util.sh
+++ b/hugegraph-pd/hg-pd-dist/src/assembly/static/bin/util.sh
@@ -83,7 +83,7 @@ function process_id() {
 
 # check the port of rest server is occupied
 function check_port() {
-    local port=`echo $1 | awk -F':' '{print $3}'`
+    local port=$(echo "$1" | sed 's|.*:||' | sed 's|/.*||')
     if ! command_available "lsof"; then
         echo "Required lsof but it is unavailable"
         exit 1

--- a/hugegraph-server/hugegraph-dist/src/assembly/static/bin/util.sh
+++ b/hugegraph-server/hugegraph-dist/src/assembly/static/bin/util.sh
@@ -81,7 +81,7 @@ function process_id() {
 
 # check the port of rest server is occupied
 function check_port() {
-    local port=$(echo "$1" | awk -F':' '{print $3}')
+    local port=$(echo "$1" | sed 's|.*:||' | sed 's|/.*||')
     if ! command_available "lsof"; then
         echo "Required lsof but it is unavailable"
         exit 1

--- a/hugegraph-store/hg-store-dist/src/assembly/static/bin/util.sh
+++ b/hugegraph-store/hg-store-dist/src/assembly/static/bin/util.sh
@@ -82,7 +82,7 @@ function process_id() {
 
 # check the port of rest server is occupied
 function check_port() {
-    local port=`echo $1 | awk -F':' '{print $3}'`
+    local port=$(echo "$1" | sed 's|.*:||' | sed 's|/.*||')
     if ! command_available "lsof"; then
         echo "Required lsof but it is unavailable"
         exit 1


### PR DESCRIPTION
## Purpose of the PR
- close #3004 

`check_port()` in `util.sh` uses `awk -F':' '{print $3}'` to extract the port, which assumes a 3-part URL like `http://host:port`. Since #2944 changed the default `restserver.url` to `host:port` format (no scheme), field `$3` is empty and `lsof -i :` fails with:

```
lsof: unacceptable port specification in: -i :
```

## Main Changes

Replace `awk` with `sed` in `check_port()` across all three `util.sh` files:

```bash
# before
local port=$(echo "$1" | awk -F':' '{print $3}')

# after  
local port=$(echo "$1" | sed 's|.*:||' | sed 's|/.*||')
```

This handles all URL formats correctly — `host:port`, `http://host:port`, `http://host:port/path`, and IPv6. Also modernizes backtick syntax to `$()` in pd and store.

## Verifying these changes
- [x] Trivial rework / code cleanup without any test coverage. (No Need)

## Does this PR potentially affect the following parts?
- [x] Nope

## Documentation Status
- [x] `Doc - No Need`