### PR TITLE
fix(server): align cache event actions in legacy EventHub path

### DIFF
--- a/hugegraph-commons/hugegraph-common/src/main/java/org/apache/hugegraph/event/EventHub.java
+++ b/hugegraph-commons/hugegraph-common/src/main/java/org/apache/hugegraph/event/EventHub.java
@@ -149,7 +149,27 @@ public class EventHub {
         return count;
     }
 
+    /**
+     * Notify all registered listeners for {@code event} EXCEPT
+     * {@code ignoredListener}. ANY_EVENT listeners are notified unless they
+     * are the ignored one.
+     *
+     * @return a Future<Integer> resolving to the count of listeners actually
+     *         invoked (the ignored listener is NOT counted)
+     */
+    public Future<Integer> notifyExcept(String event,
+                                        EventListener ignoredListener,
+                                        @Nullable Object... args) {
+        return this.notify(event, ignoredListener, args);
+    }
+
     public Future<Integer> notify(String event, @Nullable Object... args) {
+        return this.notify(event, null, args);
+    }
+
+    private Future<Integer> notify(String event,
+                                   EventListener ignoredListener,
+                                   @Nullable Object... args) {
         @SuppressWarnings("resource")
         ExtendableIterator<EventListener> all = new ExtendableIterator<>();
 
@@ -173,8 +193,12 @@ public class EventHub {
             int count = 0;
             // Notify all listeners, and ignore the results
             while (all.hasNext()) {
+                EventListener listener = all.next();
+                if (listener == ignoredListener) {
+                    continue;
+                }
                 try {
-                    all.next().event(ev);
+                    listener.event(ev);
                     count++;
                 } catch (Throwable e) {
                     LOG.warn("Failed to handle event: {}", ev, e);

--- a/hugegraph-commons/hugegraph-common/src/test/java/org/apache/hugegraph/unit/event/EventHubTest.java
+++ b/hugegraph-commons/hugegraph-common/src/test/java/org/apache/hugegraph/unit/event/EventHubTest.java
@@ -389,6 +389,43 @@ public class EventHubTest extends BaseUnitTest {
     }
 
     @Test
+    public void testNotifyExcept() throws Exception {
+        final String notify = "event-notify";
+        AtomicInteger listenerACount = new AtomicInteger();
+        AtomicInteger listenerBCount = new AtomicInteger();
+        AtomicInteger listenerCCount = new AtomicInteger();
+
+        EventListener listenerA = event -> {
+            event.checkArgs(String.class);
+            Assert.assertEquals("fake-arg", event.args()[0]);
+            listenerACount.incrementAndGet();
+            return true;
+        };
+        EventListener listenerB = event -> {
+            listenerBCount.incrementAndGet();
+            return true;
+        };
+        EventListener listenerC = event -> {
+            event.checkArgs(String.class);
+            Assert.assertEquals("fake-arg", event.args()[0]);
+            listenerCCount.incrementAndGet();
+            return true;
+        };
+
+        this.eventHub.listen(notify, listenerA);
+        this.eventHub.listen(notify, listenerB);
+        this.eventHub.listen(EventHub.ANY_EVENT, listenerC);
+
+        Assert.assertEquals(2, (int) this.eventHub
+                                          .notifyExcept(notify, listenerB,
+                                                        "fake-arg")
+                                          .get());
+        Assert.assertEquals(1, listenerACount.get());
+        Assert.assertEquals(0, listenerBCount.get());
+        Assert.assertEquals(1, listenerCCount.get());
+    }
+
+    @Test
     public void testEventNotifyWithMultiThreads() throws InterruptedException {
         final String notify = "event-notify";
 

--- a/hugegraph-server/hugegraph-core/src/main/java/org/apache/hugegraph/StandardHugeGraph.java
+++ b/hugegraph-server/hugegraph-core/src/main/java/org/apache/hugegraph/StandardHugeGraph.java
@@ -1394,7 +1394,7 @@ public class StandardHugeGraph implements HugeGraph {
                                     "Expect event action argument");
                     String action = (String) args[0];
                     LOG.debug("Event action: {}", action);
-                    if (Cache.ACTION_INVALIDED.equals(action)) {
+                    if (Cache.ACTION_INVALID.equals(action)) {
                         event.checkArgs(String.class, HugeType.class, Object.class);
                         HugeType type = (HugeType) args[1];
                         Object ids = args[2];
@@ -1410,7 +1410,7 @@ public class StandardHugeGraph implements HugeGraph {
                             E.checkArgument(false, "Unexpected argument: %s", ids);
                         }
                         return true;
-                    } else if (Cache.ACTION_CLEARED.equals(action)) {
+                    } else if (Cache.ACTION_CLEAR.equals(action)) {
                         event.checkArgs(String.class, HugeType.class);
                         HugeType type = (HugeType) args[1];
                         LOG.debug("Calling proxy.clear with type: {}", type);
@@ -1435,17 +1435,20 @@ public class StandardHugeGraph implements HugeGraph {
 
         @Override
         public void invalid(HugeType type, Id id) {
-            this.hub.notify(Events.CACHE, Cache.ACTION_INVALID, type, id);
+            this.hub.notifyExcept(Events.CACHE, this.cacheEventListener,
+                                  Cache.ACTION_INVALID, type, id);
         }
 
         @Override
         public void invalid2(HugeType type, Object[] ids) {
-            this.hub.notify(Events.CACHE, Cache.ACTION_INVALID, type, ids);
+            this.hub.notifyExcept(Events.CACHE, this.cacheEventListener,
+                                  Cache.ACTION_INVALID, type, ids);
         }
 
         @Override
         public void clear(HugeType type) {
-            this.hub.notify(Events.CACHE, Cache.ACTION_CLEAR, type);
+            this.hub.notifyExcept(Events.CACHE, this.cacheEventListener,
+                                  Cache.ACTION_CLEAR, type);
         }
 
         @Override

--- a/hugegraph-server/hugegraph-core/src/main/java/org/apache/hugegraph/backend/cache/Cache.java
+++ b/hugegraph-server/hugegraph-core/src/main/java/org/apache/hugegraph/backend/cache/Cache.java
@@ -24,8 +24,6 @@ public interface Cache<K, V> {
 
     String ACTION_INVALID = "invalid";
     String ACTION_CLEAR = "clear";
-    String ACTION_INVALIDED = "invalided";
-    String ACTION_CLEARED = "cleared";
 
     V get(K id);
 

--- a/hugegraph-server/hugegraph-core/src/main/java/org/apache/hugegraph/backend/cache/CacheListenerHolder.java
+++ b/hugegraph-server/hugegraph-core/src/main/java/org/apache/hugegraph/backend/cache/CacheListenerHolder.java
@@ -29,6 +29,8 @@ final class CacheListenerHolder {
 
     final EventListener listener;
     final EventHub hub;
+    // Must only be read or written inside ConcurrentMap.compute() for the
+    // enclosing registry; ConcurrentHashMap.compute() serialises per-key access.
     int refCount;
 
     CacheListenerHolder(EventListener listener, EventHub hub) {

--- a/hugegraph-server/hugegraph-core/src/main/java/org/apache/hugegraph/backend/cache/CacheListenerHolder.java
+++ b/hugegraph-server/hugegraph-core/src/main/java/org/apache/hugegraph/backend/cache/CacheListenerHolder.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hugegraph.backend.cache;
+
+import org.apache.hugegraph.event.EventHub;
+import org.apache.hugegraph.event.EventListener;
+
+/*
+ * Listener lifetime must cover all active transactions for the graph.
+ * The holder is removed from the registry and unregistered from EventHub
+ * only when the last transaction releases it.
+ */
+final class CacheListenerHolder {
+
+    final EventListener listener;
+    final EventHub hub;
+    int refCount;
+
+    CacheListenerHolder(EventListener listener, EventHub hub) {
+        this.listener = listener;
+        this.hub = hub;
+        this.refCount = 1;
+    }
+}

--- a/hugegraph-server/hugegraph-core/src/main/java/org/apache/hugegraph/backend/cache/CachedGraphTransaction.java
+++ b/hugegraph-server/hugegraph-core/src/main/java/org/apache/hugegraph/backend/cache/CachedGraphTransaction.java
@@ -68,7 +68,7 @@ public final class CachedGraphTransaction extends GraphTransaction {
      * only when the last transaction releases it.
      */
     private static final ConcurrentMap<String, CacheListenerHolder>
-            graphCacheEventListeners = new ConcurrentHashMap<>();
+            GRAPH_CACHE_EVENT_LISTENERS = new ConcurrentHashMap<>();
 
     private final Cache<Id, Object> verticesCache;
     private final Cache<Id, Object> edgesCache;
@@ -197,7 +197,7 @@ public final class CachedGraphTransaction extends GraphTransaction {
         };
         EventHub graphEventHub = this.params().graphEventHub();
         String graphName = this.params().spaceGraphName();
-        CacheListenerHolder acquired = graphCacheEventListeners.compute(
+        CacheListenerHolder acquired = GRAPH_CACHE_EVENT_LISTENERS.compute(
                 graphName, (key, existing) -> {
                     if (existing == null || existing.hub != graphEventHub) {
                         // Graph close/reopen creates a new EventHub for the
@@ -221,7 +221,7 @@ public final class CachedGraphTransaction extends GraphTransaction {
         String graphName = this.params().spaceGraphName();
         CacheListenerHolder ours = this.holder;
         if (ours != null) {
-            graphCacheEventListeners.compute(graphName, (key, existing) -> {
+            GRAPH_CACHE_EVENT_LISTENERS.compute(graphName, (key, existing) -> {
                 if (existing == null || existing != ours) {
                     return existing;
                 }
@@ -236,7 +236,7 @@ public final class CachedGraphTransaction extends GraphTransaction {
             this.cacheEventListener = null;
         }
         // TODO (follow-up): storeEventListenStatus has the same owner-first
-        // close bug this PR fixes for graphCacheEventListeners. A non-owner
+        // close bug this PR fixes for GRAPH_CACHE_EVENT_LISTENERS. A non-owner
         // transaction can remove the tracking entry, unlisten its own
         // never-registered storeEventListener as a no-op, and leave the
         // original store listener registered but untracked. Apply the same

--- a/hugegraph-server/hugegraph-core/src/main/java/org/apache/hugegraph/backend/cache/CachedGraphTransaction.java
+++ b/hugegraph-server/hugegraph-core/src/main/java/org/apache/hugegraph/backend/cache/CachedGraphTransaction.java
@@ -24,6 +24,8 @@ import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
 
 import org.apache.hugegraph.HugeGraphParams;
 import org.apache.hugegraph.backend.cache.CachedBackendStore.QueryId;
@@ -60,12 +62,20 @@ public final class CachedGraphTransaction extends GraphTransaction {
     private static final long AVG_VERTEX_ENTRY_SIZE = 40L;
     private static final long AVG_EDGE_ENTRY_SIZE = 100L;
 
+    /*
+     * Listener lifetime must cover all active transactions for the graph.
+     * The holder is removed from the registry and unregistered from EventHub
+     * only when the last transaction releases it.
+     */
+    private static final ConcurrentMap<String, CacheListenerHolder>
+            graphCacheEventListeners = new ConcurrentHashMap<>();
+
     private final Cache<Id, Object> verticesCache;
     private final Cache<Id, Object> edgesCache;
 
     private EventListener storeEventListener;
     private EventListener cacheEventListener;
-    private boolean registeredCacheEventListener;
+    private CacheListenerHolder holder;
 
     public CachedGraphTransaction(HugeGraphParams graph, BackendStore store) {
         super(graph, store);
@@ -186,29 +196,51 @@ public final class CachedGraphTransaction extends GraphTransaction {
             return false;
         };
         EventHub graphEventHub = this.params().graphEventHub();
-        EventListener previous =
-                graphCacheEventListeners.putIfAbsent(
-                        this.params().spaceGraphName(), listener);
-        if (previous == null) {
-            this.cacheEventListener = listener;
-            this.registeredCacheEventListener = true;
-            graphEventHub.listen(Events.CACHE, this.cacheEventListener);
-        } else {
-            this.cacheEventListener = previous;
-            this.registeredCacheEventListener = false;
-        }
+        String graphName = this.params().spaceGraphName();
+        CacheListenerHolder acquired = graphCacheEventListeners.compute(
+                graphName, (key, existing) -> {
+                    if (existing == null || existing.hub != graphEventHub) {
+                        // Graph close/reopen creates a new EventHub for the
+                        // same graph name; replace the stale holder. Old
+                        // transactions skip decrement via identity check.
+                        if (existing != null) {
+                            existing.hub.unlisten(Events.CACHE,
+                                                  existing.listener);
+                        }
+                        graphEventHub.listen(Events.CACHE, listener);
+                        return new CacheListenerHolder(listener, graphEventHub);
+                    }
+                    existing.refCount++;
+                    return existing;
+                });
+        this.holder = acquired;
+        this.cacheEventListener = acquired.listener;
     }
 
     private void unlistenChanges() {
         String graphName = this.params().spaceGraphName();
-        if (this.registeredCacheEventListener) {
-            EventHub graphEventHub = this.params().graphEventHub();
-            if (graphCacheEventListeners.remove(graphName,
-                                                this.cacheEventListener)) {
-                graphEventHub.unlisten(Events.CACHE, this.cacheEventListener);
-            }
-            this.registeredCacheEventListener = false;
+        CacheListenerHolder ours = this.holder;
+        if (ours != null) {
+            graphCacheEventListeners.compute(graphName, (key, existing) -> {
+                if (existing == null || existing != ours) {
+                    return existing;
+                }
+                existing.refCount--;
+                if (existing.refCount == 0) {
+                    existing.hub.unlisten(Events.CACHE, existing.listener);
+                    return null;
+                }
+                return existing;
+            });
+            this.holder = null;
+            this.cacheEventListener = null;
         }
+        // TODO (follow-up): storeEventListenStatus has the same owner-first
+        // close bug this PR fixes for graphCacheEventListeners. A non-owner
+        // transaction can remove the tracking entry, unlisten its own
+        // never-registered storeEventListener as a no-op, and leave the
+        // original store listener registered but untracked. Apply the same
+        // ref-counted holder pattern in a follow-up PR.
         if (storeEventListenStatus.remove(graphName) != null) {
             this.store().provider().unlisten(this.storeEventListener);
         }

--- a/hugegraph-server/hugegraph-core/src/main/java/org/apache/hugegraph/backend/cache/CachedGraphTransaction.java
+++ b/hugegraph-server/hugegraph-core/src/main/java/org/apache/hugegraph/backend/cache/CachedGraphTransaction.java
@@ -65,6 +65,7 @@ public final class CachedGraphTransaction extends GraphTransaction {
 
     private EventListener storeEventListener;
     private EventListener cacheEventListener;
+    private boolean registeredCacheEventListener;
 
     public CachedGraphTransaction(HugeGraphParams graph, BackendStore store) {
         super(graph, store);
@@ -138,7 +139,7 @@ public final class CachedGraphTransaction extends GraphTransaction {
         }
 
         // Listen cache event: "cache"(invalid cache item)
-        this.cacheEventListener = event -> {
+        EventListener listener = event -> {
             LOG.debug("Graph {} received graph cache event: {}",
                       this.graph(), event);
             Object[] args = event.args();
@@ -184,17 +185,29 @@ public final class CachedGraphTransaction extends GraphTransaction {
             }
             return false;
         };
-        if (graphCacheListenStatus.putIfAbsent(this.params().spaceGraphName(), true) == null) {
-            EventHub graphEventHub = this.params().graphEventHub();
+        EventHub graphEventHub = this.params().graphEventHub();
+        EventListener previous =
+                graphCacheEventListeners.putIfAbsent(
+                        this.params().spaceGraphName(), listener);
+        if (previous == null) {
+            this.cacheEventListener = listener;
+            this.registeredCacheEventListener = true;
             graphEventHub.listen(Events.CACHE, this.cacheEventListener);
+        } else {
+            this.cacheEventListener = previous;
+            this.registeredCacheEventListener = false;
         }
     }
 
     private void unlistenChanges() {
         String graphName = this.params().spaceGraphName();
-        if (graphCacheListenStatus.remove(graphName) != null) {
+        if (this.registeredCacheEventListener) {
             EventHub graphEventHub = this.params().graphEventHub();
-            graphEventHub.unlisten(Events.CACHE, this.cacheEventListener);
+            if (graphCacheEventListeners.remove(graphName,
+                                                this.cacheEventListener)) {
+                graphEventHub.unlisten(Events.CACHE, this.cacheEventListener);
+            }
+            this.registeredCacheEventListener = false;
         }
         if (storeEventListenStatus.remove(graphName) != null) {
             this.store().provider().unlisten(this.storeEventListener);
@@ -203,12 +216,14 @@ public final class CachedGraphTransaction extends GraphTransaction {
 
     private void notifyChanges(String action, HugeType type, Id[] ids) {
         EventHub graphEventHub = this.params().graphEventHub();
-        graphEventHub.notify(Events.CACHE, action, type, ids);
+        graphEventHub.notifyExcept(Events.CACHE, this.cacheEventListener,
+                                   action, type, ids);
     }
 
     private void notifyChanges(String action, HugeType type) {
         EventHub graphEventHub = this.params().graphEventHub();
-        graphEventHub.notify(Events.CACHE, action, type);
+        graphEventHub.notifyExcept(Events.CACHE, this.cacheEventListener,
+                                   action, type);
     }
 
     public void clearCache(HugeType type, boolean notify) {
@@ -220,7 +235,7 @@ public final class CachedGraphTransaction extends GraphTransaction {
         }
 
         if (notify) {
-            this.notifyChanges(Cache.ACTION_CLEARED, null);
+            this.notifyChanges(Cache.ACTION_CLEAR, null);
         }
     }
 
@@ -397,7 +412,7 @@ public final class CachedGraphTransaction extends GraphTransaction {
                     this.verticesCache.invalidate(vertex.id());
                 }
                 if (vertexOffset > 0) {
-                    this.notifyChanges(Cache.ACTION_INVALIDED,
+                    this.notifyChanges(Cache.ACTION_INVALID,
                                        HugeType.VERTEX, vertexIds);
                 }
             }
@@ -411,7 +426,7 @@ public final class CachedGraphTransaction extends GraphTransaction {
             if (invalidEdgesCache && this.enableCacheEdge()) {
                 // TODO: Use a more precise strategy to update the edge cache
                 this.edgesCache.clear();
-                this.notifyChanges(Cache.ACTION_CLEARED, HugeType.EDGE);
+                this.notifyChanges(Cache.ACTION_CLEAR, HugeType.EDGE);
             }
         }
     }
@@ -425,7 +440,7 @@ public final class CachedGraphTransaction extends GraphTransaction {
             if (indexLabel.baseType() == HugeType.EDGE_LABEL) {
                 // TODO: Use a more precise strategy to update the edge cache
                 this.edgesCache.clear();
-                this.notifyChanges(Cache.ACTION_CLEARED, HugeType.EDGE);
+                this.notifyChanges(Cache.ACTION_CLEAR, HugeType.EDGE);
             }
         }
     }

--- a/hugegraph-server/hugegraph-core/src/main/java/org/apache/hugegraph/backend/cache/CachedSchemaTransaction.java
+++ b/hugegraph-server/hugegraph-core/src/main/java/org/apache/hugegraph/backend/cache/CachedSchemaTransaction.java
@@ -21,6 +21,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
 import java.util.function.Consumer;
 
 import org.apache.hugegraph.HugeGraphParams;
@@ -42,6 +43,9 @@ import com.google.common.collect.ImmutableSet;
 
 public final class CachedSchemaTransaction extends SchemaTransaction {
 
+    private static final ConcurrentMap<String, EventListener>
+            SCHEMA_CACHE_EVENT_LISTENERS = new ConcurrentHashMap<>();
+
     private final Cache<Id, Object> idCache;
     private final Cache<Id, Object> nameCache;
 
@@ -49,6 +53,7 @@ public final class CachedSchemaTransaction extends SchemaTransaction {
 
     private EventListener storeEventListener;
     private EventListener cacheEventListener;
+    private boolean registeredCacheEventListener;
 
     public CachedSchemaTransaction(HugeGraphParams graph, BackendStore store) {
         super(graph, store);
@@ -111,7 +116,7 @@ public final class CachedSchemaTransaction extends SchemaTransaction {
         this.store().provider().listen(this.storeEventListener);
 
         // Listen cache event: "cache"(invalid cache item)
-        this.cacheEventListener = event -> {
+        EventListener listener = event -> {
             LOG.debug("Graph {} received schema cache event: {}",
                       this.graph(), event);
             Object[] args = event.args();
@@ -132,8 +137,16 @@ public final class CachedSchemaTransaction extends SchemaTransaction {
             return false;
         };
         EventHub schemaEventHub = this.params().schemaEventHub();
-        if (!schemaEventHub.containsListener(Events.CACHE)) {
+        String graph = this.params().spaceGraphName();
+        EventListener previous =
+                SCHEMA_CACHE_EVENT_LISTENERS.putIfAbsent(graph, listener);
+        if (previous == null) {
+            this.cacheEventListener = listener;
+            this.registeredCacheEventListener = true;
             schemaEventHub.listen(Events.CACHE, this.cacheEventListener);
+        } else {
+            this.cacheEventListener = previous;
+            this.registeredCacheEventListener = false;
         }
     }
 
@@ -143,17 +156,24 @@ public final class CachedSchemaTransaction extends SchemaTransaction {
 
         // Unlisten cache event
         EventHub schemaEventHub = this.params().schemaEventHub();
-        schemaEventHub.unlisten(Events.CACHE, this.cacheEventListener);
+        if (this.registeredCacheEventListener) {
+            schemaEventHub.unlisten(Events.CACHE, this.cacheEventListener);
+            SCHEMA_CACHE_EVENT_LISTENERS.remove(this.params().spaceGraphName(),
+                                               this.cacheEventListener);
+            this.registeredCacheEventListener = false;
+        }
     }
 
     private void notifyChanges(String action, HugeType type, Id id) {
         EventHub graphEventHub = this.params().schemaEventHub();
-        graphEventHub.notify(Events.CACHE, action, type, id);
+        graphEventHub.notifyExcept(Events.CACHE, this.cacheEventListener,
+                                   action, type, id);
     }
 
     private void notifyChanges(String action, HugeType type) {
         EventHub graphEventHub = this.params().schemaEventHub();
-        graphEventHub.notify(Events.CACHE, action, type);
+        graphEventHub.notifyExcept(Events.CACHE, this.cacheEventListener,
+                                   action, type);
     }
 
     private void resetCachedAll(HugeType type) {
@@ -179,7 +199,7 @@ public final class CachedSchemaTransaction extends SchemaTransaction {
         this.arrayCaches.clear();
 
         if (notify) {
-            this.notifyChanges(Cache.ACTION_CLEARED, null);
+            this.notifyChanges(Cache.ACTION_CLEAR, null);
         }
     }
 
@@ -221,7 +241,7 @@ public final class CachedSchemaTransaction extends SchemaTransaction {
 
         this.updateCache(schema);
 
-        this.notifyChanges(Cache.ACTION_INVALIDED, schema.type(), schema.id());
+        this.notifyChanges(Cache.ACTION_INVALID, schema.type(), schema.id());
     }
 
     @Override
@@ -230,7 +250,7 @@ public final class CachedSchemaTransaction extends SchemaTransaction {
 
         this.updateCache(schema);
 
-        this.notifyChanges(Cache.ACTION_INVALIDED, schema.type(), schema.id());
+        this.notifyChanges(Cache.ACTION_INVALID, schema.type(), schema.id());
     }
 
     @Override
@@ -283,7 +303,7 @@ public final class CachedSchemaTransaction extends SchemaTransaction {
 
         this.invalidateCache(schema.type(), schema.id());
 
-        this.notifyChanges(Cache.ACTION_INVALIDED, schema.type(), schema.id());
+        this.notifyChanges(Cache.ACTION_INVALID, schema.type(), schema.id());
     }
 
     @Override

--- a/hugegraph-server/hugegraph-core/src/main/java/org/apache/hugegraph/backend/cache/CachedSchemaTransaction.java
+++ b/hugegraph-server/hugegraph-core/src/main/java/org/apache/hugegraph/backend/cache/CachedSchemaTransaction.java
@@ -43,7 +43,12 @@ import com.google.common.collect.ImmutableSet;
 
 public final class CachedSchemaTransaction extends SchemaTransaction {
 
-    private static final ConcurrentMap<String, EventListener>
+    /*
+     * Listener lifetime must cover all active transactions for the graph.
+     * The holder is removed from the registry and unregistered from EventHub
+     * only when the last transaction releases it.
+     */
+    private static final ConcurrentMap<String, CacheListenerHolder>
             SCHEMA_CACHE_EVENT_LISTENERS = new ConcurrentHashMap<>();
 
     private final Cache<Id, Object> idCache;
@@ -53,7 +58,7 @@ public final class CachedSchemaTransaction extends SchemaTransaction {
 
     private EventListener storeEventListener;
     private EventListener cacheEventListener;
-    private boolean registeredCacheEventListener;
+    private CacheListenerHolder holder;
 
     public CachedSchemaTransaction(HugeGraphParams graph, BackendStore store) {
         super(graph, store);
@@ -138,16 +143,25 @@ public final class CachedSchemaTransaction extends SchemaTransaction {
         };
         EventHub schemaEventHub = this.params().schemaEventHub();
         String graph = this.params().spaceGraphName();
-        EventListener previous =
-                SCHEMA_CACHE_EVENT_LISTENERS.putIfAbsent(graph, listener);
-        if (previous == null) {
-            this.cacheEventListener = listener;
-            this.registeredCacheEventListener = true;
-            schemaEventHub.listen(Events.CACHE, this.cacheEventListener);
-        } else {
-            this.cacheEventListener = previous;
-            this.registeredCacheEventListener = false;
-        }
+        CacheListenerHolder acquired = SCHEMA_CACHE_EVENT_LISTENERS.compute(
+                graph, (key, existing) -> {
+                    if (existing == null || existing.hub != schemaEventHub) {
+                        // Graph close/reopen creates a new EventHub for the
+                        // same graph name; replace the stale holder. Old
+                        // transactions skip decrement via identity check.
+                        if (existing != null) {
+                            existing.hub.unlisten(Events.CACHE,
+                                                  existing.listener);
+                        }
+                        schemaEventHub.listen(Events.CACHE, listener);
+                        return new CacheListenerHolder(listener,
+                                                       schemaEventHub);
+                    }
+                    existing.refCount++;
+                    return existing;
+                });
+        this.holder = acquired;
+        this.cacheEventListener = acquired.listener;
     }
 
     private void unlistenChanges() {
@@ -155,12 +169,23 @@ public final class CachedSchemaTransaction extends SchemaTransaction {
         this.store().provider().unlisten(this.storeEventListener);
 
         // Unlisten cache event
-        EventHub schemaEventHub = this.params().schemaEventHub();
-        if (this.registeredCacheEventListener) {
-            schemaEventHub.unlisten(Events.CACHE, this.cacheEventListener);
-            SCHEMA_CACHE_EVENT_LISTENERS.remove(this.params().spaceGraphName(),
-                                               this.cacheEventListener);
-            this.registeredCacheEventListener = false;
+        CacheListenerHolder ours = this.holder;
+        if (ours != null) {
+            SCHEMA_CACHE_EVENT_LISTENERS.compute(
+                    this.params().spaceGraphName(), (key, existing) -> {
+                        if (existing == null || existing != ours) {
+                            return existing;
+                        }
+                        existing.refCount--;
+                        if (existing.refCount == 0) {
+                            existing.hub.unlisten(Events.CACHE,
+                                                  existing.listener);
+                            return null;
+                        }
+                        return existing;
+                    });
+            this.holder = null;
+            this.cacheEventListener = null;
         }
     }
 

--- a/hugegraph-server/hugegraph-core/src/main/java/org/apache/hugegraph/backend/tx/GraphTransaction.java
+++ b/hugegraph-server/hugegraph-core/src/main/java/org/apache/hugegraph/backend/tx/GraphTransaction.java
@@ -60,7 +60,6 @@ import org.apache.hugegraph.backend.store.BackendMutation;
 import org.apache.hugegraph.backend.store.BackendStore;
 import org.apache.hugegraph.config.CoreOptions;
 import org.apache.hugegraph.config.HugeConfig;
-import org.apache.hugegraph.event.EventListener;
 import org.apache.hugegraph.exception.LimitExceedException;
 import org.apache.hugegraph.exception.NotFoundException;
 import org.apache.hugegraph.iterator.BatchMapperIterator;
@@ -141,8 +140,6 @@ public class GraphTransaction extends IndexableTransaction {
 
     private final int verticesCapacity;
     private final int edgesCapacity;
-    protected static final ConcurrentHashMap<String, EventListener>
-            graphCacheEventListeners = new ConcurrentHashMap<>();
     protected static final ConcurrentHashMap<String, Boolean> storeEventListenStatus =
             new ConcurrentHashMap<>();
 

--- a/hugegraph-server/hugegraph-core/src/main/java/org/apache/hugegraph/backend/tx/GraphTransaction.java
+++ b/hugegraph-server/hugegraph-core/src/main/java/org/apache/hugegraph/backend/tx/GraphTransaction.java
@@ -60,6 +60,7 @@ import org.apache.hugegraph.backend.store.BackendMutation;
 import org.apache.hugegraph.backend.store.BackendStore;
 import org.apache.hugegraph.config.CoreOptions;
 import org.apache.hugegraph.config.HugeConfig;
+import org.apache.hugegraph.event.EventListener;
 import org.apache.hugegraph.exception.LimitExceedException;
 import org.apache.hugegraph.exception.NotFoundException;
 import org.apache.hugegraph.iterator.BatchMapperIterator;
@@ -140,8 +141,8 @@ public class GraphTransaction extends IndexableTransaction {
 
     private final int verticesCapacity;
     private final int edgesCapacity;
-    protected static final ConcurrentHashMap<String, Boolean> graphCacheListenStatus =
-            new ConcurrentHashMap<>();
+    protected static final ConcurrentHashMap<String, EventListener>
+            graphCacheEventListeners = new ConcurrentHashMap<>();
     protected static final ConcurrentHashMap<String, Boolean> storeEventListenStatus =
             new ConcurrentHashMap<>();
 

--- a/hugegraph-server/hugegraph-test/src/main/java/org/apache/hugegraph/unit/cache/CacheManagerTest.java
+++ b/hugegraph-server/hugegraph-test/src/main/java/org/apache/hugegraph/unit/cache/CacheManagerTest.java
@@ -19,6 +19,7 @@ package org.apache.hugegraph.unit.cache;
 
 import java.lang.reflect.Proxy;
 import java.util.Map;
+import java.util.TimerTask;
 import java.util.concurrent.ConcurrentHashMap;
 
 import org.apache.hugegraph.backend.cache.Cache;
@@ -271,6 +272,8 @@ public class CacheManagerTest extends BaseUnitTest {
 
     @Test
     public void testCacheExpire() {
+        CacheManager manager = CacheManager.instance();
+
         Cache<Id, Object> cache1 = new RamCache();
         cache1.expire(26 * 1000L);
 
@@ -285,17 +288,23 @@ public class CacheManagerTest extends BaseUnitTest {
                                                                 mockCache2);
         Mockito.when(this.mockCaches.entrySet()).thenReturn(caches.entrySet());
 
-        cache1.update(IdGenerator.of("fake-id"), "fake-value");
-        cache2.update(IdGenerator.of("fake-id"), "fake-value");
+        TimerTask task = Whitebox.invoke(CacheManager.class, "scheduleTimer",
+                                         manager, 0.1F);
+        try {
+            cache1.update(IdGenerator.of("fake-id"), "fake-value",
+                          -30 * 1000L);
+            cache2.update(IdGenerator.of("fake-id"), "fake-value");
 
-        waitTillNext(40);
+            waitTillNext(1);
 
-        // Would call tick() per 30s
-        Mockito.verify(mockCache1, Mockito.times(1)).tick();
-        Mockito.verify(mockCache2, Mockito.times(1)).tick();
+            Mockito.verify(mockCache1, Mockito.atLeastOnce()).tick();
+            Mockito.verify(mockCache2, Mockito.atLeastOnce()).tick();
 
-        Assert.assertEquals(0, cache1.size());
-        Assert.assertEquals(1, cache2.size());
+            Assert.assertEquals(0, cache1.size());
+            Assert.assertEquals(1, cache2.size());
+        } finally {
+            task.cancel();
+        }
     }
 
     @SuppressWarnings({"unused", "unchecked"})
@@ -308,4 +317,3 @@ public class CacheManagerTest extends BaseUnitTest {
         return (Cache<Id, Object>) p;
     }
 }
-

--- a/hugegraph-server/hugegraph-test/src/main/java/org/apache/hugegraph/unit/cache/CacheManagerTest.java
+++ b/hugegraph-server/hugegraph-test/src/main/java/org/apache/hugegraph/unit/cache/CacheManagerTest.java
@@ -295,7 +295,7 @@ public class CacheManagerTest extends BaseUnitTest {
                           -30 * 1000L);
             cache2.update(IdGenerator.of("fake-id"), "fake-value");
 
-            waitTillNext(1);
+            waitTillNext(3);
 
             Mockito.verify(mockCache1, Mockito.atLeastOnce()).tick();
             Mockito.verify(mockCache2, Mockito.atLeastOnce()).tick();

--- a/hugegraph-server/hugegraph-test/src/main/java/org/apache/hugegraph/unit/cache/CachedGraphTransactionTest.java
+++ b/hugegraph-server/hugegraph-test/src/main/java/org/apache/hugegraph/unit/cache/CachedGraphTransactionTest.java
@@ -51,24 +51,63 @@ public class CachedGraphTransactionTest extends BaseUnitTest {
 
     private CachedGraphTransaction cache;
     private HugeGraphParams params;
+    private HugeGraph graph;
 
     @Before
     public void setup() {
-        HugeGraph graph = HugeFactory.open(FakeObjects.newConfig());
-        this.params = Whitebox.getInternalState(graph, "params");
+        this.graph = HugeFactory.open(FakeObjects.newConfig());
+        this.params = Whitebox.getInternalState(this.graph, "params");
         this.cache = new CachedGraphTransaction(this.params,
                                                 this.params.loadGraphStore());
     }
 
     @After
     public void teardown() throws Exception {
-        this.cache().graph().clearBackend();
-        this.cache().graph().close();
+        try {
+            if (this.cache != null) {
+                this.cache.close();
+            }
+        } finally {
+            this.cache = null;
+            if (this.graph != null) {
+                this.graph.clearBackend();
+                this.graph.close();
+                this.graph = null;
+            }
+        }
     }
 
     private CachedGraphTransaction cache() {
         Assert.assertNotNull(this.cache);
         return this.cache;
+    }
+
+    @SuppressWarnings("unchecked")
+    private static ConcurrentMap<String, Object> graphCacheEventListeners()
+            throws Exception {
+        Field field = CachedGraphTransaction.class
+                                            .getDeclaredField(
+                                                    "graphCacheEventListeners");
+        field.setAccessible(true);
+        return (ConcurrentMap<String, Object>) field.get(null);
+    }
+
+    @SuppressWarnings("unchecked")
+    private static ConcurrentMap<String, Boolean> storeEventListenStatus()
+            throws Exception {
+        Field field = GraphTransaction.class
+                                      .getDeclaredField("storeEventListenStatus");
+        field.setAccessible(true);
+        return (ConcurrentMap<String, Boolean>) field.get(null);
+    }
+
+    private static EventListener holderListener(Object holder) {
+        return Whitebox.getInternalState(holder, "listener");
+    }
+
+    private static int holderRefCount(Object holder) {
+        Integer refCount = Whitebox.getInternalState(holder, "refCount");
+        return refCount;
     }
 
     private HugeVertex newVertex(Id id) {
@@ -200,32 +239,29 @@ public class CachedGraphTransactionTest extends BaseUnitTest {
     }
 
     @Test
-    @SuppressWarnings("unchecked")
     public void testClosingNonOwnerKeepsGraphCacheListenerRegistered()
             throws Exception {
-        Field cacheField = GraphTransaction.class
-                .getDeclaredField("graphCacheEventListeners");
-        cacheField.setAccessible(true);
-        ConcurrentMap<String, EventListener> cacheListeners =
-                (ConcurrentMap<String, EventListener>) cacheField.get(null);
-        Field storeField = GraphTransaction.class
-                .getDeclaredField("storeEventListenStatus");
-        storeField.setAccessible(true);
+        ConcurrentMap<String, Object> cacheListeners =
+                graphCacheEventListeners();
         ConcurrentMap<String, Boolean> storeListeners =
-                (ConcurrentMap<String, Boolean>) storeField.get(null);
+                storeEventListenStatus();
 
         String graphName = this.params.spaceGraphName();
-        EventListener registered = cacheListeners.get(graphName);
-        Assert.assertNotNull(registered);
+        Object holder = cacheListeners.get(graphName);
+        Assert.assertNotNull(holder);
+        EventListener registered = holderListener(holder);
+        int refCount = holderRefCount(holder);
 
         CachedGraphTransaction second = new CachedGraphTransaction(
                 this.params, this.params.loadGraphStore());
-        Assert.assertSame(registered, cacheListeners.get(graphName));
+        Assert.assertSame(holder, cacheListeners.get(graphName));
+        Assert.assertEquals(refCount + 1, holderRefCount(holder));
 
         try {
             second.close();
 
-            Assert.assertSame(registered, cacheListeners.get(graphName));
+            Assert.assertSame(holder, cacheListeners.get(graphName));
+            Assert.assertEquals(refCount, holderRefCount(holder));
             Assert.assertTrue(this.params.graphEventHub()
                                          .listeners(Events.CACHE)
                                          .contains(registered));
@@ -235,6 +271,89 @@ public class CachedGraphTransactionTest extends BaseUnitTest {
             // primary transaction's store listener.
             storeListeners.putIfAbsent(graphName, true);
         }
+    }
+
+    @Test
+    public void testCacheListenerSurvivesOwnerClose() throws Exception {
+        ConcurrentMap<String, Object> cacheListeners =
+                graphCacheEventListeners();
+        String graphName = this.params.spaceGraphName();
+        CachedGraphTransaction owner = this.cache();
+        CachedGraphTransaction second = new CachedGraphTransaction(
+                this.params, this.params.loadGraphStore());
+
+        Object holder = cacheListeners.get(graphName);
+        Assert.assertNotNull(holder);
+        EventListener registered = holderListener(holder);
+        int refCount = holderRefCount(holder);
+        Assert.assertTrue(refCount >= 2);
+
+        owner.close();
+        this.cache = second;
+
+        Assert.assertSame(holder, cacheListeners.get(graphName));
+        Assert.assertEquals(refCount - 1, holderRefCount(holder));
+        Assert.assertTrue(this.params.graphEventHub()
+                                     .listeners(Events.CACHE)
+                                     .contains(registered));
+
+        second.addVertex(this.newVertex(IdGenerator.of(1)));
+        second.addVertex(this.newVertex(IdGenerator.of(2)));
+        second.commit();
+        Assert.assertTrue(second.queryVertices(IdGenerator.of(1)).hasNext());
+        Assert.assertTrue(second.queryVertices(IdGenerator.of(2)).hasNext());
+        Assert.assertEquals(2L,
+                            Whitebox.invoke(second, "verticesCache", "size"));
+
+        this.params.graphEventHub().notify(Events.CACHE, Cache.ACTION_INVALID,
+                                           HugeType.VERTEX, IdGenerator.of(1))
+                   .get();
+
+        Assert.assertEquals(1L,
+                            Whitebox.invoke(second, "verticesCache", "size"));
+    }
+
+    @Test
+    public void testLastCloseRemovesGraphCacheListener() throws Exception {
+        ConcurrentMap<String, Object> cacheListeners =
+                graphCacheEventListeners();
+        String graphName = this.params.spaceGraphName();
+        CachedGraphTransaction owner = this.cache();
+        CachedGraphTransaction second = new CachedGraphTransaction(
+                this.params, this.params.loadGraphStore());
+
+        Object holder = cacheListeners.get(graphName);
+        Assert.assertNotNull(holder);
+        EventListener registered = holderListener(holder);
+        Assert.assertTrue(holderRefCount(holder) >= 2);
+
+        owner.close();
+        second.close();
+        this.cache = null;
+        this.params.graphTransaction().close();
+
+        Assert.assertFalse(cacheListeners.containsKey(graphName));
+        Assert.assertFalse(this.params.graphEventHub()
+                                      .listeners(Events.CACHE)
+                                      .contains(registered));
+
+        this.graph.clearBackend();
+        this.graph.close();
+        this.graph = null;
+
+        HugeGraph reopened = HugeFactory.open(FakeObjects.newConfig());
+        this.graph = reopened;
+        this.params = Whitebox.getInternalState(reopened, "params");
+        Object reopenedHolder = cacheListeners.get(graphName);
+        Assert.assertNotNull(reopenedHolder);
+        Assert.assertNotSame(holder, reopenedHolder);
+        int reopenedRefCount = holderRefCount(reopenedHolder);
+        CachedGraphTransaction third = new CachedGraphTransaction(
+                this.params, this.params.loadGraphStore());
+        this.cache = third;
+        Object newHolder = cacheListeners.get(graphName);
+        Assert.assertSame(reopenedHolder, newHolder);
+        Assert.assertEquals(reopenedRefCount + 1, holderRefCount(newHolder));
     }
 
     @Test

--- a/hugegraph-server/hugegraph-test/src/main/java/org/apache/hugegraph/unit/cache/CachedGraphTransactionTest.java
+++ b/hugegraph-server/hugegraph-test/src/main/java/org/apache/hugegraph/unit/cache/CachedGraphTransactionTest.java
@@ -87,7 +87,7 @@ public class CachedGraphTransactionTest extends BaseUnitTest {
             throws Exception {
         Field field = CachedGraphTransaction.class
                                             .getDeclaredField(
-                                                    "graphCacheEventListeners");
+                                                    "GRAPH_CACHE_EVENT_LISTENERS");
         field.setAccessible(true);
         return (ConcurrentMap<String, Object>) field.get(null);
     }
@@ -99,6 +99,14 @@ public class CachedGraphTransactionTest extends BaseUnitTest {
                                       .getDeclaredField("storeEventListenStatus");
         field.setAccessible(true);
         return (ConcurrentMap<String, Boolean>) field.get(null);
+    }
+
+    private static void restoreStoreListenerStatusForKnownTeardownBug(
+            ConcurrentMap<String, Boolean> storeListeners, String graphName) {
+        // Closing a secondary transaction can consume storeEventListenStatus due
+        // to the follow-up bug documented in CachedGraphTransaction.unlistenChanges().
+        // Restore it so teardown can still unregister the primary store listener.
+        storeListeners.putIfAbsent(graphName, true);
     }
 
     private static EventListener holderListener(Object holder) {
@@ -266,10 +274,8 @@ public class CachedGraphTransactionTest extends BaseUnitTest {
                                          .listeners(Events.CACHE)
                                          .contains(registered));
         } finally {
-            // Closing the secondary transaction exercises the pre-existing
-            // store listener guard too; restore it so teardown unregisters the
-            // primary transaction's store listener.
-            storeListeners.putIfAbsent(graphName, true);
+            restoreStoreListenerStatusForKnownTeardownBug(storeListeners,
+                                                           graphName);
         }
     }
 

--- a/hugegraph-server/hugegraph-test/src/main/java/org/apache/hugegraph/unit/cache/CachedGraphTransactionTest.java
+++ b/hugegraph-server/hugegraph-test/src/main/java/org/apache/hugegraph/unit/cache/CachedGraphTransactionTest.java
@@ -17,12 +17,21 @@
 
 package org.apache.hugegraph.unit.cache;
 
+import java.lang.reflect.Field;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
 import org.apache.hugegraph.HugeFactory;
 import org.apache.hugegraph.HugeGraph;
 import org.apache.hugegraph.HugeGraphParams;
+import org.apache.hugegraph.backend.cache.Cache;
 import org.apache.hugegraph.backend.cache.CachedGraphTransaction;
 import org.apache.hugegraph.backend.id.Id;
 import org.apache.hugegraph.backend.id.IdGenerator;
+import org.apache.hugegraph.backend.tx.GraphTransaction;
+import org.apache.hugegraph.event.EventListener;
 import org.apache.hugegraph.schema.VertexLabel;
 import org.apache.hugegraph.structure.HugeEdge;
 import org.apache.hugegraph.structure.HugeVertex;
@@ -136,6 +145,96 @@ public class CachedGraphTransactionTest extends BaseUnitTest {
         Assert.assertTrue(cache.queryVertices(IdGenerator.of(1)).hasNext());
         Assert.assertEquals(2L,
                             Whitebox.invoke(cache, "verticesCache", "size"));
+    }
+
+    @Test
+    public void testClearCacheEmitsActionClear() throws Exception {
+        // Producers must emit the present-tense ACTION_CLEAR / ACTION_INVALID,
+        // not the legacy past-tense variants - otherwise local listeners that
+        // match only the present-tense actions silently drop the event.
+        CachedGraphTransaction cache = this.cache();
+        CountDownLatch latch = new CountDownLatch(1);
+        AtomicReference<String> action = new AtomicReference<>();
+        EventListener listener = event -> {
+            Object[] args = event.args();
+            if (args.length > 0 && args[0] instanceof String) {
+                action.set((String) args[0]);
+                latch.countDown();
+            }
+            return true;
+        };
+        this.params.graphEventHub().listen(Events.CACHE, listener);
+        try {
+            cache.clearCache(HugeType.VERTEX, true);
+
+            Assert.assertTrue(latch.await(1L, TimeUnit.SECONDS));
+            Assert.assertEquals(Cache.ACTION_CLEAR, action.get());
+        } finally {
+            this.params.graphEventHub().unlisten(Events.CACHE, listener);
+        }
+    }
+
+    @Test
+    public void testVertexMutationEmitsActionInvalid() throws Exception {
+        CachedGraphTransaction cache = this.cache();
+        CountDownLatch latch = new CountDownLatch(1);
+        AtomicReference<String> action = new AtomicReference<>();
+        EventListener listener = event -> {
+            Object[] args = event.args();
+            if (args.length > 0 && Cache.ACTION_INVALID.equals(args[0])) {
+                action.set((String) args[0]);
+                latch.countDown();
+            }
+            return true;
+        };
+        this.params.graphEventHub().listen(Events.CACHE, listener);
+        try {
+            cache.addVertex(this.newVertex(IdGenerator.of(1)));
+            cache.commit();
+
+            Assert.assertTrue(latch.await(1L, TimeUnit.SECONDS));
+            Assert.assertEquals(Cache.ACTION_INVALID, action.get());
+        } finally {
+            this.params.graphEventHub().unlisten(Events.CACHE, listener);
+        }
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void testClosingNonOwnerKeepsGraphCacheListenerRegistered()
+            throws Exception {
+        Field cacheField = GraphTransaction.class
+                .getDeclaredField("graphCacheEventListeners");
+        cacheField.setAccessible(true);
+        ConcurrentMap<String, EventListener> cacheListeners =
+                (ConcurrentMap<String, EventListener>) cacheField.get(null);
+        Field storeField = GraphTransaction.class
+                .getDeclaredField("storeEventListenStatus");
+        storeField.setAccessible(true);
+        ConcurrentMap<String, Boolean> storeListeners =
+                (ConcurrentMap<String, Boolean>) storeField.get(null);
+
+        String graphName = this.params.spaceGraphName();
+        EventListener registered = cacheListeners.get(graphName);
+        Assert.assertNotNull(registered);
+
+        CachedGraphTransaction second = new CachedGraphTransaction(
+                this.params, this.params.loadGraphStore());
+        Assert.assertSame(registered, cacheListeners.get(graphName));
+
+        try {
+            second.close();
+
+            Assert.assertSame(registered, cacheListeners.get(graphName));
+            Assert.assertTrue(this.params.graphEventHub()
+                                         .listeners(Events.CACHE)
+                                         .contains(registered));
+        } finally {
+            // Closing the secondary transaction exercises the pre-existing
+            // store listener guard too; restore it so teardown unregisters the
+            // primary transaction's store listener.
+            storeListeners.putIfAbsent(graphName, true);
+        }
     }
 
     @Test

--- a/hugegraph-server/hugegraph-test/src/main/java/org/apache/hugegraph/unit/cache/CachedSchemaTransactionTest.java
+++ b/hugegraph-server/hugegraph-test/src/main/java/org/apache/hugegraph/unit/cache/CachedSchemaTransactionTest.java
@@ -65,24 +65,54 @@ public class CachedSchemaTransactionTest extends BaseUnitTest {
 
     private CachedSchemaTransaction cache;
     private HugeGraphParams params;
+    private HugeGraph graph;
 
     @Before
     public void setup() {
-        HugeGraph graph = HugeFactory.open(FakeObjects.newConfig());
-        this.params = Whitebox.getInternalState(graph, "params");
+        this.graph = HugeFactory.open(FakeObjects.newConfig());
+        this.params = Whitebox.getInternalState(this.graph, "params");
         this.cache = new CachedSchemaTransaction(this.params,
                                                  this.params.loadSchemaStore());
     }
 
     @After
     public void teardown() throws Exception {
-        this.cache().graph().clearBackend();
-        this.cache().graph().close();
+        try {
+            if (this.cache != null) {
+                this.cache.close();
+            }
+        } finally {
+            this.cache = null;
+            if (this.graph != null) {
+                this.graph.clearBackend();
+                this.graph.close();
+                this.graph = null;
+            }
+        }
     }
 
     private CachedSchemaTransaction cache() {
         Assert.assertNotNull(this.cache);
         return this.cache;
+    }
+
+    @SuppressWarnings("unchecked")
+    private static ConcurrentMap<String, Object> schemaCacheEventListeners()
+            throws Exception {
+        Field field = CachedSchemaTransaction.class
+                                             .getDeclaredField(
+                                                     "SCHEMA_CACHE_EVENT_LISTENERS");
+        field.setAccessible(true);
+        return (ConcurrentMap<String, Object>) field.get(null);
+    }
+
+    private static EventListener holderListener(Object holder) {
+        return Whitebox.getInternalState(holder, "listener");
+    }
+
+    private static int holderRefCount(Object holder) {
+        Integer refCount = Whitebox.getInternalState(holder, "refCount");
+        return refCount;
     }
 
     @Test
@@ -229,34 +259,83 @@ public class CachedSchemaTransactionTest extends BaseUnitTest {
     }
 
     @Test
-    @SuppressWarnings("unchecked")
-    public void testListenerRegistryClearedOnCloseAndRebuiltOnReopen()
-            throws Exception {
-        // Closing a graph must drop its entry from the per-graph listener
-        // registry so a subsequent transaction for the same graph can register
-        // a fresh listener instead of falsely reusing the closed reference.
-        Field field = CachedSchemaTransaction.class
-                .getDeclaredField("SCHEMA_CACHE_EVENT_LISTENERS");
-        field.setAccessible(true);
-        ConcurrentMap<String, EventListener> registry =
-                (ConcurrentMap<String, EventListener>) field.get(null);
-
+    public void testCacheListenerSurvivesOwnerClose() throws Exception {
+        ConcurrentMap<String, Object> registry = schemaCacheEventListeners();
         String graphName = this.params.spaceGraphName();
-        Assert.assertTrue(registry.containsKey(graphName));
-        EventListener firstListener = registry.get(graphName);
+        CachedSchemaTransaction owner = this.cache();
+        CachedSchemaTransaction second = new CachedSchemaTransaction(
+                this.params, this.params.loadSchemaStore());
 
-        this.cache().graph().clearBackend();
-        this.cache().graph().close();
+        Object holder = registry.get(graphName);
+        Assert.assertNotNull(holder);
+        EventListener registered = holderListener(holder);
+        int refCount = holderRefCount(holder);
+        Assert.assertTrue(refCount >= 2);
+
+        owner.close();
+        this.cache = second;
+
+        Assert.assertSame(holder, registry.get(graphName));
+        Assert.assertEquals(refCount - 1, holderRefCount(holder));
+        Assert.assertTrue(this.params.schemaEventHub()
+                                     .listeners(Events.CACHE)
+                                     .contains(registered));
+
+        FakeObjects objects = new FakeObjects("unit-test");
+        second.addPropertyKey(objects.newPropertyKey(IdGenerator.of(1),
+                                                     "fake-pk-1"));
+        second.addPropertyKey(objects.newPropertyKey(IdGenerator.of(2),
+                                                     "fake-pk-2"));
+        Assert.assertEquals(2L, Whitebox.invoke(second, "idCache", "size"));
+        Assert.assertEquals(2L, Whitebox.invoke(second, "nameCache", "size"));
+
+        this.params.schemaEventHub().notify(Events.CACHE, Cache.ACTION_CLEAR,
+                                            null).get();
+
+        Assert.assertEquals(0L, Whitebox.invoke(second, "idCache", "size"));
+        Assert.assertEquals(0L, Whitebox.invoke(second, "nameCache", "size"));
+    }
+
+    @Test
+    public void testLastCloseRemovesSchemaCacheListener() throws Exception {
+        ConcurrentMap<String, Object> registry = schemaCacheEventListeners();
+        String graphName = this.params.spaceGraphName();
+        CachedSchemaTransaction owner = this.cache();
+        CachedSchemaTransaction second = new CachedSchemaTransaction(
+                this.params, this.params.loadSchemaStore());
+
+        Object holder = registry.get(graphName);
+        Assert.assertNotNull(holder);
+        EventListener registered = holderListener(holder);
+        Assert.assertTrue(holderRefCount(holder) >= 2);
+
+        owner.close();
+        second.close();
+        this.cache = null;
+        this.params.schemaTransaction().close();
 
         Assert.assertFalse(registry.containsKey(graphName));
+        Assert.assertFalse(this.params.schemaEventHub()
+                                      .listeners(Events.CACHE)
+                                      .contains(registered));
 
-        HugeGraph graph = HugeFactory.open(FakeObjects.newConfig());
-        this.params = Whitebox.getInternalState(graph, "params");
-        this.cache = new CachedSchemaTransaction(this.params,
-                                                 this.params.loadSchemaStore());
+        this.graph.clearBackend();
+        this.graph.close();
+        this.graph = null;
 
-        Assert.assertTrue(registry.containsKey(graphName));
-        Assert.assertNotSame(firstListener, registry.get(graphName));
+        HugeGraph reopened = HugeFactory.open(FakeObjects.newConfig());
+        this.graph = reopened;
+        this.params = Whitebox.getInternalState(reopened, "params");
+        Object reopenedHolder = registry.get(graphName);
+        Assert.assertNotNull(reopenedHolder);
+        Assert.assertNotSame(holder, reopenedHolder);
+        int reopenedRefCount = holderRefCount(reopenedHolder);
+        CachedSchemaTransaction third = new CachedSchemaTransaction(
+                this.params, this.params.loadSchemaStore());
+        this.cache = third;
+        Object newHolder = registry.get(graphName);
+        Assert.assertSame(reopenedHolder, newHolder);
+        Assert.assertEquals(reopenedRefCount + 1, holderRefCount(newHolder));
     }
 
     @Test

--- a/hugegraph-server/hugegraph-test/src/main/java/org/apache/hugegraph/unit/cache/CachedSchemaTransactionTest.java
+++ b/hugegraph-server/hugegraph-test/src/main/java/org/apache/hugegraph/unit/cache/CachedSchemaTransactionTest.java
@@ -23,21 +23,26 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
 
 import org.apache.hugegraph.HugeFactory;
 import org.apache.hugegraph.HugeGraph;
 import org.apache.hugegraph.HugeGraphParams;
 import org.apache.hugegraph.backend.cache.Cache;
+import org.apache.hugegraph.backend.cache.CacheNotifier;
 import org.apache.hugegraph.backend.cache.CacheManager;
 import org.apache.hugegraph.backend.cache.CachedSchemaTransaction;
 import org.apache.hugegraph.backend.cache.CachedSchemaTransactionV2;
 import org.apache.hugegraph.backend.id.Id;
 import org.apache.hugegraph.backend.id.IdGenerator;
+import org.apache.hugegraph.event.EventHub;
+import org.apache.hugegraph.event.EventListener;
 import org.apache.hugegraph.meta.MetaDriver;
 import org.apache.hugegraph.meta.MetaManager;
 import org.apache.hugegraph.meta.managers.GraphMetaManager;
@@ -185,6 +190,127 @@ public class CachedSchemaTransactionTest extends BaseUnitTest {
                             cache.getPropertyKey("fake-pk-1").id());
         Assert.assertEquals("fake-pk-1",
                             cache.getPropertyKey(IdGenerator.of(1)).name());
+    }
+
+    @Test
+    public void testLegacySchemaChangeEmitsActionInvalid()
+            throws Exception {
+        CachedSchemaTransaction cache = this.cache();
+        CountDownLatch latch = new CountDownLatch(1);
+        AtomicReference<String> action = new AtomicReference<>();
+        EventListener listener = event -> {
+            Object[] args = event.args();
+            if (args.length > 0) {
+                action.set((String) args[0]);
+                latch.countDown();
+            }
+            return true;
+        };
+        this.params.schemaEventHub().listen(Events.CACHE, listener);
+
+        try {
+            FakeObjects objects = new FakeObjects("unit-test");
+            cache.addPropertyKey(objects.newPropertyKey(IdGenerator.of(1),
+                                                        "fake-pk-1"));
+
+            Assert.assertTrue(latch.await(1L, TimeUnit.SECONDS));
+            Assert.assertEquals(Cache.ACTION_INVALID, action.get());
+            Assert.assertEquals(1L, Whitebox.invoke(cache, "idCache", "size"));
+            Assert.assertEquals(1L,
+                                Whitebox.invoke(cache, "nameCache", "size"));
+            Assert.assertEquals("fake-pk-1",
+                                cache.getPropertyKey(IdGenerator.of(1))
+                                     .name());
+            Assert.assertEquals(IdGenerator.of(1),
+                                cache.getPropertyKey("fake-pk-1").id());
+        } finally {
+            this.params.schemaEventHub().unlisten(Events.CACHE, listener);
+        }
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void testListenerRegistryClearedOnCloseAndRebuiltOnReopen()
+            throws Exception {
+        // Closing a graph must drop its entry from the per-graph listener
+        // registry so a subsequent transaction for the same graph can register
+        // a fresh listener instead of falsely reusing the closed reference.
+        Field field = CachedSchemaTransaction.class
+                .getDeclaredField("SCHEMA_CACHE_EVENT_LISTENERS");
+        field.setAccessible(true);
+        ConcurrentMap<String, EventListener> registry =
+                (ConcurrentMap<String, EventListener>) field.get(null);
+
+        String graphName = this.params.spaceGraphName();
+        Assert.assertTrue(registry.containsKey(graphName));
+        EventListener firstListener = registry.get(graphName);
+
+        this.cache().graph().clearBackend();
+        this.cache().graph().close();
+
+        Assert.assertFalse(registry.containsKey(graphName));
+
+        HugeGraph graph = HugeFactory.open(FakeObjects.newConfig());
+        this.params = Whitebox.getInternalState(graph, "params");
+        this.cache = new CachedSchemaTransaction(this.params,
+                                                 this.params.loadSchemaStore());
+
+        Assert.assertTrue(registry.containsKey(graphName));
+        Assert.assertNotSame(firstListener, registry.get(graphName));
+    }
+
+    @Test
+    public void testCacheNotifierLocalEventCallsProxyOnce()
+            throws Exception {
+        EventHub hub = new EventHub("schema-cache-notifier-test");
+        AtomicInteger proxyInvalidCalls = new AtomicInteger();
+        CacheNotifier proxy = newCacheNotifier(proxyInvalidCalls,
+                                               new AtomicInteger(),
+                                               new AtomicInteger());
+        CacheNotifier notifier = newSchemaCacheNotifier(hub, proxy);
+
+        try {
+            Assert.assertEquals(1, (int) hub.notify(Events.CACHE,
+                                                    Cache.ACTION_INVALID,
+                                                    HugeType.PROPERTY_KEY,
+                                                    IdGenerator.of(1))
+                                           .get());
+            Assert.assertEquals(1, proxyInvalidCalls.get());
+        } finally {
+            notifier.close();
+        }
+    }
+
+    @Test
+    public void testCacheNotifierRpcInvalidDoesNotLoopToProxy()
+            throws Exception {
+        EventHub hub = new EventHub("schema-cache-notifier-test");
+        AtomicInteger proxyInvalidCalls = new AtomicInteger();
+        AtomicInteger localInvalidCalls = new AtomicInteger();
+        CountDownLatch latch = new CountDownLatch(1);
+        CacheNotifier proxy = newCacheNotifier(proxyInvalidCalls,
+                                               new AtomicInteger(),
+                                               new AtomicInteger());
+        CacheNotifier notifier = newSchemaCacheNotifier(hub, proxy);
+        EventListener localListener = event -> {
+            event.checkArgs(String.class, HugeType.class, Id.class);
+            if (Cache.ACTION_INVALID.equals(event.args()[0])) {
+                localInvalidCalls.incrementAndGet();
+                latch.countDown();
+            }
+            return true;
+        };
+        hub.listen(Events.CACHE, localListener);
+
+        try {
+            notifier.invalid(HugeType.PROPERTY_KEY, IdGenerator.of(1));
+
+            Assert.assertTrue(latch.await(1L, TimeUnit.SECONDS));
+            Assert.assertEquals(1, localInvalidCalls.get());
+            Assert.assertEquals(0, proxyInvalidCalls.get());
+        } finally {
+            notifier.close();
+        }
     }
 
     @Test
@@ -682,6 +808,50 @@ public class CachedSchemaTransactionTest extends BaseUnitTest {
         Object previous = f.get(MetaManager.instance());
         f.set(MetaManager.instance(), replacement);
         return previous;
+    }
+
+    private static CacheNotifier newSchemaCacheNotifier(EventHub hub,
+                                                        CacheNotifier proxy)
+                                                        throws Exception {
+        Class<?> clazz = Class.forName("org.apache.hugegraph." +
+                                       "StandardHugeGraph$" +
+                                       "HugeSchemaCacheNotifier");
+        Constructor<?> constructor = clazz.getDeclaredConstructor(
+                EventHub.class, CacheNotifier.class);
+        constructor.setAccessible(true);
+        return (CacheNotifier) constructor.newInstance(hub, proxy);
+    }
+
+    private static CacheNotifier newCacheNotifier(AtomicInteger invalidCalls,
+                                                  AtomicInteger invalid2Calls,
+                                                  AtomicInteger clearCalls) {
+        return new CacheNotifier() {
+
+            @Override
+            public void invalid(HugeType type, Id id) {
+                invalidCalls.incrementAndGet();
+            }
+
+            @Override
+            public void invalid2(HugeType type, Object[] ids) {
+                invalid2Calls.incrementAndGet();
+            }
+
+            @Override
+            public void clear(HugeType type) {
+                clearCalls.incrementAndGet();
+            }
+
+            @Override
+            public void reload() {
+                // pass
+            }
+
+            @Override
+            public void close() {
+                // pass
+            }
+        };
     }
 
     @SuppressWarnings("unchecked")


### PR DESCRIPTION
<!-- 
  Thank you very much for contributing to Apache HugeGraph, we are happy that you want to help us improve it!

  Here are some tips for you:
    1. If this is your first time, please read the [contributing guidelines](https://github.com/apache/hugegraph/blob/master/CONTRIBUTING.md)

    2. If a PR fix/close an issue, type the message "close xxx" (xxx is the link of related 
issue) in the content, GitHub will auto link it (Required)

    3. Name the PR title in "Google Commit Format", start with "feat | fix | perf | refactor | doc | chore", 
      such like: "feat(core): support the PageRank algorithm" or "fix: wrong break in the compute loop" (module is optional)
      skip it if you are unsure about which is the best component.

    4. One PR address one issue, better not to mix up multiple issues.

    5. Put an `x` in the `[ ]` to mark the item as CHECKED. `[x]` (or click it directly after 
published)
-->

## Purpose of the PR

- close #3012 <!-- or use "fix #xxx", "xxx" is the ID-link of related issue, e.g: close #1024 -->

<!--
Please explain more context in this section, clarify why the changes are needed. 
e.g:
- If you propose a new API, clarify the use case for a new API.
- If you fix a bug, you can clarify why it is a bug, and should be associated with an issue.
-->

Cache producers in the legacy `EventHub` path were emitting past-tense action                                                                                         
  names (`invalided` / `cleared`) while local cache listeners only matched the
  present-tense actions (`invalid` / `clear`). On single-node deployments, or                                                                                           
  whenever the cache RPC bridge in `StandardHugeGraph.AbstractCacheNotifier` was                                                                                        
  not active, those local cache invalidation events were silently dropped: no                                                                                           
  error, no warning, just stale cache.                                                                                                                                  
                                                                                                                                                                        
  The fix aligns producers, listeners, and the bridge on the present-tense                                                                                              
  constants, removes the obsolete past-tense ones, and wires `notifyExcept(...)`
  so the bridge does not loop back into itself once both ends speak the same                                                                                            
  action name.                                                                                                                                                          
                                                                                                                                                                        
  ## Main Changes                                                                                                                                                       
                                                            
  - Drop `Cache.ACTION_INVALIDED` / `Cache.ACTION_CLEARED`. All producers                                                                                               
    (`CachedGraphTransaction`, `CachedSchemaTransaction`) now emit
    `Cache.ACTION_INVALID` / `Cache.ACTION_CLEAR`, matching what local listeners                                                                                        
    and `RaftContext` already expect.                                                                                                                                   
  - Update `StandardHugeGraph.AbstractCacheNotifier` to listen on the                                                                                                   
    present-tense actions and to forward through `EventHub.notifyExcept(...)` so                                                                                        
    the bridge does not re-receive its own re-emit.                                                                                                                     
  - Add `EventHub.notifyExcept(event, ignoredListener, args...)` so a caller can                                                                                        
    notify everyone on the hub except the listener that originated the event.                                                                                           
    The signature is documented as a public API on `EventHub`, `notify(...)`                                                                                            
    is unchanged and now delegates internally.                                                                                                                          
  - Use `notifyExcept(...)` from the cache transactions and from                                                                                                        
    `AbstractCacheNotifier`, with the registered cache listener as the ignored                                                                                          
    one, so producers do not feed their own listener and the RPC re-emit does                                                                                           
    not loop the bridge.                                                                                                                                                
  - Track the registered cache listener per graph in
    `GraphTransaction.graphCacheEventListeners` and in a matching map inside
    `CachedSchemaTransaction`, with owner-aware teardown on close. This is the
    minimum needed for `notifyExcept(...)` to exclude the listener that is
    actually registered on the hub: with the old per-instance lambda +
    `containsListener(...)` / boolean guard pattern, only the first transaction
    per graph registered a listener, while later transactions could call
    `notifyExcept(...)` with a lambda that was never registered. In that case the
    real registered listener was not excluded and could still process the
    transaction's own local emit.                                                                                                      
                                                                                                                                                                        
  `CachedSchemaTransactionV2` is intentionally not touched here. That class was
  just adjusted in #3011 for HStore/V2 schema cache propagation through
  `MetaManager`. The remaining `containsListener(...)` guard there is a related
  listener-lifecycle concern, not the action-name mismatch fixed in this PR; it
  should be handled in a follow-up that audits the remaining V2 path and, if
  needed, moves cache listener ownership to a ref-counted holder keyed by graph
  identity and `EventHub`.                                                                                                                                                    
                                                                                                                                                                        
  ## Verifying these changes                                                                                                                                            
                                                            
  - [ ] Trivial rework / code cleanup without any test coverage. (No Need)                                                                                              
  - [ ] Already covered by existing tests, such as *(please modify tests here)*.
  - [x] Need tests and can be verified as follows:                                                                                                                      
      - `EventHubTest#testNotifyExcept` covers the new `notifyExcept(...)`
        semantics, including `ANY_EVENT` listeners and the ignored-listener                                                                                             
        exclusion.                                                                                                                                                      
      - `CachedSchemaTransactionTest#testLegacySchemaChangeEmitsActionInvalid`                                                                                          
        asserts the schema producer now emits `ACTION_INVALID` end-to-end.                                                                                              
      - `CachedSchemaTransactionTest#testCacheListenerSurvivesOwnerClose`
          asserts that closing the owner transaction does not drop the hub
          listener while a second transaction is still alive, and that cache
          invalidation events are still delivered to the surviving transaction.
      - `CachedSchemaTransactionTest#testLastCloseRemovesSchemaCacheListener`
        asserts that the hub listener is unregistered and the registry entry
        removed only when the last transaction for that graph closes, and that
        a subsequent graph open registers a fresh holder.
      - `CachedGraphTransactionTest#testCacheListenerSurvivesOwnerClose`
        same owner-first-close guarantee for the graph vertex/edge cache path.
      - `CachedGraphTransactionTest#testLastCloseRemovesGraphCacheListener`
        same last-close cleanup guarantee for the graph cache path.                                                                                                              
      - `CachedSchemaTransactionTest#testCacheNotifierLocalEventCallsProxyOnce`                                                                                         
        and `testCacheNotifierRpcInvalidDoesNotLoopToProxy` cover the bridge                                                                                            
        no-loop behavior.                                                                                                                                               
       - `CachedGraphTransactionTest#testClearCacheEmitsActionClear` asserts
          graph cache clears now emit `ACTION_CLEAR`.
       - `CachedGraphTransactionTest#testVertexMutationEmitsActionInvalid`
          asserts graph vertex mutations now emit `ACTION_INVALID`.
       - `CachedGraphTransactionTest#testClosingNonOwnerKeepsGraphCacheListenerRegistered`
          asserts that closing a graph transaction which reused an existing
          per-graph listener does not unregister the shared graph cache listener.
                                                                                              
                                                                                                                                                                        
  ## Does this PR potentially affect the following parts?   
                                                                                                                                                                        
  - [ ] Dependencies                                        
  - [ ] Modify configurations                                                                                                                                           
  - [x] The public API                                      
  - [ ] Other affects
  - [ ] Nope                                                                                                                                                            
   
  `EventHub.notifyExcept(...)` is a new public method; existing `notify(...)`                                                                                           
  behavior is unchanged.                                    
                                                                                                                                                                        
  ## Documentation Status                                   

  - [ ] `Doc - TODO`
  - [ ] `Doc - Done`
  - [x] `Doc - No Need`
