### PR TITLE
fix(server): different graph name share the same backend

### DIFF
--- a/hugegraph-server/hugegraph-core/src/main/java/org/apache/hugegraph/task/ServerInfoManager.java
+++ b/hugegraph-server/hugegraph-core/src/main/java/org/apache/hugegraph/task/ServerInfoManager.java
@@ -105,7 +105,9 @@ public class ServerInfoManager {
     public synchronized void initServerInfo(GlobalMasterInfo nodeInfo) {
         E.checkArgument(nodeInfo != null, "The global node info can't be null");
 
-        Id serverId = nodeInfo.nodeId();
+        this.globalNodeInfo = nodeInfo;
+
+        Id serverId = this.selfNodeId();
         HugeServerInfo existed = this.serverInfo(serverId);
         if (existed != null && existed.alive()) {
             final long now = DateUtil.now().getTime();
@@ -137,8 +139,6 @@ public class ServerInfoManager {
                 }
             } while (page != null);
         }
-
-        this.globalNodeInfo = nodeInfo;
 
         // TODO: save ServerInfo to AuthServer
         this.saveServerInfo(this.selfNodeId(), this.selfNodeRole());

--- a/hugegraph-server/hugegraph-core/src/main/java/org/apache/hugegraph/task/ServerInfoManager.java
+++ b/hugegraph-server/hugegraph-core/src/main/java/org/apache/hugegraph/task/ServerInfoManager.java
@@ -29,6 +29,7 @@ import org.apache.hugegraph.HugeException;
 import org.apache.hugegraph.HugeGraph;
 import org.apache.hugegraph.HugeGraphParams;
 import org.apache.hugegraph.backend.id.Id;
+import org.apache.hugegraph.backend.id.IdGenerator;
 import org.apache.hugegraph.backend.page.PageInfo;
 import org.apache.hugegraph.backend.query.Condition;
 import org.apache.hugegraph.backend.query.ConditionQuery;
@@ -162,7 +163,9 @@ public class ServerInfoManager {
         if (this.globalNodeInfo == null) {
             return null;
         }
-        return this.globalNodeInfo.nodeId();
+        // Scope server id to graph to avoid cross-graph collision
+        return IdGenerator.of(this.graph.spaceGraphName() + "/" +
+                             this.globalNodeInfo.nodeId().asString());
     }
 
     public NodeRole selfNodeRole() {

--- a/hugegraph-server/hugegraph-test/src/main/java/org/apache/hugegraph/unit/UnitTestSuite.java
+++ b/hugegraph-server/hugegraph-test/src/main/java/org/apache/hugegraph/unit/UnitTestSuite.java
@@ -45,6 +45,7 @@ import org.apache.hugegraph.unit.core.RolePermissionTest;
 import org.apache.hugegraph.unit.core.RowLockTest;
 import org.apache.hugegraph.unit.core.SecurityManagerTest;
 import org.apache.hugegraph.unit.core.SerialEnumTest;
+import org.apache.hugegraph.unit.core.ServerInfoManagerTest;
 import org.apache.hugegraph.unit.core.SystemSchemaStoreTest;
 import org.apache.hugegraph.unit.core.TraversalUtilTest;
 import org.apache.hugegraph.unit.id.EdgeIdTest;
@@ -125,6 +126,7 @@ import org.junit.runners.Suite;
         TraversalUtilTest.class,
         PageStateTest.class,
         SystemSchemaStoreTest.class,
+        ServerInfoManagerTest.class,
         RoleElectionStateMachineTest.class,
         HugeGraphAuthProxyTest.class,
 

--- a/hugegraph-server/hugegraph-test/src/main/java/org/apache/hugegraph/unit/core/ServerInfoManagerTest.java
+++ b/hugegraph-server/hugegraph-test/src/main/java/org/apache/hugegraph/unit/core/ServerInfoManagerTest.java
@@ -1,0 +1,76 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hugegraph.unit.core;
+
+import java.util.concurrent.ExecutorService;
+
+import org.apache.hugegraph.HugeGraphParams;
+import org.apache.hugegraph.backend.id.Id;
+import org.apache.hugegraph.masterelection.GlobalMasterInfo;
+import org.apache.hugegraph.task.ServerInfoManager;
+import org.apache.hugegraph.testutil.Assert;
+import org.apache.hugegraph.testutil.Whitebox;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+public class ServerInfoManagerTest {
+
+    private ServerInfoManager sysGraphManager;
+    private ServerInfoManager hugegraphManager;
+
+    @Before
+    public void setup() {
+        HugeGraphParams sysGraphParams = Mockito.mock(HugeGraphParams.class);
+        Mockito.when(sysGraphParams.spaceGraphName())
+               .thenReturn("DEFAULT-~sys_graph");
+
+        HugeGraphParams hugegraphParams = Mockito.mock(HugeGraphParams.class);
+        Mockito.when(hugegraphParams.spaceGraphName())
+               .thenReturn("DEFAULT-hugegraph");
+
+        ExecutorService executor = Mockito.mock(ExecutorService.class);
+
+        this.sysGraphManager = new ServerInfoManager(sysGraphParams, executor);
+        this.hugegraphManager = new ServerInfoManager(hugegraphParams, executor);
+    }
+
+    @Test
+    public void testSelfNodeIdScopedByGraphWithSameNodeId() {
+        GlobalMasterInfo nodeInfo = GlobalMasterInfo.master("server-1");
+
+        Whitebox.setInternalState(this.sysGraphManager,
+                                  "globalNodeInfo", nodeInfo);
+        Whitebox.setInternalState(this.hugegraphManager,
+                                  "globalNodeInfo", nodeInfo);
+
+        Id sysGraphNodeId = this.sysGraphManager.selfNodeId();
+        Id hugegraphNodeId = this.hugegraphManager.selfNodeId();
+
+        Assert.assertEquals("DEFAULT-~sys_graph/server-1",
+                            sysGraphNodeId.asString());
+        Assert.assertEquals("DEFAULT-hugegraph/server-1",
+                            hugegraphNodeId.asString());
+        Assert.assertFalse(sysGraphNodeId.equals(hugegraphNodeId));
+    }
+
+    @Test
+    public void testSelfNodeIdReturnsNullWhenNotInitialized() {
+        Assert.assertNull(this.sysGraphManager.selfNodeId());
+    }
+}


### PR DESCRIPTION
<!-- 
  Thank you very much for contributing to Apache HugeGraph, we are happy that you want to help us improve it!

  Here are some tips for you:
    1. If this is your first time, please read the [contributing guidelines](https://github.com/apache/hugegraph/blob/master/CONTRIBUTING.md)

    2. If a PR fix/close an issue, type the message "close xxx" (xxx is the link of related 
issue) in the content, GitHub will auto link it (Required)

    3. Name the PR title in "Google Commit Format", start with "feat | fix | perf | refactor | doc | chore", 
      such like: "feat(core): support the PageRank algorithm" or "fix: wrong break in the compute loop" (module is optional)
      skip it if you are unsure about which is the best component.

    4. One PR address one issue, better not to mix up multiple issues.

    5. Put an `x` in the `[ ]` to mark the item as CHECKED. `[x]` (or click it directly after 
published)
-->

## Purpose of the PR

- close #3007 

<!--
Please explain more context in this section, clarify why the changes are needed. 
e.g:
- If you propose a new API, clarify the use case for a new API.
- If you fix a bug, you can clarify why it is a bug, and should be associated with an issue.
-->

During backend initialization, the server creates two graphs — ~sys_graph and hugegraph (default) — that share the same store backend. This leads to a key collision:

- ~sys_graph writes server node info with id server-1 
- ~sys_graph reads back server-1 successfully 
- hugegraph writes server node info with the same id server-1 
- hugegraph reads from the shared table — retrieves ~sys_graph's record instead → type mismatch → parse error

## Main Changes

Change `ServerInfoManager.selfNodeId()` which returns "server-1" previously to "{graphname}/server-1"

## Upgrade impact

This change namespaces the server id by graph name, so old unfinished tasks in the non-PD local scheduler may still reference the previous bare server id, for example `server-1`.

Those historical tasks can remain visible, but they may not be restored or cancelled by the new namespaced server id after upgrade. The impact is limited to unfinished local-scheduler tasks that already existed before upgrading; newly scheduled tasks use the new namespaced id. To avoid this compatibility edge case, finish or cancel pending local tasks before upgrading.

## Verifying these changes

<!-- Please pick the proper options below -->

- [ ] Trivial rework / code cleanup without any test coverage. (No Need)
- [x] Already covered by existing tests, such as *(please modify tests here)*.
- [ ] Need tests and can be verified as follows:
    - xxx

## Does this PR potentially affect the following parts?

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ]  Dependencies ([add/update license](https://hugegraph.apache.org/docs/contribution-guidelines/contribute/#321-check-licenses) info & [regenerate_known_dependencies.sh](../install-dist/scripts/dependency/regenerate_known_dependencies.sh)) <!-- Don't forget to add/update the info in "LICENSE" & "NOTICE" files (both in root & dist module) -->
- [ ]  Modify configurations
- [ ]  The public API
- [ ]  Other affects (typed here)
- [x]  Nope


## Documentation Status

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ]  `Doc - TODO` <!-- Your PR changes impact docs and you will update later -->
- [ ]  `Doc - Done` <!-- Related docs have been already added or updated -->
- [x]  `Doc - No Need` <!-- Your PR changes don't impact/need docs -->
