### PR TITLE
[Feature] Unify REST API response format for server, pd and store modules #2975

### DIFF
--- a/hugegraph-commons/hugegraph-common/src/main/java/org/apache/hugegraph/rest/response/ApiResponse.java
+++ b/hugegraph-commons/hugegraph-common/src/main/java/org/apache/hugegraph/rest/response/ApiResponse.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with this
+ * work for additional information regarding copyright ownership. The ASF
+ * licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.hugegraph.rest.response;
+
+public class ApiResponse<T> {
+    private int code;
+    private String message;
+    private T data;
+    private String status;    
+    
+    public ApiResponse(){
+        
+    }
+
+    public ApiResponse(int code, String message, T data, String status) {
+        this.code = code;
+        this.message = message;
+        this.data = data;
+        this.status = status;
+    }
+
+    public int getCode() {
+        return code;
+    }
+
+    public void setCode(int code) {
+        this.code = code;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+
+    public void setMessage(String message) {
+        this.message = message;
+    }
+
+    public T getData() {
+        return data;
+    }
+
+    public void setData(T data) {
+        this.data = data;
+    }
+
+    public String getStatus() {
+        return status;
+    }
+
+    public void setStatus(String status) {
+        this.status = status;
+    }
+    
+}

--- a/hugegraph-pd/hg-pd-service/pom.xml
+++ b/hugegraph-pd/hg-pd-service/pom.xml
@@ -175,6 +175,7 @@
                             <mainClass>
                                 org.apache.hugegraph.pd.boot.HugePDServer
                             </mainClass>
+                            <classifier>exec</classifier>
                         </configuration>
                         <!-- should configure explicitly without spring-boot-starter-parent -->
                         <goals>

--- a/hugegraph-pd/hg-pd-service/src/main/java/org/apache/hugegraph/pd/rest/exceptionshandler/GenericExceptionMapper.java
+++ b/hugegraph-pd/hg-pd-service/src/main/java/org/apache/hugegraph/pd/rest/exceptionshandler/GenericExceptionMapper.java
@@ -17,7 +17,6 @@
 
 package org.apache.hugegraph.pd.rest.exceptionshandler;
 
-import org.apache.hugegraph.pd.common.PDException;
 import org.apache.hugegraph.rest.response.ApiResponse;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -27,42 +26,23 @@ import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
 @RestControllerAdvice
-public class PDExceptionMapper {
+public class GenericExceptionMapper {
 
-     private static final Logger logger = LogManager.getLogger(PDExceptionMapper.class);
+    private static final Logger logger = LogManager.getLogger(GenericExceptionMapper.class);
 
-    @ExceptionHandler(PDException.class)
-    public ResponseEntity<ApiResponse<Object>> toResponse(PDException exception) {
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ApiResponse<Object>>handleGenericException(Exception exception) {
 
-         logger.error(exception.getMessage(), exception);
+        HttpStatus springStatus = HttpStatus.INTERNAL_SERVER_ERROR;
 
-        HttpStatus status = resolveStatus(exception.getErrorCode());
-        String reasonPhrase = status.getReasonPhrase();
-
+        logger.error("Unexpected error ", exception);
+        
         ApiResponse<Object> apiResponse = new ApiResponse<>(
-                exception.getErrorCode(),
-                exception.getMessage(),
+                500,
+                "An unexpected error occurred",
                 null,
-                reasonPhrase);
+                springStatus.getReasonPhrase());
 
-        return ResponseEntity
-                .status(status)
-                .body(apiResponse);
-
-    }
-
-    private HttpStatus resolveStatus(int code) {
-        try {
-            return HttpStatus.valueOf(code);
-        } catch (Exception e) {
-
-            if (code >= 400 && code < 500) {
-                return HttpStatus.BAD_REQUEST;
-            }
-            if (code >= 500 && code < 600) {
-                return HttpStatus.INTERNAL_SERVER_ERROR;
-            }
-            return HttpStatus.INTERNAL_SERVER_ERROR;
-        }
+        return ResponseEntity.status(springStatus).body(apiResponse);
     }
 }

--- a/hugegraph-pd/hg-pd-service/src/main/java/org/apache/hugegraph/pd/rest/exceptionshandler/PDExceptionMapper.java
+++ b/hugegraph-pd/hg-pd-service/src/main/java/org/apache/hugegraph/pd/rest/exceptionshandler/PDExceptionMapper.java
@@ -53,15 +53,17 @@ public class PDExceptionMapper {
 
     private HttpStatus resolveStatus(int code) {
         try {
+            // Tenta mapear códigos HTTP exatos (ex: 400, 404, 500)
             return HttpStatus.valueOf(code);
-        } catch (Exception e) {
+        } catch (IllegalArgumentException e) {
+            // Se falhar (ex: 4001), extraímos o primeiro dígito para descobrir a família do erro
+            String codeStr = String.valueOf(code);
 
-            if (code >= 400 && code < 500) {
-                return HttpStatus.BAD_REQUEST;
+            if (codeStr.startsWith("4")) {
+                return HttpStatus.BAD_REQUEST; // Erros de cliente -> 400
             }
-            if (code >= 500 && code < 600) {
-                return HttpStatus.INTERNAL_SERVER_ERROR;
-            }
+
+            // Tudo que for da família 5000 ou não reconhecido vira Erro de Servidor -> 500
             return HttpStatus.INTERNAL_SERVER_ERROR;
         }
     }

--- a/hugegraph-pd/hg-pd-service/src/main/java/org/apache/hugegraph/pd/rest/exceptionshandler/PDExceptionMapper.java
+++ b/hugegraph-pd/hg-pd-service/src/main/java/org/apache/hugegraph/pd/rest/exceptionshandler/PDExceptionMapper.java
@@ -1,0 +1,50 @@
+package org.apache.hugegraph.pd.rest.exceptionshandler;
+
+import org.apache.hugegraph.pd.common.PDException;
+import org.apache.hugegraph.rest.response.ApiResponse;
+
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.ext.ExceptionMapper;
+import jakarta.ws.rs.ext.Provider;
+
+@Provider
+public class PDExceptionMapper implements ExceptionMapper<PDException> {
+
+    @Override
+    public Response toResponse(PDException exception) {
+
+        Response.Status status = getStatusCode(exception.getErrorCode());
+        String reasonPhrase = status.getReasonPhrase();
+
+        ApiResponse<Object> apiResponse = new ApiResponse<>(
+                exception.getErrorCode(),
+                exception.getMessage(),
+                null,
+                reasonPhrase);
+
+        return Response.status(status)
+                .type(MediaType.APPLICATION_JSON)
+                .entity(apiResponse)
+                .build();
+    }
+
+    private Response.Status getStatusCode(int code) {
+        
+        Response.Status status = Response.Status.fromStatusCode(code);
+
+        if (status != null) {
+            return status;
+        }
+
+        if (code >= 400 && code < 500) {
+            return Response.Status.BAD_REQUEST;
+        }
+
+        if (code >= 500 && code < 600) {
+            return Response.Status.INTERNAL_SERVER_ERROR;
+        }
+
+        return Response.Status.INTERNAL_SERVER_ERROR;
+    }
+}

--- a/hugegraph-pd/hg-pd-test/src/main/java/org/apache/hugegraph/pd/rest/exceptions/PDExceptionMapperTest.java
+++ b/hugegraph-pd/hg-pd-test/src/main/java/org/apache/hugegraph/pd/rest/exceptions/PDExceptionMapperTest.java
@@ -1,0 +1,75 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hugegraph.pd.rest.exceptions;
+
+import org.junit.Test;
+import org.junit.Assert;
+
+import org.springframework.http.ResponseEntity;
+
+import org.apache.hugegraph.pd.common.PDException;
+import org.apache.hugegraph.pd.rest.exceptionshandler.GenericExceptionMapper;
+import org.apache.hugegraph.pd.rest.exceptionshandler.PDExceptionMapper;
+import org.apache.hugegraph.rest.response.ApiResponse;
+
+public class PDExceptionMapperTest {
+
+    @Test
+    public void testPDExceptionMapping() {
+        PDExceptionMapper mapper = new PDExceptionMapper();
+
+        PDException exception = new PDException(4001, "test error");
+
+        ResponseEntity<ApiResponse<Object>> response =
+                mapper.toResponse(exception);
+
+        Assert.assertEquals(400, response.getStatusCodeValue());
+        Assert.assertEquals(4001, response.getBody().getCode());
+        Assert.assertEquals("test error", response.getBody().getMessage());
+        Assert.assertEquals("Bad Request", response.getBody().getStatus());
+    }
+
+    @Test
+    public void testGenericExceptionFallback() {
+        PDExceptionMapper mapper = new PDExceptionMapper();
+
+        PDException exception = new PDException(9999, "Erro desconhecido");
+
+        ResponseEntity<ApiResponse<Object>> response =
+                mapper.toResponse(exception);
+
+        Assert.assertEquals(500, response.getStatusCodeValue());
+        Assert.assertEquals(9999, response.getBody().getCode());
+        Assert.assertEquals("Internal Server Error", response.getBody().getStatus());
+    }
+
+    @Test
+    public void testGenericExceptionMapping() {
+        GenericExceptionMapper mapper = new GenericExceptionMapper();
+
+        Exception exception = new RuntimeException("Erro genérico");
+
+        ResponseEntity<ApiResponse<Object>> response =
+                mapper.handleGenericException(exception);
+
+        Assert.assertEquals(500, response.getStatusCodeValue());
+        Assert.assertEquals(500, response.getBody().getCode());
+        Assert.assertEquals("An unexpected error occurred", response.getBody().getMessage());
+        Assert.assertEquals("Internal Server Error", response.getBody().getStatus());
+    }
+}

--- a/hugegraph-server/hugegraph-api/src/main/java/org/apache/hugegraph/api/exceptionshandler/GenericExceptionMapper.java
+++ b/hugegraph-server/hugegraph-api/src/main/java/org/apache/hugegraph/api/exceptionshandler/GenericExceptionMapper.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hugegraph.api.exceptionshandler;
+
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.ext.ExceptionMapper;
+import jakarta.ws.rs.ext.Provider;
+import org.apache.hugegraph.rest.response.ApiResponse;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+@Provider
+public class GenericExceptionMapper implements ExceptionMapper<Exception> {
+
+    private static final Logger LOG = LogManager.getLogger(GenericExceptionMapper.class);
+
+    @Override
+    public Response toResponse(Exception exception) {
+        LOG.error("Unexpected error occurred", exception);
+
+        int code = 500;
+        ApiResponse<Object> apiResponse = new ApiResponse<>(
+                code,
+                "An unexpected error occurred",
+                null,
+                Response.Status.INTERNAL_SERVER_ERROR.getReasonPhrase());
+
+        return Response.status(code)
+                       .type(MediaType.APPLICATION_JSON)
+                       .entity(apiResponse)
+                       .build();
+    }
+}

--- a/hugegraph-server/hugegraph-api/src/main/java/org/apache/hugegraph/api/exceptionshandler/HugeExceptionMapper.java
+++ b/hugegraph-server/hugegraph-api/src/main/java/org/apache/hugegraph/api/exceptionshandler/HugeExceptionMapper.java
@@ -1,0 +1,74 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hugegraph.api.exceptionshandler;
+
+import com.alipay.sofa.rpc.log.Logger;
+import com.alipay.sofa.rpc.log.LoggerFactory;
+
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.ext.ExceptionMapper;
+import jakarta.ws.rs.ext.Provider;
+import org.apache.hugegraph.HugeException;
+import org.apache.hugegraph.rest.response.ApiResponse;
+
+@Provider
+public class HugeExceptionMapper implements ExceptionMapper<HugeException> {
+
+    private static final Logger LOG =
+            LoggerFactory.getLogger(HugeExceptionMapper.class);
+
+    @Override
+    public Response toResponse(HugeException exception) {
+
+        Throwable rootCause = HugeException.rootCause(exception);
+        int code;
+
+        if (rootCause instanceof InterruptedException) {
+            code = 500;
+        } else if (rootCause instanceof IllegalArgumentException) {
+            code = 400;
+        } else if (rootCause instanceof java.util.NoSuchElementException) {
+            code = 404;
+        } else {
+            code = 400;
+        }
+
+        if (code >= 500) {
+            LOG.error("Unexpected server error", exception);
+        } else {
+            LOG.warn("Request error: {}", exception.getMessage());
+        }
+
+        Response.Status statusCode = Response.Status.fromStatusCode(code);
+        String statusText = (statusCode != null ) ? statusCode.getReasonPhrase() : "BAD REQUEST";
+
+        ApiResponse<Object> apiResponse = new ApiResponse<>(
+                code,
+                exception.getMessage(),
+                null,
+                statusText
+        );
+
+        return Response.status(code)
+                       .type(MediaType.APPLICATION_JSON)
+                       .entity(apiResponse)
+                       .build();
+    }
+}
+

--- a/hugegraph-store/hg-store-node/src/main/java/org/apache/hugegraph/store/node/controller/exceptionhandlers/GenericExceptionMapper.java
+++ b/hugegraph-store/hg-store-node/src/main/java/org/apache/hugegraph/store/node/controller/exceptionhandlers/GenericExceptionMapper.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hugegraph.store.node.controller.exceptionhandlers;
+
+import org.apache.hugegraph.rest.response.ApiResponse;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+public class GenericExceptionMapper {
+
+    private static final Logger logger = LogManager.getLogger(GenericExceptionMapper.class);
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ApiResponse<Object>> handleGenericException(Exception exception) {
+
+        HttpStatus springStatus = HttpStatus.INTERNAL_SERVER_ERROR;
+
+        logger.error("Unexpected error ", exception);
+
+        ApiResponse<Object> apiResponse = new ApiResponse<>(
+                500,
+                "An unexpected error occurred",
+                null,
+                springStatus.getReasonPhrase());
+
+        return ResponseEntity.status(springStatus).body(apiResponse);
+    }
+}

--- a/hugegraph-store/hg-store-node/src/main/java/org/apache/hugegraph/store/node/controller/exceptionhandlers/StoreExceptionHandler.java
+++ b/hugegraph-store/hg-store-node/src/main/java/org/apache/hugegraph/store/node/controller/exceptionhandlers/StoreExceptionHandler.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hugegraph.store.node.controller.exceptionhandlers;
+
+import org.apache.hugegraph.rest.response.ApiResponse;
+import org.apache.hugegraph.store.util.HgStoreException;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+@RestControllerAdvice
+public class StoreExceptionHandler {
+
+    private static final Logger logger = Logger.getLogger(StoreExceptionHandler.class.getName());
+
+    @ExceptionHandler(HgStoreException.class)
+    public ResponseEntity<ApiResponse<Object>> handleHgStoreException(HgStoreException exception) {
+        int errorCode = exception.getCode();
+        HttpStatus status;
+
+        if (errorCode >= 1200 && errorCode < 1300) {
+            status = HttpStatus.INTERNAL_SERVER_ERROR;
+            logger.log(Level.SEVERE,
+                       "Critical error at database (Code " + errorCode + "): " + exception.getMessage(), exception);
+        } else if (errorCode >= 1000 && errorCode < 1200) {
+            status = HttpStatus.BAD_REQUEST;
+
+            logger.log(Level.WARNING,
+                       "Validation failed at store (Code " + errorCode + "): " + exception.getMessage(), exception);
+        } else {
+            status = HttpStatus.INTERNAL_SERVER_ERROR;
+
+            logger.log(Level.SEVERE,
+                       "Unexpected error at store (Code " + errorCode + "): " + exception.getMessage(), exception);
+        }
+
+        ApiResponse<Object> apiResponse = new ApiResponse<>(
+                status.value(),
+                exception.getMessage(),
+                null,
+                status.getReasonPhrase()
+        );
+
+        return ResponseEntity.status(status).body(apiResponse);
+    }
+}


### PR DESCRIPTION
## Purpose of the PR

- close #2975

The purpose of this PR is to standardize and unify the REST API global error response format across the core modules (`pd`, `server` and `store/hg-store-node`) using the centralized `ApiResponse` envelope wrapper. 

Currently, unhandled exceptions or module-specific errors could return inconsistent formats or expose raw stack traces to the client. This tracking change enforces a clean, predictable JSON error contract across different frameworks used in the ecosystem (Jersey and Spring Boot), enhancing API security and client-side error handling.

## Main Changes

This PR introduces centralized exception mapping logic across two distinct sub-framework layers within the project:

### 1. `hugegraph-server` module (Jersey / JAX-RS)
* **`HugeExceptionMapper`**: Intercepts all `HugeException` occurrences. It safely resolves the underlying root cause using a recursive `rootCause()` lookup and maps internal core errors directly to appropriate HTTP Status Codes (e.g., `IllegalArgumentException` -> 400 Bad Request, `NoSuchElementException` -> 404 Not Found) wrapped cleanly inside `ApiResponse`.
* **`GenericExceptionMapper`**: Implemented as a top-level global catch-all provider for `Exception.class` to prevent infrastructure leakages, mapping unexpected exceptions to a secure HTTP 500 `"An unexpected error occurred"` message payload.

### 2. `hugegraph-store` module (`hg-store-node` sub-module / Spring Boot)
* **`StoreExceptionHandler`**: Created using Spring's `@RestControllerAdvice` to intercept `HgStoreException`. It dynamically parses the exception's internal error `code` to differentiate client errors from infrastructure faults based on explicit ranges:
  * Codes `[1200, 1300)` (e.g., RocksDB storage failures) -> **500 Internal Server Error** (logged as `SEVERE/ERROR` with full stack trace).
  * Codes `[1000, 1200)` (e.g., Unsupported data formats) -> **400 Bad Request** (logged cleanly as a `WARNING` message).
* **`GenericExceptionMapper`**: Added as a fallback interceptor for standard `Exception.class` instances inside the store node rest controllers to ensure uniform 500 error envelopes using the Log4j wrapper.

### 3. `hugegraph-pd` module (`hg-pd-service` sub-module / Spring Boot)
* **`PdExceptionHandler`**: Implemented via `@RestControllerAdvice` to handle metadata and coordination cluster exceptions (`PDException`). Centralizes cluster control plane failure logging (Raft state, partition routing) and converts them into the unified `ApiResponse` schema.
* **Catch-All Filter**: Includes standard `Exception.class` mapping to gracefully mask unhandled runtime infrastructure glitches with a generic `"An unexpected error occurred in the cluster control plane"` feedback text.

## Verifying these changes

- [x] Need tests and can be verified as follows:
    - Executed `mvn clean compile -DskipTests` from the root directory to confirm proper multi-module compile-time dependency alignment (validating `ApiResponse` cross-package visibility inside `hg-store-node`).
    - Validated error response payloads against the unified schema structure ensuring it adheres to the contract:
      ```json
      {
        "status": 400,
        "message": "Specific validation/error message string",
        "data": null,
        "statusText": "Bad Request"
      }
      ```

## Does this PR potentially affect the following parts?

- [ ]  Dependencies
- [ ]  Modify configurations
- [x]  The public API 
- [ ]  Other affects (typed here)
- [ ]  Nope


## Documentation Status

- [ ]  `Doc - TODO`
- [ ]  `Doc - Done`
- [x]  `Doc - No Need`