### PR TITLE
fix(server): keep schema ~create_time as Date after reload

### DIFF
--- a/hugegraph-server/hugegraph-core/src/main/java/org/apache/hugegraph/schema/SchemaElement.java
+++ b/hugegraph-server/hugegraph-core/src/main/java/org/apache/hugegraph/schema/SchemaElement.java
@@ -103,7 +103,7 @@ public abstract class SchemaElement implements Nameable, Typeable,
     public void userdata(String key, Object value) {
         E.checkArgumentNotNull(key, "userdata key");
         E.checkArgumentNotNull(value, "userdata value");
-        this.userdata.put(key, Userdata.normalizeValue(key, value));
+        this.userdata.put(key, value);
     }
 
     /**
@@ -112,11 +112,7 @@ public abstract class SchemaElement implements Nameable, Typeable,
      */
     public void userdata(Userdata userdata) {
         E.checkArgumentNotNull(userdata, "userdata");
-        for (Map.Entry<String, Object> e : userdata.entrySet()) {
-            this.userdata.put(e.getKey(),
-                              Userdata.normalizeValue(e.getKey(),
-                                                      e.getValue()));
-        }
+        this.userdata.putAll(userdata);
     }
 
     public void removeUserdata(String key) {

--- a/hugegraph-server/hugegraph-core/src/main/java/org/apache/hugegraph/schema/SchemaElement.java
+++ b/hugegraph-server/hugegraph-core/src/main/java/org/apache/hugegraph/schema/SchemaElement.java
@@ -27,7 +27,6 @@ import org.apache.hugegraph.backend.id.IdGenerator;
 import org.apache.hugegraph.type.Nameable;
 import org.apache.hugegraph.type.Typeable;
 import org.apache.hugegraph.type.define.SchemaStatus;
-import org.apache.hugegraph.util.DateUtil;
 import org.apache.hugegraph.util.E;
 import org.apache.tinkerpop.gremlin.structure.Graph;
 
@@ -97,40 +96,27 @@ public abstract class SchemaElement implements Nameable, Typeable,
         return Collections.unmodifiableMap(this.userdata);
     }
 
+    /**
+     * Add userdata. String values of {@link Userdata#CREATE_TIME} are
+     * normalized to {@link java.util.Date} and malformed strings are rejected.
+     */
     public void userdata(String key, Object value) {
         E.checkArgumentNotNull(key, "userdata key");
         E.checkArgumentNotNull(value, "userdata value");
-        this.userdata.put(key, normalizeUserdataValue(key, value));
+        this.userdata.put(key, Userdata.normalizeValue(key, value));
     }
 
+    /**
+     * Add userdata in bulk. String values of {@link Userdata#CREATE_TIME} are
+     * normalized to {@link java.util.Date} and malformed strings are rejected.
+     */
     public void userdata(Userdata userdata) {
         E.checkArgumentNotNull(userdata, "userdata");
         for (Map.Entry<String, Object> e : userdata.entrySet()) {
             this.userdata.put(e.getKey(),
-                              normalizeUserdataValue(e.getKey(), e.getValue()));
+                              Userdata.normalizeValue(e.getKey(),
+                                                      e.getValue()));
         }
-    }
-
-    /**
-     * Normalize internal userdata values whose runtime type can diverge from
-     * their serialized form. The only such key today is
-     * {@link Userdata#CREATE_TIME}: it is written as a {@link java.util.Date}
-     * but persisted as a formatted JSON string by the backend serializers,
-     * and Jackson cannot re-type a value to {@code Date} when the target is
-     * a raw {@code Map}. This method restores the original type after
-     * deserialization. Idempotent for values already of the expected type.
-     */
-    private static Object normalizeUserdataValue(String key, Object value) {
-        if (Userdata.CREATE_TIME.equals(key) && value instanceof String) {
-            try {
-                return DateUtil.parse((String) value);
-            } catch (RuntimeException e) {
-                throw new IllegalArgumentException(String.format(
-                          "Invalid userdata '%s' value: '%s'",
-                          Userdata.CREATE_TIME, value), e);
-            }
-        }
-        return value;
     }
 
     public void removeUserdata(String key) {
@@ -139,6 +125,7 @@ public abstract class SchemaElement implements Nameable, Typeable,
     }
 
     public void removeUserdata(Userdata userdata) {
+        E.checkArgumentNotNull(userdata, "userdata");
         for (String key : userdata.keySet()) {
             this.userdata.remove(key);
         }

--- a/hugegraph-server/hugegraph-core/src/main/java/org/apache/hugegraph/schema/SchemaElement.java
+++ b/hugegraph-server/hugegraph-core/src/main/java/org/apache/hugegraph/schema/SchemaElement.java
@@ -27,6 +27,7 @@ import org.apache.hugegraph.backend.id.IdGenerator;
 import org.apache.hugegraph.type.Nameable;
 import org.apache.hugegraph.type.Typeable;
 import org.apache.hugegraph.type.define.SchemaStatus;
+import org.apache.hugegraph.util.DateUtil;
 import org.apache.hugegraph.util.E;
 import org.apache.tinkerpop.gremlin.structure.Graph;
 
@@ -99,11 +100,37 @@ public abstract class SchemaElement implements Nameable, Typeable,
     public void userdata(String key, Object value) {
         E.checkArgumentNotNull(key, "userdata key");
         E.checkArgumentNotNull(value, "userdata value");
-        this.userdata.put(key, value);
+        this.userdata.put(key, normalizeUserdataValue(key, value));
     }
 
     public void userdata(Userdata userdata) {
-        this.userdata.putAll(userdata);
+        E.checkArgumentNotNull(userdata, "userdata");
+        for (Map.Entry<String, Object> e : userdata.entrySet()) {
+            this.userdata.put(e.getKey(),
+                              normalizeUserdataValue(e.getKey(), e.getValue()));
+        }
+    }
+
+    /**
+     * Normalize internal userdata values whose runtime type can diverge from
+     * their serialized form. The only such key today is
+     * {@link Userdata#CREATE_TIME}: it is written as a {@link java.util.Date}
+     * but persisted as a formatted JSON string by the backend serializers,
+     * and Jackson cannot re-type a value to {@code Date} when the target is
+     * a raw {@code Map}. This method restores the original type after
+     * deserialization. Idempotent for values already of the expected type.
+     */
+    private static Object normalizeUserdataValue(String key, Object value) {
+        if (Userdata.CREATE_TIME.equals(key) && value instanceof String) {
+            try {
+                return DateUtil.parse((String) value);
+            } catch (RuntimeException e) {
+                throw new IllegalArgumentException(String.format(
+                          "Invalid userdata '%s' value: '%s'",
+                          Userdata.CREATE_TIME, value), e);
+            }
+        }
+        return value;
     }
 
     public void removeUserdata(String key) {

--- a/hugegraph-server/hugegraph-core/src/main/java/org/apache/hugegraph/schema/Userdata.java
+++ b/hugegraph-server/hugegraph-core/src/main/java/org/apache/hugegraph/schema/Userdata.java
@@ -62,9 +62,16 @@ public class Userdata extends HashMap<String, Object> {
      * value to {@code Date} when the target is a raw {@code Map}. This method
      * restores the original type after deserialization. Idempotent for values
      * already of the expected type.
+     * <p>
+     * An empty string is passed through unchanged: it is the key-only
+     * placeholder used by the {@code eliminate()}/{@code DELETE} builder flow
+     * (e.g. {@code .userdata(CREATE_TIME, "").eliminate()}), where the value is
+     * ignored and only the key drives {@code removeUserdata}. Parsing it would
+     * fail before the eliminate path can apply its key-only semantics.
      */
     public static Object normalizeValue(String key, Object value) {
-        if (CREATE_TIME.equals(key) && value instanceof String) {
+        if (CREATE_TIME.equals(key) && value instanceof String &&
+            !((String) value).isEmpty()) {
             try {
                 return DateUtil.parse((String) value);
             } catch (RuntimeException e) {

--- a/hugegraph-server/hugegraph-core/src/main/java/org/apache/hugegraph/schema/Userdata.java
+++ b/hugegraph-server/hugegraph-core/src/main/java/org/apache/hugegraph/schema/Userdata.java
@@ -35,8 +35,22 @@ public class Userdata extends HashMap<String, Object> {
     }
 
     public Userdata(Map<String, Object> map) {
-        for (Map.Entry<String, Object> e : map.entrySet()) {
-            this.put(e.getKey(), normalizeValue(e.getKey(), e.getValue()));
+        this.putAll(map);
+    }
+
+    /**
+     * Normalizes the value before storing so the {@link #CREATE_TIME}-is-Date
+     * invariant holds regardless of how entries are added.
+     */
+    @Override
+    public Object put(String key, Object value) {
+        return super.put(key, normalizeValue(key, value));
+    }
+
+    @Override
+    public void putAll(Map<? extends String, ?> map) {
+        for (Map.Entry<? extends String, ?> e : map.entrySet()) {
+            this.put(e.getKey(), e.getValue());
         }
     }
 

--- a/hugegraph-server/hugegraph-core/src/main/java/org/apache/hugegraph/schema/Userdata.java
+++ b/hugegraph-server/hugegraph-core/src/main/java/org/apache/hugegraph/schema/Userdata.java
@@ -22,6 +22,7 @@ import java.util.Map;
 
 import org.apache.hugegraph.exception.NotAllowException;
 import org.apache.hugegraph.type.define.Action;
+import org.apache.hugegraph.util.DateUtil;
 
 public class Userdata extends HashMap<String, Object> {
 
@@ -34,7 +35,31 @@ public class Userdata extends HashMap<String, Object> {
     }
 
     public Userdata(Map<String, Object> map) {
-        this.putAll(map);
+        for (Map.Entry<String, Object> e : map.entrySet()) {
+            this.put(e.getKey(), normalizeValue(e.getKey(), e.getValue()));
+        }
+    }
+
+    /**
+     * Normalize internal userdata values whose runtime type can diverge from
+     * their serialized form. The only such key today is {@link #CREATE_TIME}:
+     * it is written as a {@link java.util.Date} but persisted as a formatted
+     * JSON string by the backend serializers, and Jackson cannot re-type a
+     * value to {@code Date} when the target is a raw {@code Map}. This method
+     * restores the original type after deserialization. Idempotent for values
+     * already of the expected type.
+     */
+    public static Object normalizeValue(String key, Object value) {
+        if (CREATE_TIME.equals(key) && value instanceof String) {
+            try {
+                return DateUtil.parse((String) value);
+            } catch (RuntimeException e) {
+                throw new IllegalArgumentException(String.format(
+                          "Invalid userdata '%s' value: '%s'",
+                          CREATE_TIME, value), e);
+            }
+        }
+        return value;
     }
 
     public static void check(Userdata userdata, Action action) {

--- a/hugegraph-server/hugegraph-test/src/main/java/org/apache/hugegraph/core/PropertyKeyCoreTest.java
+++ b/hugegraph-server/hugegraph-test/src/main/java/org/apache/hugegraph/core/PropertyKeyCoreTest.java
@@ -632,6 +632,26 @@ public class PropertyKeyCoreTest extends SchemaCoreTest {
     }
 
     @Test
+    public void testEliminatePropertyKeyCreateTimeUserdata() {
+        SchemaManager schema = graph().schema();
+
+        PropertyKey age = schema.propertyKey("age")
+                                .userdata("min", 0)
+                                .create();
+        Assert.assertEquals(2, age.userdata().size());
+        Assert.assertTrue(age.userdata().containsKey(Userdata.CREATE_TIME));
+
+        // "" is a key-only placeholder for eliminate; it must not be parsed
+        // as a date (regression: normalization on Userdata.put()).
+        age = schema.propertyKey("age")
+                    .userdata(Userdata.CREATE_TIME, "")
+                    .eliminate();
+        Assert.assertEquals(1, age.userdata().size());
+        Assert.assertFalse(age.userdata().containsKey(Userdata.CREATE_TIME));
+        Assert.assertEquals(0, age.userdata().get("min"));
+    }
+
+    @Test
     public void testUpdatePropertyKeyWithoutUserdata() {
         SchemaManager schema = graph().schema();
 

--- a/hugegraph-server/hugegraph-test/src/main/java/org/apache/hugegraph/unit/UnitTestSuite.java
+++ b/hugegraph-server/hugegraph-test/src/main/java/org/apache/hugegraph/unit/UnitTestSuite.java
@@ -43,6 +43,7 @@ import org.apache.hugegraph.unit.core.QueryTest;
 import org.apache.hugegraph.unit.core.RangeTest;
 import org.apache.hugegraph.unit.core.RolePermissionTest;
 import org.apache.hugegraph.unit.core.RowLockTest;
+import org.apache.hugegraph.unit.core.SchemaElementTest;
 import org.apache.hugegraph.unit.core.SecurityManagerTest;
 import org.apache.hugegraph.unit.core.SerialEnumTest;
 import org.apache.hugegraph.unit.core.SystemSchemaStoreTest;
@@ -64,6 +65,7 @@ import org.apache.hugegraph.unit.serializer.SerializerFactoryTest;
 import org.apache.hugegraph.unit.serializer.StoreSerializerTest;
 import org.apache.hugegraph.unit.serializer.TableBackendEntryTest;
 import org.apache.hugegraph.unit.serializer.TextBackendEntryTest;
+import org.apache.hugegraph.unit.serializer.TextSerializerTest;
 import org.apache.hugegraph.unit.store.RamIntObjectMapTest;
 import org.apache.hugegraph.unit.util.CompressUtilTest;
 import org.apache.hugegraph.unit.util.JsonUtilTest;
@@ -127,6 +129,7 @@ import org.junit.runners.Suite;
         SystemSchemaStoreTest.class,
         RoleElectionStateMachineTest.class,
         HugeGraphAuthProxyTest.class,
+        SchemaElementTest.class,
 
         /* serializer */
         BytesBufferTest.class,
@@ -137,6 +140,7 @@ import org.junit.runners.Suite;
         BinarySerializerTest.class,
         BinaryScatterSerializerTest.class,
         StoreSerializerTest.class,
+        TextSerializerTest.class,
 
         /* cassandra */
         CassandraTest.class,

--- a/hugegraph-server/hugegraph-test/src/main/java/org/apache/hugegraph/unit/core/SchemaElementTest.java
+++ b/hugegraph-server/hugegraph-test/src/main/java/org/apache/hugegraph/unit/core/SchemaElementTest.java
@@ -113,6 +113,33 @@ public class SchemaElementTest {
     }
 
     @Test
+    public void testUserdataConstructorLeavesOtherEntriesUntouched() {
+        Map<String, Object> map = new HashMap<>();
+        map.put("note", "2026-05-14 10:11:12.345");
+        map.put("count", 42);
+
+        Userdata userdata = new Userdata(map);
+
+        Assert.assertEquals("2026-05-14 10:11:12.345",
+                            userdata.get("note"));
+        Assert.assertEquals(42, userdata.get("count"));
+    }
+
+    @Test
+    public void testUserdataConstructorRejectsInvalidCreateTimeString() {
+        Map<String, Object> map = new HashMap<>();
+        map.put(Userdata.CREATE_TIME, "not-a-date");
+
+        Assert.assertThrows(IllegalArgumentException.class, () -> {
+            new Userdata(map);
+        }, e -> {
+            Assert.assertContains(Userdata.CREATE_TIME, e.getMessage());
+            Assert.assertContains("not-a-date", e.getMessage());
+            Assert.assertNotNull(e.getCause());
+        });
+    }
+
+    @Test
     public void testBulkSetterNormalizesCreateTimeAndKeepsOtherEntries() {
         SchemaElement schema = newSchema();
         Userdata bulk = new Userdata();

--- a/hugegraph-server/hugegraph-test/src/main/java/org/apache/hugegraph/unit/core/SchemaElementTest.java
+++ b/hugegraph-server/hugegraph-test/src/main/java/org/apache/hugegraph/unit/core/SchemaElementTest.java
@@ -18,12 +18,16 @@
 package org.apache.hugegraph.unit.core;
 
 import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
 
 import org.apache.hugegraph.backend.id.IdGenerator;
 import org.apache.hugegraph.schema.PropertyKey;
 import org.apache.hugegraph.schema.SchemaElement;
 import org.apache.hugegraph.schema.Userdata;
+import org.apache.hugegraph.schema.VertexLabel;
 import org.apache.hugegraph.testutil.Assert;
+import org.apache.hugegraph.unit.FakeObjects;
 import org.apache.hugegraph.util.DateUtil;
 import org.junit.Test;
 
@@ -68,6 +72,18 @@ public class SchemaElementTest {
         }, e -> {
             Assert.assertContains(Userdata.CREATE_TIME, e.getMessage());
             Assert.assertContains("not-a-date", e.getMessage());
+            Assert.assertNotNull(e.getCause());
+        });
+    }
+
+    @Test
+    public void testSingleSetterRejectsNullCreateTime() {
+        SchemaElement schema = newSchema();
+
+        Assert.assertThrows(IllegalArgumentException.class, () -> {
+            schema.userdata(Userdata.CREATE_TIME, null);
+        }, e -> {
+            Assert.assertContains("userdata value", e.getMessage());
         });
     }
 
@@ -80,6 +96,20 @@ public class SchemaElementTest {
         Object value = schema.userdata().get("note");
         Assert.assertTrue(value instanceof String);
         Assert.assertEquals("2026-05-14 10:11:12.345", value);
+    }
+
+    @Test
+    public void testUserdataConstructorNormalizesCreateTimeString() {
+        String formatted = "2026-05-14 10:11:12.345";
+        Map<String, Object> map = new HashMap<>();
+        map.put(Userdata.CREATE_TIME, formatted);
+
+        Userdata userdata = new Userdata(map);
+
+        Object createTime = userdata.get(Userdata.CREATE_TIME);
+        Assert.assertTrue(createTime instanceof Date);
+        Assert.assertEquals(DateUtil.parse(formatted, DATE_FORMAT),
+                            createTime);
     }
 
     @Test
@@ -110,6 +140,26 @@ public class SchemaElementTest {
         schema.userdata(bulk);
 
         Assert.assertSame(now, schema.userdata().get(Userdata.CREATE_TIME));
+    }
+
+    @Test
+    public void testVertexLabelFromMapNormalizesCreateTimeString() {
+        String formatted = "2026-05-14 10:11:12.345";
+        Map<String, Object> userdata = new HashMap<>();
+        userdata.put(Userdata.CREATE_TIME, formatted);
+
+        Map<String, Object> map = new HashMap<>();
+        map.put(VertexLabel.P.ID, 1);
+        map.put(VertexLabel.P.NAME, "person");
+        map.put(VertexLabel.P.USERDATA, userdata);
+
+        VertexLabel vertexLabel = VertexLabel.fromMap(map,
+                                                      new FakeObjects().graph());
+
+        Object createTime = vertexLabel.userdata().get(Userdata.CREATE_TIME);
+        Assert.assertTrue(createTime instanceof Date);
+        Assert.assertEquals(DateUtil.parse(formatted, DATE_FORMAT),
+                            createTime);
     }
 
     @Test

--- a/hugegraph-server/hugegraph-test/src/main/java/org/apache/hugegraph/unit/core/SchemaElementTest.java
+++ b/hugegraph-server/hugegraph-test/src/main/java/org/apache/hugegraph/unit/core/SchemaElementTest.java
@@ -33,8 +33,6 @@ import org.junit.Test;
 
 public class SchemaElementTest {
 
-    private static final String DATE_FORMAT = "yyyy-MM-dd HH:mm:ss.SSS";
-
     private static SchemaElement newSchema() {
         return new PropertyKey(null, IdGenerator.of(1L), "test");
     }
@@ -50,7 +48,7 @@ public class SchemaElementTest {
         Assert.assertTrue("CREATE_TIME should be a Date, was " +
                           (value == null ? "null" : value.getClass()),
                           value instanceof Date);
-        Assert.assertEquals(DateUtil.parse(formatted, DATE_FORMAT), value);
+        Assert.assertEquals(DateUtil.parse(formatted), value);
     }
 
     @Test
@@ -108,7 +106,7 @@ public class SchemaElementTest {
 
         Object createTime = userdata.get(Userdata.CREATE_TIME);
         Assert.assertTrue(createTime instanceof Date);
-        Assert.assertEquals(DateUtil.parse(formatted, DATE_FORMAT),
+        Assert.assertEquals(DateUtil.parse(formatted),
                             createTime);
     }
 
@@ -152,7 +150,7 @@ public class SchemaElementTest {
 
         Object createTime = schema.userdata().get(Userdata.CREATE_TIME);
         Assert.assertTrue(createTime instanceof Date);
-        Assert.assertEquals(DateUtil.parse(formatted, DATE_FORMAT), createTime);
+        Assert.assertEquals(DateUtil.parse(formatted), createTime);
         Assert.assertEquals("hello", schema.userdata().get("note"));
         Assert.assertEquals(42, schema.userdata().get("count"));
     }
@@ -185,7 +183,7 @@ public class SchemaElementTest {
 
         Object createTime = vertexLabel.userdata().get(Userdata.CREATE_TIME);
         Assert.assertTrue(createTime instanceof Date);
-        Assert.assertEquals(DateUtil.parse(formatted, DATE_FORMAT),
+        Assert.assertEquals(DateUtil.parse(formatted),
                             createTime);
     }
 

--- a/hugegraph-server/hugegraph-test/src/main/java/org/apache/hugegraph/unit/core/SchemaElementTest.java
+++ b/hugegraph-server/hugegraph-test/src/main/java/org/apache/hugegraph/unit/core/SchemaElementTest.java
@@ -86,6 +86,18 @@ public class SchemaElementTest {
     }
 
     @Test
+    public void testSingleSetterPassesThroughBlankCreateTime() {
+        // "" is the key-only placeholder for the eliminate()/DELETE builder
+        // flow (.userdata(CREATE_TIME, "").eliminate()); it must not be parsed.
+        SchemaElement schema = newSchema();
+
+        schema.userdata(Userdata.CREATE_TIME, "");
+
+        Object value = schema.userdata().get(Userdata.CREATE_TIME);
+        Assert.assertEquals("", value);
+    }
+
+    @Test
     public void testSingleSetterLeavesOtherStringKeysUntouched() {
         SchemaElement schema = newSchema();
 

--- a/hugegraph-server/hugegraph-test/src/main/java/org/apache/hugegraph/unit/core/SchemaElementTest.java
+++ b/hugegraph-server/hugegraph-test/src/main/java/org/apache/hugegraph/unit/core/SchemaElementTest.java
@@ -1,0 +1,125 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hugegraph.unit.core;
+
+import java.util.Date;
+
+import org.apache.hugegraph.backend.id.IdGenerator;
+import org.apache.hugegraph.schema.PropertyKey;
+import org.apache.hugegraph.schema.SchemaElement;
+import org.apache.hugegraph.schema.Userdata;
+import org.apache.hugegraph.testutil.Assert;
+import org.apache.hugegraph.util.DateUtil;
+import org.junit.Test;
+
+public class SchemaElementTest {
+
+    private static final String DATE_FORMAT = "yyyy-MM-dd HH:mm:ss.SSS";
+
+    private static SchemaElement newSchema() {
+        return new PropertyKey(null, IdGenerator.of(1L), "test");
+    }
+
+    @Test
+    public void testSingleSetterNormalizesCreateTimeStringToDate() {
+        SchemaElement schema = newSchema();
+        String formatted = "2026-05-14 10:11:12.345";
+
+        schema.userdata(Userdata.CREATE_TIME, formatted);
+
+        Object value = schema.userdata().get(Userdata.CREATE_TIME);
+        Assert.assertTrue("CREATE_TIME should be a Date, was " +
+                          (value == null ? "null" : value.getClass()),
+                          value instanceof Date);
+        Assert.assertEquals(DateUtil.parse(formatted, DATE_FORMAT), value);
+    }
+
+    @Test
+    public void testSingleSetterKeepsCreateTimeDateUnchanged() {
+        SchemaElement schema = newSchema();
+        Date now = DateUtil.now();
+
+        schema.userdata(Userdata.CREATE_TIME, now);
+
+        Assert.assertSame(now, schema.userdata().get(Userdata.CREATE_TIME));
+    }
+
+    @Test
+    public void testSingleSetterRejectsInvalidCreateTimeString() {
+        SchemaElement schema = newSchema();
+
+        Assert.assertThrows(IllegalArgumentException.class, () -> {
+            schema.userdata(Userdata.CREATE_TIME, "not-a-date");
+        }, e -> {
+            Assert.assertContains(Userdata.CREATE_TIME, e.getMessage());
+            Assert.assertContains("not-a-date", e.getMessage());
+        });
+    }
+
+    @Test
+    public void testSingleSetterLeavesOtherStringKeysUntouched() {
+        SchemaElement schema = newSchema();
+
+        schema.userdata("note", "2026-05-14 10:11:12.345");
+
+        Object value = schema.userdata().get("note");
+        Assert.assertTrue(value instanceof String);
+        Assert.assertEquals("2026-05-14 10:11:12.345", value);
+    }
+
+    @Test
+    public void testBulkSetterNormalizesCreateTimeAndKeepsOtherEntries() {
+        SchemaElement schema = newSchema();
+        Userdata bulk = new Userdata();
+        String formatted = "2026-05-14 10:11:12.345";
+        bulk.put(Userdata.CREATE_TIME, formatted);
+        bulk.put("note", "hello");
+        bulk.put("count", 42);
+
+        schema.userdata(bulk);
+
+        Object createTime = schema.userdata().get(Userdata.CREATE_TIME);
+        Assert.assertTrue(createTime instanceof Date);
+        Assert.assertEquals(DateUtil.parse(formatted, DATE_FORMAT), createTime);
+        Assert.assertEquals("hello", schema.userdata().get("note"));
+        Assert.assertEquals(42, schema.userdata().get("count"));
+    }
+
+    @Test
+    public void testBulkSetterKeepsCreateTimeDateUnchanged() {
+        SchemaElement schema = newSchema();
+        Userdata bulk = new Userdata();
+        Date now = DateUtil.now();
+        bulk.put(Userdata.CREATE_TIME, now);
+
+        schema.userdata(bulk);
+
+        Assert.assertSame(now, schema.userdata().get(Userdata.CREATE_TIME));
+    }
+
+    @Test
+    public void testBulkSetterRejectsNullUserdata() {
+        SchemaElement schema = newSchema();
+
+        Assert.assertThrows(IllegalArgumentException.class, () -> {
+            schema.userdata(null);
+        }, e -> {
+            Assert.assertContains("userdata", e.getMessage());
+        });
+    }
+}

--- a/hugegraph-server/hugegraph-test/src/main/java/org/apache/hugegraph/unit/serializer/BinarySerializerTest.java
+++ b/hugegraph-server/hugegraph-test/src/main/java/org/apache/hugegraph/unit/serializer/BinarySerializerTest.java
@@ -17,15 +17,21 @@
 
 package org.apache.hugegraph.unit.serializer;
 
+import java.util.Date;
+
+import org.apache.hugegraph.backend.id.IdGenerator;
 import org.apache.hugegraph.backend.serializer.BinarySerializer;
 import org.apache.hugegraph.backend.store.BackendEntry;
 import org.apache.hugegraph.config.HugeConfig;
+import org.apache.hugegraph.schema.PropertyKey;
+import org.apache.hugegraph.schema.Userdata;
 import org.apache.hugegraph.structure.HugeEdge;
 import org.apache.hugegraph.structure.HugeVertex;
 import org.apache.hugegraph.testutil.Assert;
 import org.apache.hugegraph.testutil.Whitebox;
 import org.apache.hugegraph.unit.BaseUnitTest;
 import org.apache.hugegraph.unit.FakeObjects;
+import org.apache.hugegraph.util.DateUtil;
 import org.junit.Test;
 
 public class BinarySerializerTest extends BaseUnitTest {
@@ -103,6 +109,28 @@ public class BinarySerializerTest extends BaseUnitTest {
         Assert.assertEquals(0, entry3.columnsSize());
 
         Assert.assertNull(ser.readVertex(edge.graph(), null));
+    }
+
+    @Test
+    public void testPropertyKeyUserdataCreateTimeRoundTripsAsDate() {
+        HugeConfig config = FakeObjects.newConfig();
+        BinarySerializer ser = new BinarySerializer(config);
+
+        FakeObjects objects = new FakeObjects();
+        PropertyKey original = objects.newPropertyKey(IdGenerator.of(1L),
+                                                      "name");
+        Date created = DateUtil.parse("2026-05-14 10:11:12.345",
+                                      "yyyy-MM-dd HH:mm:ss.SSS");
+        original.userdata(Userdata.CREATE_TIME, created);
+
+        BackendEntry entry = ser.writePropertyKey(original);
+        PropertyKey reloaded = ser.readPropertyKey(objects.graph(), entry);
+
+        Object value = reloaded.userdata().get(Userdata.CREATE_TIME);
+        Assert.assertTrue("CREATE_TIME should be a Date after round-trip, " +
+                          "was " + (value == null ? "null" : value.getClass()),
+                          value instanceof Date);
+        Assert.assertEquals(created, value);
     }
 
     @Test

--- a/hugegraph-server/hugegraph-test/src/main/java/org/apache/hugegraph/unit/serializer/BinarySerializerTest.java
+++ b/hugegraph-server/hugegraph-test/src/main/java/org/apache/hugegraph/unit/serializer/BinarySerializerTest.java
@@ -119,8 +119,7 @@ public class BinarySerializerTest extends BaseUnitTest {
         FakeObjects objects = new FakeObjects();
         PropertyKey original = objects.newPropertyKey(IdGenerator.of(1L),
                                                       "name");
-        Date created = DateUtil.parse("2026-05-14 10:11:12.345",
-                                      "yyyy-MM-dd HH:mm:ss.SSS");
+        Date created = DateUtil.parse("2026-05-14 10:11:12.345");
         original.userdata(Userdata.CREATE_TIME, created);
 
         BackendEntry entry = ser.writePropertyKey(original);

--- a/hugegraph-server/hugegraph-test/src/main/java/org/apache/hugegraph/unit/serializer/TextSerializerTest.java
+++ b/hugegraph-server/hugegraph-test/src/main/java/org/apache/hugegraph/unit/serializer/TextSerializerTest.java
@@ -33,8 +33,6 @@ import org.junit.Test;
 
 public class TextSerializerTest extends BaseUnitTest {
 
-    private static final String DATE_FORMAT = "yyyy-MM-dd HH:mm:ss.SSS";
-
     @Test
     public void testPropertyKeyUserdataCreateTimeRoundTripsAsDate() {
         HugeConfig config = FakeObjects.newConfig();
@@ -43,7 +41,7 @@ public class TextSerializerTest extends BaseUnitTest {
         FakeObjects objects = new FakeObjects();
         PropertyKey original = objects.newPropertyKey(IdGenerator.of(1L),
                                                       "name");
-        Date created = DateUtil.parse("2026-05-14 10:11:12.345", DATE_FORMAT);
+        Date created = DateUtil.parse("2026-05-14 10:11:12.345");
         original.userdata(Userdata.CREATE_TIME, created);
 
         BackendEntry entry = ser.writePropertyKey(original);

--- a/hugegraph-server/hugegraph-test/src/main/java/org/apache/hugegraph/unit/serializer/TextSerializerTest.java
+++ b/hugegraph-server/hugegraph-test/src/main/java/org/apache/hugegraph/unit/serializer/TextSerializerTest.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hugegraph.unit.serializer;
+
+import java.util.Date;
+
+import org.apache.hugegraph.backend.id.IdGenerator;
+import org.apache.hugegraph.backend.serializer.TextSerializer;
+import org.apache.hugegraph.backend.store.BackendEntry;
+import org.apache.hugegraph.config.HugeConfig;
+import org.apache.hugegraph.schema.PropertyKey;
+import org.apache.hugegraph.schema.Userdata;
+import org.apache.hugegraph.testutil.Assert;
+import org.apache.hugegraph.unit.BaseUnitTest;
+import org.apache.hugegraph.unit.FakeObjects;
+import org.apache.hugegraph.util.DateUtil;
+import org.junit.Test;
+
+public class TextSerializerTest extends BaseUnitTest {
+
+    private static final String DATE_FORMAT = "yyyy-MM-dd HH:mm:ss.SSS";
+
+    @Test
+    public void testPropertyKeyUserdataCreateTimeRoundTripsAsDate() {
+        HugeConfig config = FakeObjects.newConfig();
+        TextSerializer ser = new TextSerializer(config);
+
+        FakeObjects objects = new FakeObjects();
+        PropertyKey original = objects.newPropertyKey(IdGenerator.of(1L),
+                                                      "name");
+        Date created = DateUtil.parse("2026-05-14 10:11:12.345", DATE_FORMAT);
+        original.userdata(Userdata.CREATE_TIME, created);
+
+        BackendEntry entry = ser.writePropertyKey(original);
+        PropertyKey reloaded = ser.readPropertyKey(objects.graph(), entry);
+
+        Object value = reloaded.userdata().get(Userdata.CREATE_TIME);
+        Assert.assertTrue("CREATE_TIME should be a Date after round-trip, " +
+                          "was " + (value == null ? "null" : value.getClass()),
+                          value instanceof Date);
+        Assert.assertEquals(created, value);
+    }
+}


### PR DESCRIPTION
- close #3013

  `Userdata.CREATE_TIME` (`"~create_time"`) is written as `java.util.Date`
  by `SchemaTransaction.setCreateTimeIfNeeded()`, then persisted through backend
  serializers as JSON. On reload, userdata is deserialized through raw
  `Map.class` paths, so Jackson cannot restore the value type and
  `schemaElement.userdata().get(Userdata.CREATE_TIME)` can come back as `String`.

  That breaks callers and existing tests that expect `~create_time` to keep the
  server-side `Date` contract after a schema is reloaded from backend storage.

  ## Main Changes

  - Added `Userdata.normalizeValue(key, value)` as a static helper on the `Userdata` class.
    - Converts `Userdata.CREATE_TIME` string values back with `DateUtil.parse(...)`.
    - Leaves existing `Date` values and all other userdata keys unchanged.
    - Throws a clearer `IllegalArgumentException` if a `~create_time` string is invalid.

  - Routed both userdata setters through `Userdata.put(key, value)`, which applies
    normalization before storing:
    - `userdata(String, Object)` covers serializer reload paths such as
      `TextSerializer`, `BinarySerializer`, `MysqlSerializer`, and
      `CassandraSerializer`.
    - `userdata(Userdata)` covers schema `fromMap()` hydration paths for
      `PropertyKey`, `VertexLabel`, `EdgeLabel`, and `IndexLabel`.

  - Added a null check to `userdata(Userdata)` for consistent argument validation.

  - Added regression coverage for schema userdata normalization and serializer
    round trips.

  This PR is intentionally limited to the server-side `SchemaElement`. The mirror
  class in `hugegraph-struct` has a similar userdata shape and can be handled in a
  separate follow-up PR.

  ## Verifying these changes

  - [ ] Trivial rework / code cleanup without any test coverage. (No Need)
  - [ ] Already covered by existing tests, such as *(please modify tests here)*.
  - [x] Need tests and can be verified as follows:
      - `SchemaElementTest` covers single-key normalization, bulk normalization,
        idempotency for `Date`, invalid `~create_time` strings, null bulk userdata,
        and non-`CREATE_TIME` keys.
      - `TextSerializerTest#testPropertyKeyUserdataCreateTimeRoundTripsAsDate`
        verifies the text serializer schema round trip keeps `CREATE_TIME` as `Date`.
      - `BinarySerializerTest#testPropertyKeyUserdataCreateTimeRoundTripsAsDate`
        verifies the binary serializer schema round trip keeps `CREATE_TIME` as `Date`.
      - The new test class is registered in `UnitTestSuite`.

  ## Does this PR potentially affect the following parts?

  - [ ]  Dependencies (add/update license (https://hugegraph.apache.org/docs/contribution-guidelines/contribute/#321-check-licenses) info & ../install-dist/scripts/dependency/regenerate_known_dependencies.sh)
  - [ ]  Modify configurations
  - [ ]  The public API
  - [ ]  Other affects (typed here)
  - [x]  Nope

  The public SchemaElement.userdata(...) signatures are unchanged. The behavior change is limited to internal userdata    normalization for Userdata.CREATE_TIME, handled via `Userdata.normalizeValue` / `Userdata.put()`.

  ## Documentation Status

  - [ ]  Doc - TODO
  - [ ]  Doc - Done
  - [x]  Doc - No Need

## Notes

- This PR fixes the server-side schema reload path for `Userdata.CREATE_TIME` (`~create_time`) only.
- `~create_time` is a server-reserved userdata key; valid string values are normalized back to `java.util.Date`, while malformed values now fail with `IllegalArgumentException`.
- Follow-up: #3028  tracks preserving typed `Userdata.DEFAULT_VALUE` (`~default_value`) reloads and checking the same raw userdata deserialization gap in `hugegraph-struct`.


