### PR TITLE
perf(docker): improve all images build cache efficiency

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,34 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# NOTE: This file intentionally stays minimal.
+# Most patterns (IDE files, build artifacts, logs, OS files) are already
+# covered by .gitignore. Only Docker-specific extras are listed here.
+
+# Git internals (never tracked by git, must be explicit here)
+.git
+.gitignore
+.gitattributes
+.github
+
+# Docker compose files not needed in build context
+**/docker-compose*.yml
+**/docker-compose*.yaml
+
+# Docs not needed in build context
+**/*.md
+docs/

--- a/.dockerignore
+++ b/.dockerignore
@@ -40,7 +40,7 @@ apache-hugegraph-*/
 **/*.class
 **/gen-java/
 **/upload-files/
-**/dist/
+**/target/dist/
 **/build/
 **/node_modules/
 

--- a/.dockerignore
+++ b/.dockerignore
@@ -23,7 +23,7 @@
 # Pre-extracted release dirs / archives
 apache-hugegraph-*/
 **/*.tar
-**/*.tar.gz*
+**/*.tar.gz
 **/*.zip
 **/*.war
 
@@ -40,7 +40,6 @@ apache-hugegraph-*/
 **/*.class
 **/gen-java/
 **/upload-files/
-**/target/dist/
 **/build/
 **/node_modules/
 
@@ -51,7 +50,7 @@ apache-hugegraph-*/
 # Git internals
 .git
 .gitignore
-.gitattribut
+.gitattributes
 .github
 
 # Compose / docs not needed in build context

--- a/.dockerignore
+++ b/.dockerignore
@@ -15,21 +15,47 @@
 # limitations under the License.
 #
 
-# NOTE: This file intentionally stays minimal.
-**/target/
-# Most patterns (IDE files, build artifacts, logs, OS files) are already
-# covered by .gitignore. Only Docker-specific extras are listed here.
+# IMPORTANT: .dockerignore does NOT inherit .gitignore — patterns must be restated.
 
-# Git internals (never tracked by git, must be explicit here)
+# Build output
+**/target/
+
+# Pre-extracted release dirs / archives
+apache-hugegraph-*/
+**/*.tar
+**/*.tar.gz*
+**/*.zip
+**/*.war
+
+# IDE / OS
+.idea/
+.vscode/
+**/*.iml
+**/*.iws
+**/.DS_Store
+
+# Build / runtime artifacts
+**/logs/
+**/*.log
+**/*.class
+**/gen-java/
+**/upload-files/
+**/dist/
+**/build/
+**/node_modules/
+
+# Env files
+.env.local
+.env.*.local
+
+# Git internals
 .git
 .gitignore
-.gitattributes
+.gitattribut
 .github
 
-# Docker compose files not needed in build context
+# Compose / docs not needed in build context
 **/docker-compose*.yml
 **/docker-compose*.yaml
-
-# Docs not needed in build context
 **/*.md
 docs/

--- a/.dockerignore
+++ b/.dockerignore
@@ -16,6 +16,7 @@
 #
 
 # NOTE: This file intentionally stays minimal.
+**/target/
 # Most patterns (IDE files, build artifacts, logs, OS files) are already
 # covered by .gitignore. Only Docker-specific extras are listed here.
 

--- a/.github/workflows/docker-build-ci.yml
+++ b/.github/workflows/docker-build-ci.yml
@@ -43,9 +43,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
       - name: Build ${{ matrix.dockerfile }}
         run: |
-          docker buildx build -f ${{ matrix.dockerfile }} --load .
+          docker build -f ${{ matrix.dockerfile }} .

--- a/.github/workflows/docker-build-ci.yml
+++ b/.github/workflows/docker-build-ci.yml
@@ -1,0 +1,51 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+name: "Docker Build CI"
+
+on:
+  push:
+    branches:
+      - master
+      - 'release-*'
+  pull_request:
+    paths:
+      - '**/Dockerfile*'
+      - '.dockerignore'
+
+jobs:
+  docker-build:
+    runs-on: ubuntu-24.04
+    strategy:
+      fail-fast: false
+      matrix:
+        dockerfile:
+          - hugegraph-pd/Dockerfile
+          - hugegraph-store/Dockerfile
+          - hugegraph-server/Dockerfile
+          - hugegraph-server/Dockerfile-hstore
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build ${{ matrix.dockerfile }}
+        run: |
+          docker buildx build -f ${{ matrix.dockerfile }} --load .

--- a/.github/workflows/server-ci.yml
+++ b/.github/workflows/server-ci.yml
@@ -10,8 +10,7 @@ on:
 
 jobs:
   build-server:
-    # TODO: we need test & replace it to ubuntu-24.04 or ubuntu-latest
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     env:
       USE_STAGE: 'false' # Whether to include the stage repository.
       TRAVIS_DIR: hugegraph-server/hugegraph-dist/src/assembly/travis

--- a/.github/workflows/server-ci.yml
+++ b/.github/workflows/server-ci.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   build-server:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     env:
       USE_STAGE: 'false' # Whether to include the stage repository.
       TRAVIS_DIR: hugegraph-server/hugegraph-dist/src/assembly/travis

--- a/.github/workflows/server-ci.yml
+++ b/.github/workflows/server-ci.yml
@@ -10,6 +10,7 @@ on:
 
 jobs:
   build-server:
+    # TODO: we need test & replace it to ubuntu-24.04 or ubuntu-latest
     runs-on: ubuntu-22.04
     env:
       USE_STAGE: 'false' # Whether to include the stage repository.

--- a/hugegraph-pd/Dockerfile
+++ b/hugegraph-pd/Dockerfile
@@ -16,15 +16,21 @@
 #
 
 # Dockerfile for HugeGraph PD
+# NOTE: Build with DOCKER_BUILDKIT=1 to enable cache mounts and --parents COPY.
 # 1st stage: build source code
 FROM maven:3.9.0-eclipse-temurin-11 AS build
 
-COPY . /pkg
 WORKDIR /pkg
+
+# Copy pom files first — layer is only invalidated when pom files change,
+# keeping the Maven cache mount warm across source-only changes.
+COPY --parents **/pom.xml ./
 ARG MAVEN_ARGS
 
-RUN mvn package $MAVEN_ARGS -e -B -ntp -Dmaven.test.skip=true -Dmaven.javadoc.skip=true && pwd && ls -l && rm \
-    ./hugegraph-server/*.tar.gz && rm ./hugegraph-pd/*.tar.gz && rm ./hugegraph-store/*.tar.gz
+COPY . .
+RUN --mount=type=cache,target=/root/.m2 \
+    mvn package $MAVEN_ARGS -e -B -ntp -Dmaven.test.skip=true -Dmaven.javadoc.skip=true \
+    && rm ./hugegraph-server/*.tar.gz ./hugegraph-pd/*.tar.gz ./hugegraph-store/*.tar.gz
 
 # 2nd stage: runtime env
 # Note: ZGC (The Z Garbage Collector) is only supported on ARM-Mac with java > 13
@@ -38,25 +44,17 @@ ENV JAVA_OPTS="-XX:+UnlockExperimentalVMOptions -XX:+UseContainerSupport -XX:Max
     HUGEGRAPH_HOME="hugegraph-pd" \
     STDOUT_MODE="true"
 
-#COPY . /hugegraph/hugegraph-pd
 WORKDIR /hugegraph-pd/
 
-# 1. Install environment and init HugeGraph Sever
-RUN set -x \
-    && rm /var/lib/dpkg/info/libc-bin.* \
-    && apt-get -q clean \
-    && apt-get -q update \
+# 1. Install runtime dependencies
+RUN apt-get -q update \
     && apt-get -q install -y --no-install-recommends --no-install-suggests \
        dumb-init \
        procps \
        curl \
        lsof \
-       vim \
-       cron \
     && apt-get clean \
-    && rm -rf /var/lib/apt/lists/* \
-    && service cron start \
-    && pwd && cd /hugegraph-pd/
+    && rm -rf /var/lib/apt/lists/*
 
 # 2. Init docker script
 COPY hugegraph-pd/hg-pd-dist/docker/docker-entrypoint.sh .

--- a/hugegraph-pd/Dockerfile
+++ b/hugegraph-pd/Dockerfile
@@ -1,3 +1,4 @@
+# syntax=docker/dockerfile:1
 #
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
@@ -53,6 +54,7 @@ RUN apt-get -q update \
        procps \
        curl \
        lsof \
+       cron \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 

--- a/hugegraph-pd/Dockerfile
+++ b/hugegraph-pd/Dockerfile
@@ -52,6 +52,7 @@ RUN apt-get -q update \
        curl \
        lsof \
        vim \
+       cron \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 

--- a/hugegraph-pd/Dockerfile
+++ b/hugegraph-pd/Dockerfile
@@ -17,18 +17,15 @@
 #
 
 # Dockerfile for HugeGraph PD
-# NOTE: Build with DOCKER_BUILDKIT=1 to enable cache mounts and --parents COPY.
 # 1st stage: build source code
 FROM maven:3.9.0-eclipse-temurin-11 AS build
 
 WORKDIR /pkg
 
-# Copy pom files first — layer is only invalidated when pom files change,
-# keeping the Maven cache mount warm across source-only changes.
-COPY --parents **/pom.xml ./
+COPY . .
+
 ARG MAVEN_ARGS
 
-COPY . .
 RUN --mount=type=cache,target=/root/.m2 \
     mvn package $MAVEN_ARGS -e -B -ntp -Dmaven.test.skip=true -Dmaven.javadoc.skip=true \
     && rm ./hugegraph-server/*.tar.gz ./hugegraph-pd/*.tar.gz ./hugegraph-store/*.tar.gz
@@ -54,7 +51,7 @@ RUN apt-get -q update \
        procps \
        curl \
        lsof \
-       cron \
+       vim \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 

--- a/hugegraph-server/Dockerfile
+++ b/hugegraph-server/Dockerfile
@@ -16,18 +16,24 @@
 #
 
 # Dockerfile for HugeGraph Server
+# NOTE: Build with DOCKER_BUILDKIT=1 to enable cache mounts and --parents COPY.
 # 1st stage: build source code
 FROM maven:3.9.0-eclipse-temurin-11 AS build
 
-COPY . /pkg
 WORKDIR /pkg
+
+# Copy pom files first — layer is only invalidated when pom files change,
+# keeping the Maven cache mount warm across source-only changes.
+COPY --parents **/pom.xml ./
 ARG MAVEN_ARGS
 
-RUN mvn package $MAVEN_ARGS -e -B -ntp -Dmaven.test.skip=true -Dmaven.javadoc.skip=true && pwd && ls -l && rm \
-    ./hugegraph-server/*.tar.gz && rm ./hugegraph-pd/*.tar.gz && rm ./hugegraph-store/*.tar.gz
+COPY . .
+RUN --mount=type=cache,target=/root/.m2 \
+    mvn package $MAVEN_ARGS -e -B -ntp -Dmaven.test.skip=true -Dmaven.javadoc.skip=true \
+    && rm ./hugegraph-server/*.tar.gz ./hugegraph-pd/*.tar.gz ./hugegraph-store/*.tar.gz
 
 # 2nd stage: runtime env
-# Note: ZGC (The Z Garbage Collector) is only supported on ARM-Mac with java > 13 
+# Note: ZGC (The Z Garbage Collector) is only supported on ARM-Mac with java > 13
 FROM eclipse-temurin:11-jre-jammy
 
 COPY --from=build /pkg/hugegraph-server/apache-hugegraph-server-*/ /hugegraph-server/
@@ -39,25 +45,17 @@ ENV JAVA_OPTS="-XX:+UnlockExperimentalVMOptions -XX:+UseContainerSupport -XX:Max
     HUGEGRAPH_HOME="hugegraph-server" \
     STDOUT_MODE="true"
 
-#COPY . /hugegraph/hugegraph-server
 WORKDIR /hugegraph-server/
 
-# 1. Install environment and init HugeGraph Sever
-RUN set -x \
-    && rm /var/lib/dpkg/info/libc-bin.* \
-    && apt-get -q clean \
-    && apt-get -q update \
+# 1. Install runtime dependencies and configure server
+RUN apt-get -q update \
     && apt-get -q install -y --no-install-recommends --no-install-suggests \
        dumb-init \
        procps \
        curl \
        lsof \
-       vim \
-       cron \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/* \
-    && service cron start \
-    && pwd && cd /hugegraph-server/ \
     && sed -i "s/^restserver.url.*$/restserver.url=http:\/\/0.0.0.0:8080/g" ./conf/rest-server.properties
 
 # 2. Init docker script

--- a/hugegraph-server/Dockerfile
+++ b/hugegraph-server/Dockerfile
@@ -1,3 +1,4 @@
+# syntax=docker/dockerfile:1
 #
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
@@ -54,6 +55,7 @@ RUN apt-get -q update \
        procps \
        curl \
        lsof \
+       cron \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/* \
     && sed -i "s/^restserver.url.*$/restserver.url=http:\/\/0.0.0.0:8080/g" ./conf/rest-server.properties

--- a/hugegraph-server/Dockerfile
+++ b/hugegraph-server/Dockerfile
@@ -53,6 +53,7 @@ RUN apt-get -q update \
        curl \
        lsof \
        vim \
+       cron \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/* \
     && sed -i "s/^restserver.url.*$/restserver.url=http:\/\/0.0.0.0:8080/g" ./conf/rest-server.properties

--- a/hugegraph-server/Dockerfile
+++ b/hugegraph-server/Dockerfile
@@ -17,18 +17,15 @@
 #
 
 # Dockerfile for HugeGraph Server
-# NOTE: Build with DOCKER_BUILDKIT=1 to enable cache mounts and --parents COPY.
 # 1st stage: build source code
 FROM maven:3.9.0-eclipse-temurin-11 AS build
 
 WORKDIR /pkg
 
-# Copy pom files first — layer is only invalidated when pom files change,
-# keeping the Maven cache mount warm across source-only changes.
-COPY --parents **/pom.xml ./
+COPY . .
+
 ARG MAVEN_ARGS
 
-COPY . .
 RUN --mount=type=cache,target=/root/.m2 \
     mvn package $MAVEN_ARGS -e -B -ntp -Dmaven.test.skip=true -Dmaven.javadoc.skip=true \
     && rm ./hugegraph-server/*.tar.gz ./hugegraph-pd/*.tar.gz ./hugegraph-store/*.tar.gz
@@ -55,7 +52,7 @@ RUN apt-get -q update \
        procps \
        curl \
        lsof \
-       cron \
+       vim \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/* \
     && sed -i "s/^restserver.url.*$/restserver.url=http:\/\/0.0.0.0:8080/g" ./conf/rest-server.properties

--- a/hugegraph-server/Dockerfile-hstore
+++ b/hugegraph-server/Dockerfile-hstore
@@ -15,19 +15,25 @@
 # limitations under the License.
 #
 
-# Dockerfile for HugeGraph Server
+# Dockerfile for HugeGraph Server (hstore backend)
+# NOTE: Build with DOCKER_BUILDKIT=1 to enable cache mounts and --parents COPY.
 # 1st stage: build source code
 FROM maven:3.9.0-eclipse-temurin-11 AS build
 
-COPY . /pkg
 WORKDIR /pkg
+
+# Copy pom files first — layer is only invalidated when pom files change,
+# keeping the Maven cache mount warm across source-only changes.
+COPY --parents **/pom.xml ./
 ARG MAVEN_ARGS
 
-RUN mvn package $MAVEN_ARGS -e -B -ntp -DskipTests -Dmaven.javadoc.skip=true && pwd && ls -l && rm \
-    ./hugegraph-server/*.tar.gz && rm ./hugegraph-pd/*.tar.gz && rm ./hugegraph-store/*.tar.gz
+COPY . .
+RUN --mount=type=cache,target=/root/.m2 \
+    mvn package $MAVEN_ARGS -e -B -ntp -DskipTests -Dmaven.javadoc.skip=true \
+    && rm ./hugegraph-server/*.tar.gz ./hugegraph-pd/*.tar.gz ./hugegraph-store/*.tar.gz
 
 # 2nd stage: runtime env
-# Note: ZGC (The Z Garbage Collector) is only supported on ARM-Mac with java > 13 
+# Note: ZGC (The Z Garbage Collector) is only supported on ARM-Mac with java > 13
 FROM eclipse-temurin:11-jre-jammy
 
 COPY --from=build /pkg/hugegraph-server/apache-hugegraph-server-*/ /hugegraph-server/
@@ -41,23 +47,17 @@ LABEL maintainer="HugeGraph Docker Maintainers <dev@hugegraph.apache.org>"
 ENV JAVA_OPTS="-XX:+UnlockExperimentalVMOptions -XX:+UseContainerSupport -XX:MaxRAMPercentage=50 -XshowSettings:vm" \
     HUGEGRAPH_HOME="hugegraph-server"
 
-#COPY . /hugegraph/hugegraph-server
 WORKDIR /hugegraph-server/
 
-# 1. Install environment and init HugeGraph Sever
-RUN set -x \
-    && apt-get -q update \
+# 1. Install runtime dependencies and configure server
+RUN apt-get -q update \
     && apt-get -q install -y --no-install-recommends --no-install-suggests \
        dumb-init \
        procps \
        curl \
        lsof \
-       vim \
-       cron \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/* \
-    && service cron start \
-    && pwd && cd /hugegraph-server/ \
     && sed -i "s/^restserver.url.*$/restserver.url=http:\/\/0.0.0.0:8080/g" ./conf/rest-server.properties
 
 # 2. Init docker script

--- a/hugegraph-server/Dockerfile-hstore
+++ b/hugegraph-server/Dockerfile-hstore
@@ -55,6 +55,7 @@ RUN apt-get -q update \
        curl \
        lsof \
        vim \
+       cron \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/* \
     && sed -i "s/^restserver.url.*$/restserver.url=http:\/\/0.0.0.0:8080/g" ./conf/rest-server.properties

--- a/hugegraph-server/Dockerfile-hstore
+++ b/hugegraph-server/Dockerfile-hstore
@@ -1,3 +1,4 @@
+# syntax=docker/dockerfile:1
 #
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
@@ -56,6 +57,7 @@ RUN apt-get -q update \
        procps \
        curl \
        lsof \
+       cron \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/* \
     && sed -i "s/^restserver.url.*$/restserver.url=http:\/\/0.0.0.0:8080/g" ./conf/rest-server.properties

--- a/hugegraph-server/Dockerfile-hstore
+++ b/hugegraph-server/Dockerfile-hstore
@@ -17,18 +17,15 @@
 #
 
 # Dockerfile for HugeGraph Server (hstore backend)
-# NOTE: Build with DOCKER_BUILDKIT=1 to enable cache mounts and --parents COPY.
 # 1st stage: build source code
 FROM maven:3.9.0-eclipse-temurin-11 AS build
 
 WORKDIR /pkg
 
-# Copy pom files first — layer is only invalidated when pom files change,
-# keeping the Maven cache mount warm across source-only changes.
-COPY --parents **/pom.xml ./
+COPY . .
+
 ARG MAVEN_ARGS
 
-COPY . .
 RUN --mount=type=cache,target=/root/.m2 \
     mvn package $MAVEN_ARGS -e -B -ntp -DskipTests -Dmaven.javadoc.skip=true \
     && rm ./hugegraph-server/*.tar.gz ./hugegraph-pd/*.tar.gz ./hugegraph-store/*.tar.gz
@@ -57,7 +54,7 @@ RUN apt-get -q update \
        procps \
        curl \
        lsof \
-       cron \
+       vim \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/* \
     && sed -i "s/^restserver.url.*$/restserver.url=http:\/\/0.0.0.0:8080/g" ./conf/rest-server.properties

--- a/hugegraph-store/Dockerfile
+++ b/hugegraph-store/Dockerfile
@@ -1,3 +1,4 @@
+# syntax=docker/dockerfile:1
 #
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
@@ -53,6 +54,7 @@ RUN apt-get -q update \
        procps \
        curl \
        lsof \
+       cron \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 

--- a/hugegraph-store/Dockerfile
+++ b/hugegraph-store/Dockerfile
@@ -16,15 +16,21 @@
 #
 
 # Dockerfile for HugeGraph Store
+# NOTE: Build with DOCKER_BUILDKIT=1 to enable cache mounts and --parents COPY.
 # 1st stage: build source code
 FROM maven:3.9.0-eclipse-temurin-11 AS build
 
-COPY . /pkg
 WORKDIR /pkg
+
+# Copy pom files first — layer is only invalidated when pom files change,
+# keeping the Maven cache mount warm across source-only changes.
+COPY --parents **/pom.xml ./
 ARG MAVEN_ARGS
 
-RUN mvn package $MAVEN_ARGS -e -B -ntp -Dmaven.test.skip=true -Dmaven.javadoc.skip=true && pwd && ls -l && rm \
-    ./hugegraph-server/*.tar.gz && rm ./hugegraph-pd/*.tar.gz && rm ./hugegraph-store/*.tar.gz
+COPY . .
+RUN --mount=type=cache,target=/root/.m2 \
+    mvn package $MAVEN_ARGS -e -B -ntp -Dmaven.test.skip=true -Dmaven.javadoc.skip=true \
+    && rm ./hugegraph-server/*.tar.gz ./hugegraph-pd/*.tar.gz ./hugegraph-store/*.tar.gz
 
 # 2nd stage: runtime env
 # Note: ZGC (The Z Garbage Collector) is only supported on ARM-Mac with java > 13
@@ -38,25 +44,17 @@ ENV JAVA_OPTS="-XX:+UnlockExperimentalVMOptions -XX:+UseContainerSupport -XX:Max
     HUGEGRAPH_HOME="hugegraph-store" \
     STDOUT_MODE="true"
 
-#COPY . /hugegraph/hugegraph-store
 WORKDIR /hugegraph-store/
 
-# 1. Install environment and init HugeGraph Sever
-RUN set -x \
-    && rm /var/lib/dpkg/info/libc-bin.* \
-    && apt-get -q clean \
-    && apt-get -q update \
+# 1. Install runtime dependencies
+RUN apt-get -q update \
     && apt-get -q install -y --no-install-recommends --no-install-suggests \
        dumb-init \
        procps \
        curl \
        lsof \
-       vim \
-       cron \
     && apt-get clean \
-    && rm -rf /var/lib/apt/lists/* \
-    && service cron start \
-    && pwd && cd /hugegraph-store/
+    && rm -rf /var/lib/apt/lists/*
 
 # 2. Init docker script
 COPY hugegraph-store/hg-store-dist/docker/docker-entrypoint.sh .

--- a/hugegraph-store/Dockerfile
+++ b/hugegraph-store/Dockerfile
@@ -17,18 +17,15 @@
 #
 
 # Dockerfile for HugeGraph Store
-# NOTE: Build with DOCKER_BUILDKIT=1 to enable cache mounts and --parents COPY.
 # 1st stage: build source code
 FROM maven:3.9.0-eclipse-temurin-11 AS build
 
 WORKDIR /pkg
 
-# Copy pom files first — layer is only invalidated when pom files change,
-# keeping the Maven cache mount warm across source-only changes.
-COPY --parents **/pom.xml ./
+COPY . .
+
 ARG MAVEN_ARGS
 
-COPY . .
 RUN --mount=type=cache,target=/root/.m2 \
     mvn package $MAVEN_ARGS -e -B -ntp -Dmaven.test.skip=true -Dmaven.javadoc.skip=true \
     && rm ./hugegraph-server/*.tar.gz ./hugegraph-pd/*.tar.gz ./hugegraph-store/*.tar.gz
@@ -54,7 +51,7 @@ RUN apt-get -q update \
        procps \
        curl \
        lsof \
-       cron \
+       vim \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 

--- a/hugegraph-store/Dockerfile
+++ b/hugegraph-store/Dockerfile
@@ -52,6 +52,7 @@ RUN apt-get -q update \
        curl \
        lsof \
        vim \
+       cron \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
## Purpose of the PR

close #2977

## Main Changes

**`.dockerignore` (new file)**
- Excludes Docker build-context noise explicitly because `.dockerignore` does not inherit `.gitignore`
- Filters local build outputs, extracted release directories, archives, IDE/OS files, logs, generated artifacts, env-local files, git internals, compose files, and docs

**All 4 Dockerfiles**
- Added `--mount=type=cache,target=/root/.m2` on `mvn package` — deps cached across repeated builds
- Kept `vim` and `cron` in the runtime images to preserve existing container debugging workflows and the current `start-hugegraph.sh -m true` monitor path
- Removed ineffective build-time `service cron start`, `rm /var/lib/dpkg/info/libc-bin.*`, and other dead cleanup/debug commands from runtime stages

> Note: `dependency:go-offline` not used — inter-module deps like `hg-pd-client` are not on Maven Central and would cause it to fail.

## Verifying these changes

- [x] Need tests and can be verified as follows:  
```markdown
# Build all 4 images
docker build -f hugegraph-pd/Dockerfile        -t hugegraph/pd:test .  
docker build -f hugegraph-store/Dockerfile     -t hugegraph/store:test .  
docker build -f hugegraph-server/Dockerfile    -t hugegraph/server:test .  
docker build -f hugegraph-server/Dockerfile-hstore -t hugegraph/server-hstore:test .  
  
# Verify runtime contents and cron in each image
docker run --rm --entrypoint /bin/bash hugegraph/pd:test    -c "ls /hugegraph-pd/    && which cron"  
docker run --rm --entrypoint /bin/bash hugegraph/store:test -c "ls /hugegraph-store/ && which cron"  
docker run --rm --entrypoint /bin/bash hugegraph/server:test -c "ls /hugegraph-server/ && which cron"  
  
# Full stack health check (pull_policy: always requires --pull never for local images)
HUGEGRAPH_VERSION=test docker compose -f docker/docker-compose.yml up --pull never  
# All 3 containers should show (healthy) in docker ps 
```
```markdown
- [x] Tested and verified:
  - All 4 Dockerfiles build successfully (Maven deps cached via `--mount=type=cache`)
  - Runtime contents and `cron` confirmed in all images
  - Full stack health check passed — all 3 containers came up `(healthy)`:
    - `hugegraph/pd:test` — healthy on port 8620
    - `hugegraph/store:test` — healthy on port 8520
    - `hugegraph/server:test` — healthy on port 8080
```

## Does this PR potentially affect the following parts?

- [ ] Dependencies (add/update license info & regenerate_known_dependencies.sh)
- [ ] Modify configurations
- [ ] The public API
- [ ] Other affects (typed here)
- [x] Nope

## Documentation Status

- [x] `Doc - No Need`