### PR TITLE
fix(server): avoid extracting text range filters

### DIFF
--- a/hugegraph-server/hugegraph-core/src/main/java/org/apache/hugegraph/traversal/optimize/TraversalUtil.java
+++ b/hugegraph-server/hugegraph-core/src/main/java/org/apache/hugegraph/traversal/optimize/TraversalUtil.java
@@ -20,12 +20,10 @@ package org.apache.hugegraph.traversal.optimize;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.Set;
 import java.util.function.BiPredicate;
 import java.util.function.Function;
 import java.util.regex.Matcher;
@@ -44,7 +42,6 @@ import org.apache.hugegraph.backend.query.Query;
 import org.apache.hugegraph.exception.NotFoundException;
 import org.apache.hugegraph.exception.NotSupportException;
 import org.apache.hugegraph.iterator.FilterIterator;
-import org.apache.hugegraph.schema.IndexLabel;
 import org.apache.hugegraph.schema.PropertyKey;
 import org.apache.hugegraph.schema.SchemaLabel;
 import org.apache.hugegraph.structure.HugeElement;
@@ -203,48 +200,41 @@ public final class TraversalUtil {
     private static boolean extractHasContainers(HugeGraphStep<?, ?> newStep,
                                                 HasContainerHolder holder) {
         HugeGraph graph = TraversalUtil.tryGetGraph(newStep);
-        List<HasContainer> hasContainers = new ArrayList<>(holder.getHasContainers());
-        HugeType type = newStep.returnsVertex() ? HugeType.VERTEX : HugeType.EDGE;
-        Set<Id> labelIds = collectLabelIds(graph, type, newStep.getHasContainers(),
-                                           hasContainers);
-        for (HasContainer has : hasContainers) {
-            if (!canExtractHasContainer(graph, type, labelIds, has)) {
-                continue;
-            }
+        if (!canExtractHasContainers(graph, holder)) {
+            return false;
+        }
+        for (HasContainer has : holder.getHasContainers()) {
             if (!GraphStep.processHasContainerIds(newStep, has)) {
                 newStep.addHasContainer(has);
             }
-            holder.removeHasContainer(has);
         }
-        return holder.getHasContainers().isEmpty();
+        return true;
     }
 
     private static boolean extractHasContainers(HugeVertexStep<?> newStep,
                                                 HasContainerHolder holder) {
         HugeGraph graph = TraversalUtil.tryGetGraph(newStep);
-        List<HasContainer> hasContainers = new ArrayList<>(holder.getHasContainers());
-        HugeType type = newStep.returnsVertex() ? HugeType.VERTEX : HugeType.EDGE;
-        Set<Id> labelIds = collectLabelIds(graph, type, newStep.getHasContainers(),
-                                           hasContainers);
-        for (HasContainer has : hasContainers) {
-            if (!canExtractHasContainer(graph, type, labelIds, has)) {
-                continue;
-            }
-            newStep.addHasContainer(has);
-            holder.removeHasContainer(has);
+        if (!canExtractHasContainers(graph, holder)) {
+            return false;
         }
-        return holder.getHasContainers().isEmpty();
+        for (HasContainer has : holder.getHasContainers()) {
+            newStep.addHasContainer(has);
+        }
+        return true;
+    }
+
+    private static boolean canExtractHasContainers(HugeGraph graph,
+                                                   HasContainerHolder holder) {
+        for (HasContainer has : holder.getHasContainers()) {
+            if (!canExtractHasContainer(graph, has)) {
+                return false;
+            }
+        }
+        return true;
     }
 
     static boolean canExtractHasContainer(HugeGraph graph,
                                           HasContainer has) {
-        return canExtractHasContainer(graph, HugeType.UNKNOWN, null, has);
-    }
-
-    private static boolean canExtractHasContainer(HugeGraph graph,
-                                                  HugeType type,
-                                                  Set<Id> labelIds,
-                                                  HasContainer has) {
         if (isSysProp(has.getKey())) {
             return true;
         }
@@ -256,9 +246,6 @@ public final class TraversalUtil {
         try {
             pkey = graph.propertyKey(has.getKey());
         } catch (NotFoundException e) {
-            return false;
-        }
-        if (!hasIndexForProperty(graph, type, labelIds, pkey, has)) {
             return false;
         }
         if (!pkey.dataType().isText()) {
@@ -275,112 +262,6 @@ public final class TraversalUtil {
             }
         }
         return true;
-    }
-
-    private static boolean hasIndexForProperty(HugeGraph graph,
-                                               HugeType type,
-                                               Set<Id> labelIds,
-                                               PropertyKey pkey,
-                                               HasContainer has) {
-        if (labelIds == null || labelIds.size() != 1) {
-            return false;
-        }
-
-        SchemaLabel schemaLabel = schemaLabel(graph, type, labelIds.iterator().next());
-        for (Id indexLabelId : schemaLabel.indexLabels()) {
-            IndexLabel indexLabel = graph.indexLabel(indexLabelId);
-            if (matchIndexField(indexLabel, pkey) &&
-                matchIndexType(indexLabel, has)) {
-                return true;
-            }
-        }
-        return false;
-    }
-
-    private static boolean matchIndexField(IndexLabel indexLabel,
-                                           PropertyKey pkey) {
-        List<Id> fields = indexLabel.indexFields();
-        return !fields.isEmpty() && fields.get(0).equals(pkey.id());
-    }
-
-    private static SchemaLabel schemaLabel(HugeGraph graph, HugeType type,
-                                           Id label) {
-        if (type.isVertex()) {
-            return graph.vertexLabel(label);
-        } else {
-            assert type.isEdge();
-            return graph.edgeLabel(label);
-        }
-    }
-
-    private static boolean matchIndexType(IndexLabel indexLabel,
-                                          HasContainer has) {
-        if (indexLabel.indexType().isUnique()) {
-            return false;
-        }
-
-        boolean range = false;
-        boolean search = false;
-        List<P<Object>> predicates = new ArrayList<>();
-        collectPredicates(predicates, ImmutableList.of(has.getPredicate()));
-        for (P<Object> pred : predicates) {
-            BiPredicate<?, ?> bp = pred.getBiPredicate();
-            if (bp == Compare.neq || bp == Contains.without) {
-                return false;
-            }
-            range |= bp == Compare.gt || bp == Compare.gte ||
-                     bp == Compare.lt || bp == Compare.lte;
-            search |= bp instanceof Condition.RelationType &&
-                      ((Condition.RelationType) bp).isSearchType();
-        }
-
-        if (search) {
-            return indexLabel.indexType().isSearch();
-        }
-        if (indexLabel.indexType().isSearch()) {
-            return false;
-        }
-        return !range || indexLabel.indexType().isNumeric();
-    }
-
-    @SafeVarargs
-    private static Set<Id> collectLabelIds(HugeGraph graph, HugeType type,
-                                           List<HasContainer>... containers) {
-        if (graph == null) {
-            return null;
-        }
-
-        Set<Id> labelIds = new HashSet<>();
-        for (List<HasContainer> list : containers) {
-            for (HasContainer has : list) {
-                if (token2HugeKey(has.getKey()) != HugeKeys.LABEL) {
-                    continue;
-                }
-                if (!collectLabelIds(graph, type, has, labelIds)) {
-                    return null;
-                }
-            }
-        }
-        return labelIds;
-    }
-
-    private static boolean collectLabelIds(HugeGraph graph, HugeType type,
-                                           HasContainer has, Set<Id> labels) {
-        BiPredicate<?, ?> bp = has.getPredicate().getBiPredicate();
-        if (bp == Compare.eq) {
-            labels.add((Id) convSysValueIfNeeded(graph, type, HugeKeys.LABEL,
-                                                 has.getValue()));
-            return true;
-        }
-        if (bp == Contains.within) {
-            Collection<?> values = (Collection<?>) has.getValue();
-            for (Object value : values) {
-                labels.add((Id) convSysValueIfNeeded(graph, type, HugeKeys.LABEL,
-                                                     value));
-            }
-            return true;
-        }
-        return false;
     }
 
     public static void extractOrder(Step<?, ?> newStep,

--- a/hugegraph-server/hugegraph-core/src/main/java/org/apache/hugegraph/traversal/optimize/TraversalUtil.java
+++ b/hugegraph-server/hugegraph-core/src/main/java/org/apache/hugegraph/traversal/optimize/TraversalUtil.java
@@ -166,9 +166,8 @@ public final class TraversalUtil {
 
     public static void extractHasContainer(HugeGraphStep<?, ?> newStep,
                                            Traversal.Admin<?, ?> traversal) {
-        Step<?, ?> step = newStep;
-        do {
-            step = step.getNextStep();
+        Step<?, ?> step = newStep.getNextStep();
+        while (step instanceof HasStep || step instanceof NoOpBarrierStep) {
             if (step instanceof HasStep) {
                 HasContainerHolder holder = (HasContainerHolder) step;
                 if (extractHasContainers(newStep, holder)) {
@@ -176,7 +175,8 @@ public final class TraversalUtil {
                     traversal.removeStep(step);
                 }
             }
-        } while (step instanceof HasStep || step instanceof NoOpBarrierStep);
+            step = step.getNextStep();
+        }
     }
 
     public static void extractHasContainer(HugeVertexStep<?> newStep,
@@ -232,8 +232,8 @@ public final class TraversalUtil {
         return true;
     }
 
-    private static boolean canExtractHasContainer(HugeGraph graph,
-                                                  HasContainer has) {
+    static boolean canExtractHasContainer(HugeGraph graph,
+                                          HasContainer has) {
         if (isSysProp(has.getKey())) {
             return true;
         }

--- a/hugegraph-server/hugegraph-core/src/main/java/org/apache/hugegraph/traversal/optimize/TraversalUtil.java
+++ b/hugegraph-server/hugegraph-core/src/main/java/org/apache/hugegraph/traversal/optimize/TraversalUtil.java
@@ -289,12 +289,18 @@ public final class TraversalUtil {
         SchemaLabel schemaLabel = schemaLabel(graph, type, labelIds.iterator().next());
         for (Id indexLabelId : schemaLabel.indexLabels()) {
             IndexLabel indexLabel = graph.indexLabel(indexLabelId);
-            if (indexLabel.indexFields().contains(pkey.id()) &&
+            if (matchIndexField(indexLabel, pkey) &&
                 matchIndexType(indexLabel, has)) {
                 return true;
             }
         }
         return false;
+    }
+
+    private static boolean matchIndexField(IndexLabel indexLabel,
+                                           PropertyKey pkey) {
+        List<Id> fields = indexLabel.indexFields();
+        return !fields.isEmpty() && fields.get(0).equals(pkey.id());
     }
 
     private static SchemaLabel schemaLabel(HugeGraph graph, HugeType type,
@@ -319,6 +325,9 @@ public final class TraversalUtil {
         collectPredicates(predicates, ImmutableList.of(has.getPredicate()));
         for (P<Object> pred : predicates) {
             BiPredicate<?, ?> bp = pred.getBiPredicate();
+            if (bp == Compare.neq || bp == Contains.without) {
+                return false;
+            }
             range |= bp == Compare.gt || bp == Compare.gte ||
                      bp == Compare.lt || bp == Compare.lte;
             search |= bp instanceof Condition.RelationType &&

--- a/hugegraph-server/hugegraph-core/src/main/java/org/apache/hugegraph/traversal/optimize/TraversalUtil.java
+++ b/hugegraph-server/hugegraph-core/src/main/java/org/apache/hugegraph/traversal/optimize/TraversalUtil.java
@@ -197,33 +197,39 @@ public final class TraversalUtil {
     private static boolean extractHasContainers(HugeGraphStep<?, ?> newStep,
                                                 HasContainerHolder holder) {
         HugeGraph graph = TraversalUtil.tryGetGraph(newStep);
-        Iterator<HasContainer> iterator = holder.getHasContainers().iterator();
-        while (iterator.hasNext()) {
-            HasContainer has = iterator.next();
-            if (!canExtractHasContainer(graph, has)) {
-                continue;
-            }
+        List<HasContainer> hasContainers = holder.getHasContainers();
+        if (!canExtractHasContainers(graph, hasContainers)) {
+            return false;
+        }
+        for (HasContainer has : hasContainers) {
             if (!GraphStep.processHasContainerIds(newStep, has)) {
                 newStep.addHasContainer(has);
             }
-            iterator.remove();
         }
-        return holder.getHasContainers().isEmpty();
+        return true;
     }
 
     private static boolean extractHasContainers(HugeVertexStep<?> newStep,
                                                 HasContainerHolder holder) {
         HugeGraph graph = TraversalUtil.tryGetGraph(newStep);
-        Iterator<HasContainer> iterator = holder.getHasContainers().iterator();
-        while (iterator.hasNext()) {
-            HasContainer has = iterator.next();
-            if (!canExtractHasContainer(graph, has)) {
-                continue;
-            }
-            newStep.addHasContainer(has);
-            iterator.remove();
+        List<HasContainer> hasContainers = holder.getHasContainers();
+        if (!canExtractHasContainers(graph, hasContainers)) {
+            return false;
         }
-        return holder.getHasContainers().isEmpty();
+        for (HasContainer has : hasContainers) {
+            newStep.addHasContainer(has);
+        }
+        return true;
+    }
+
+    private static boolean canExtractHasContainers(HugeGraph graph,
+                                                   List<HasContainer> hasContainers) {
+        for (HasContainer has : hasContainers) {
+            if (!canExtractHasContainer(graph, has)) {
+                return false;
+            }
+        }
+        return true;
     }
 
     private static boolean canExtractHasContainer(HugeGraph graph,

--- a/hugegraph-server/hugegraph-core/src/main/java/org/apache/hugegraph/traversal/optimize/TraversalUtil.java
+++ b/hugegraph-server/hugegraph-core/src/main/java/org/apache/hugegraph/traversal/optimize/TraversalUtil.java
@@ -20,10 +20,12 @@ package org.apache.hugegraph.traversal.optimize;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.function.BiPredicate;
 import java.util.function.Function;
 import java.util.regex.Matcher;
@@ -202,8 +204,11 @@ public final class TraversalUtil {
                                                 HasContainerHolder holder) {
         HugeGraph graph = TraversalUtil.tryGetGraph(newStep);
         List<HasContainer> hasContainers = new ArrayList<>(holder.getHasContainers());
+        HugeType type = newStep.returnsVertex() ? HugeType.VERTEX : HugeType.EDGE;
+        Set<Id> labelIds = collectLabelIds(graph, type, newStep.getHasContainers(),
+                                           hasContainers);
         for (HasContainer has : hasContainers) {
-            if (!canExtractHasContainer(graph, has)) {
+            if (!canExtractHasContainer(graph, type, labelIds, has)) {
                 continue;
             }
             if (!GraphStep.processHasContainerIds(newStep, has)) {
@@ -218,8 +223,11 @@ public final class TraversalUtil {
                                                 HasContainerHolder holder) {
         HugeGraph graph = TraversalUtil.tryGetGraph(newStep);
         List<HasContainer> hasContainers = new ArrayList<>(holder.getHasContainers());
+        HugeType type = newStep.returnsVertex() ? HugeType.VERTEX : HugeType.EDGE;
+        Set<Id> labelIds = collectLabelIds(graph, type, newStep.getHasContainers(),
+                                           hasContainers);
         for (HasContainer has : hasContainers) {
-            if (!canExtractHasContainer(graph, has)) {
+            if (!canExtractHasContainer(graph, type, labelIds, has)) {
                 continue;
             }
             newStep.addHasContainer(has);
@@ -230,6 +238,13 @@ public final class TraversalUtil {
 
     static boolean canExtractHasContainer(HugeGraph graph,
                                           HasContainer has) {
+        return canExtractHasContainer(graph, HugeType.UNKNOWN, null, has);
+    }
+
+    private static boolean canExtractHasContainer(HugeGraph graph,
+                                                  HugeType type,
+                                                  Set<Id> labelIds,
+                                                  HasContainer has) {
         if (isSysProp(has.getKey())) {
             return true;
         }
@@ -243,7 +258,7 @@ public final class TraversalUtil {
         } catch (NotFoundException e) {
             return false;
         }
-        if (!hasIndexForProperty(graph, pkey)) {
+        if (!hasIndexForProperty(graph, type, labelIds, pkey, has)) {
             return false;
         }
         if (!pkey.dataType().isText()) {
@@ -263,11 +278,98 @@ public final class TraversalUtil {
     }
 
     private static boolean hasIndexForProperty(HugeGraph graph,
-                                               PropertyKey pkey) {
-        for (IndexLabel indexLabel : graph.indexLabels()) {
-            if (indexLabel.indexFields().contains(pkey.id())) {
+                                               HugeType type,
+                                               Set<Id> labelIds,
+                                               PropertyKey pkey,
+                                               HasContainer has) {
+        if (labelIds == null || labelIds.size() != 1) {
+            return false;
+        }
+
+        SchemaLabel schemaLabel = schemaLabel(graph, type, labelIds.iterator().next());
+        for (Id indexLabelId : schemaLabel.indexLabels()) {
+            IndexLabel indexLabel = graph.indexLabel(indexLabelId);
+            if (indexLabel.indexFields().contains(pkey.id()) &&
+                matchIndexType(indexLabel, has)) {
                 return true;
             }
+        }
+        return false;
+    }
+
+    private static SchemaLabel schemaLabel(HugeGraph graph, HugeType type,
+                                           Id label) {
+        if (type.isVertex()) {
+            return graph.vertexLabel(label);
+        } else {
+            assert type.isEdge();
+            return graph.edgeLabel(label);
+        }
+    }
+
+    private static boolean matchIndexType(IndexLabel indexLabel,
+                                          HasContainer has) {
+        if (indexLabel.indexType().isUnique()) {
+            return false;
+        }
+
+        boolean range = false;
+        boolean search = false;
+        List<P<Object>> predicates = new ArrayList<>();
+        collectPredicates(predicates, ImmutableList.of(has.getPredicate()));
+        for (P<Object> pred : predicates) {
+            BiPredicate<?, ?> bp = pred.getBiPredicate();
+            range |= bp == Compare.gt || bp == Compare.gte ||
+                     bp == Compare.lt || bp == Compare.lte;
+            search |= bp instanceof Condition.RelationType &&
+                      ((Condition.RelationType) bp).isSearchType();
+        }
+
+        if (search) {
+            return indexLabel.indexType().isSearch();
+        }
+        if (indexLabel.indexType().isSearch()) {
+            return false;
+        }
+        return !range || indexLabel.indexType().isNumeric();
+    }
+
+    @SafeVarargs
+    private static Set<Id> collectLabelIds(HugeGraph graph, HugeType type,
+                                           List<HasContainer>... containers) {
+        if (graph == null) {
+            return null;
+        }
+
+        Set<Id> labelIds = new HashSet<>();
+        for (List<HasContainer> list : containers) {
+            for (HasContainer has : list) {
+                if (token2HugeKey(has.getKey()) != HugeKeys.LABEL) {
+                    continue;
+                }
+                if (!collectLabelIds(graph, type, has, labelIds)) {
+                    return null;
+                }
+            }
+        }
+        return labelIds;
+    }
+
+    private static boolean collectLabelIds(HugeGraph graph, HugeType type,
+                                           HasContainer has, Set<Id> labels) {
+        BiPredicate<?, ?> bp = has.getPredicate().getBiPredicate();
+        if (bp == Compare.eq) {
+            labels.add((Id) convSysValueIfNeeded(graph, type, HugeKeys.LABEL,
+                                                 has.getValue()));
+            return true;
+        }
+        if (bp == Contains.within) {
+            Collection<?> values = (Collection<?>) has.getValue();
+            for (Object value : values) {
+                labels.add((Id) convSysValueIfNeeded(graph, type, HugeKeys.LABEL,
+                                                     value));
+            }
+            return true;
         }
         return false;
     }

--- a/hugegraph-server/hugegraph-core/src/main/java/org/apache/hugegraph/traversal/optimize/TraversalUtil.java
+++ b/hugegraph-server/hugegraph-core/src/main/java/org/apache/hugegraph/traversal/optimize/TraversalUtil.java
@@ -42,6 +42,7 @@ import org.apache.hugegraph.backend.query.Query;
 import org.apache.hugegraph.exception.NotFoundException;
 import org.apache.hugegraph.exception.NotSupportException;
 import org.apache.hugegraph.iterator.FilterIterator;
+import org.apache.hugegraph.schema.IndexLabel;
 import org.apache.hugegraph.schema.PropertyKey;
 import org.apache.hugegraph.schema.SchemaLabel;
 import org.apache.hugegraph.structure.HugeElement;
@@ -200,39 +201,31 @@ public final class TraversalUtil {
     private static boolean extractHasContainers(HugeGraphStep<?, ?> newStep,
                                                 HasContainerHolder holder) {
         HugeGraph graph = TraversalUtil.tryGetGraph(newStep);
-        List<HasContainer> hasContainers = holder.getHasContainers();
-        if (!canExtractHasContainers(graph, hasContainers)) {
-            return false;
-        }
+        List<HasContainer> hasContainers = new ArrayList<>(holder.getHasContainers());
         for (HasContainer has : hasContainers) {
+            if (!canExtractHasContainer(graph, has)) {
+                continue;
+            }
             if (!GraphStep.processHasContainerIds(newStep, has)) {
                 newStep.addHasContainer(has);
             }
+            holder.removeHasContainer(has);
         }
-        return true;
+        return holder.getHasContainers().isEmpty();
     }
 
     private static boolean extractHasContainers(HugeVertexStep<?> newStep,
                                                 HasContainerHolder holder) {
         HugeGraph graph = TraversalUtil.tryGetGraph(newStep);
-        List<HasContainer> hasContainers = holder.getHasContainers();
-        if (!canExtractHasContainers(graph, hasContainers)) {
-            return false;
-        }
-        for (HasContainer has : hasContainers) {
-            newStep.addHasContainer(has);
-        }
-        return true;
-    }
-
-    private static boolean canExtractHasContainers(HugeGraph graph,
-                                                   List<HasContainer> hasContainers) {
+        List<HasContainer> hasContainers = new ArrayList<>(holder.getHasContainers());
         for (HasContainer has : hasContainers) {
             if (!canExtractHasContainer(graph, has)) {
-                return false;
+                continue;
             }
+            newStep.addHasContainer(has);
+            holder.removeHasContainer(has);
         }
-        return true;
+        return holder.getHasContainers().isEmpty();
     }
 
     static boolean canExtractHasContainer(HugeGraph graph,
@@ -250,6 +243,9 @@ public final class TraversalUtil {
         } catch (NotFoundException e) {
             return false;
         }
+        if (!hasIndexForProperty(graph, pkey)) {
+            return false;
+        }
         if (!pkey.dataType().isText()) {
             return true;
         }
@@ -264,6 +260,16 @@ public final class TraversalUtil {
             }
         }
         return true;
+    }
+
+    private static boolean hasIndexForProperty(HugeGraph graph,
+                                               PropertyKey pkey) {
+        for (IndexLabel indexLabel : graph.indexLabels()) {
+            if (indexLabel.indexFields().contains(pkey.id())) {
+                return true;
+            }
+        }
+        return false;
     }
 
     public static void extractOrder(Step<?, ?> newStep,

--- a/hugegraph-server/hugegraph-core/src/main/java/org/apache/hugegraph/traversal/optimize/TraversalUtil.java
+++ b/hugegraph-server/hugegraph-core/src/main/java/org/apache/hugegraph/traversal/optimize/TraversalUtil.java
@@ -39,6 +39,7 @@ import org.apache.hugegraph.backend.query.Aggregate;
 import org.apache.hugegraph.backend.query.Condition;
 import org.apache.hugegraph.backend.query.ConditionQuery;
 import org.apache.hugegraph.backend.query.Query;
+import org.apache.hugegraph.exception.NotFoundException;
 import org.apache.hugegraph.exception.NotSupportException;
 import org.apache.hugegraph.iterator.FilterIterator;
 import org.apache.hugegraph.schema.PropertyKey;
@@ -168,6 +169,7 @@ public final class TraversalUtil {
                                            Traversal.Admin<?, ?> traversal) {
         Step<?, ?> step = newStep.getNextStep();
         while (step instanceof HasStep || step instanceof NoOpBarrierStep) {
+            Step<?, ?> nextStep = step.getNextStep();
             if (step instanceof HasStep) {
                 HasContainerHolder holder = (HasContainerHolder) step;
                 if (extractHasContainers(newStep, holder)) {
@@ -175,7 +177,7 @@ public final class TraversalUtil {
                     traversal.removeStep(step);
                 }
             }
-            step = step.getNextStep();
+            step = nextStep;
         }
     }
 
@@ -183,6 +185,7 @@ public final class TraversalUtil {
                                            Traversal.Admin<?, ?> traversal) {
         Step<?, ?> step = newStep;
         do {
+            Step<?, ?> nextStep = step.getNextStep();
             if (step instanceof HasStep) {
                 HasContainerHolder holder = (HasContainerHolder) step;
                 if (extractHasContainers(newStep, holder)) {
@@ -190,7 +193,7 @@ public final class TraversalUtil {
                     traversal.removeStep(step);
                 }
             }
-            step = step.getNextStep();
+            step = nextStep;
         } while (step instanceof HasStep || step instanceof NoOpBarrierStep);
     }
 
@@ -241,7 +244,12 @@ public final class TraversalUtil {
             return false;
         }
 
-        PropertyKey pkey = graph.propertyKey(has.getKey());
+        PropertyKey pkey;
+        try {
+            pkey = graph.propertyKey(has.getKey());
+        } catch (NotFoundException e) {
+            return false;
+        }
         if (!pkey.dataType().isText()) {
             return true;
         }

--- a/hugegraph-server/hugegraph-core/src/main/java/org/apache/hugegraph/traversal/optimize/TraversalUtil.java
+++ b/hugegraph-server/hugegraph-core/src/main/java/org/apache/hugegraph/traversal/optimize/TraversalUtil.java
@@ -171,13 +171,10 @@ public final class TraversalUtil {
             step = step.getNextStep();
             if (step instanceof HasStep) {
                 HasContainerHolder holder = (HasContainerHolder) step;
-                for (HasContainer has : holder.getHasContainers()) {
-                    if (!GraphStep.processHasContainerIds(newStep, has)) {
-                        newStep.addHasContainer(has);
-                    }
+                if (extractHasContainers(newStep, holder)) {
+                    TraversalHelper.copyLabels(step, step.getPreviousStep(), false);
+                    traversal.removeStep(step);
                 }
-                TraversalHelper.copyLabels(step, step.getPreviousStep(), false);
-                traversal.removeStep(step);
             }
         } while (step instanceof HasStep || step instanceof NoOpBarrierStep);
     }
@@ -188,14 +185,71 @@ public final class TraversalUtil {
         do {
             if (step instanceof HasStep) {
                 HasContainerHolder holder = (HasContainerHolder) step;
-                for (HasContainer has : holder.getHasContainers()) {
-                    newStep.addHasContainer(has);
+                if (extractHasContainers(newStep, holder)) {
+                    TraversalHelper.copyLabels(step, step.getPreviousStep(), false);
+                    traversal.removeStep(step);
                 }
-                TraversalHelper.copyLabels(step, step.getPreviousStep(), false);
-                traversal.removeStep(step);
             }
             step = step.getNextStep();
         } while (step instanceof HasStep || step instanceof NoOpBarrierStep);
+    }
+
+    private static boolean extractHasContainers(HugeGraphStep<?, ?> newStep,
+                                                HasContainerHolder holder) {
+        HugeGraph graph = TraversalUtil.tryGetGraph(newStep);
+        Iterator<HasContainer> iterator = holder.getHasContainers().iterator();
+        while (iterator.hasNext()) {
+            HasContainer has = iterator.next();
+            if (!canExtractHasContainer(graph, has)) {
+                continue;
+            }
+            if (!GraphStep.processHasContainerIds(newStep, has)) {
+                newStep.addHasContainer(has);
+            }
+            iterator.remove();
+        }
+        return holder.getHasContainers().isEmpty();
+    }
+
+    private static boolean extractHasContainers(HugeVertexStep<?> newStep,
+                                                HasContainerHolder holder) {
+        HugeGraph graph = TraversalUtil.tryGetGraph(newStep);
+        Iterator<HasContainer> iterator = holder.getHasContainers().iterator();
+        while (iterator.hasNext()) {
+            HasContainer has = iterator.next();
+            if (!canExtractHasContainer(graph, has)) {
+                continue;
+            }
+            newStep.addHasContainer(has);
+            iterator.remove();
+        }
+        return holder.getHasContainers().isEmpty();
+    }
+
+    private static boolean canExtractHasContainer(HugeGraph graph,
+                                                  HasContainer has) {
+        if (isSysProp(has.getKey())) {
+            return true;
+        }
+        if (graph == null) {
+            return false;
+        }
+
+        PropertyKey pkey = graph.propertyKey(has.getKey());
+        if (!pkey.dataType().isText()) {
+            return true;
+        }
+
+        List<P<Object>> predicates = new ArrayList<>();
+        collectPredicates(predicates, ImmutableList.of(has.getPredicate()));
+        for (P<Object> pred : predicates) {
+            BiPredicate<?, ?> bp = pred.getBiPredicate();
+            if (bp == Compare.gt || bp == Compare.gte ||
+                bp == Compare.lt || bp == Compare.lte) {
+                return false;
+            }
+        }
+        return true;
     }
 
     public static void extractOrder(Step<?, ?> newStep,

--- a/hugegraph-server/hugegraph-core/src/main/java/org/apache/hugegraph/traversal/optimize/TraversalUtil.java
+++ b/hugegraph-server/hugegraph-core/src/main/java/org/apache/hugegraph/traversal/optimize/TraversalUtil.java
@@ -171,6 +171,10 @@ public final class TraversalUtil {
             step = step.getNextStep();
             if (step instanceof HasStep) {
                 HasContainerHolder holder = (HasContainerHolder) step;
+                if (!canExtractHasContainers(TraversalUtil.getGraph(newStep),
+                                             holder.getHasContainers())) {
+                    break;
+                }
                 for (HasContainer has : holder.getHasContainers()) {
                     if (!GraphStep.processHasContainerIds(newStep, has)) {
                         newStep.addHasContainer(has);
@@ -188,6 +192,10 @@ public final class TraversalUtil {
         do {
             if (step instanceof HasStep) {
                 HasContainerHolder holder = (HasContainerHolder) step;
+                if (!canExtractHasContainers(TraversalUtil.getGraph(newStep),
+                                             holder.getHasContainers())) {
+                    break;
+                }
                 for (HasContainer has : holder.getHasContainers()) {
                     newStep.addHasContainer(has);
                 }
@@ -196,6 +204,39 @@ public final class TraversalUtil {
             }
             step = step.getNextStep();
         } while (step instanceof HasStep || step instanceof NoOpBarrierStep);
+    }
+
+    private static boolean canExtractHasContainers(HugeGraph graph,
+                                                   List<HasContainer> hasContainers) {
+        for (HasContainer has : hasContainers) {
+            if (!canExtractHasContainer(graph, has)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private static boolean canExtractHasContainer(HugeGraph graph,
+                                                  HasContainer has) {
+        if (isSysProp(has.getKey())) {
+            return true;
+        }
+
+        PropertyKey pkey = graph.propertyKey(has.getKey());
+        if (!pkey.dataType().isText()) {
+            return true;
+        }
+
+        List<P<Object>> predicates = new ArrayList<>();
+        collectPredicates(predicates, ImmutableList.of(has.getPredicate()));
+        for (P<Object> pred : predicates) {
+            BiPredicate<?, ?> bp = pred.getBiPredicate();
+            if (bp == Compare.gt || bp == Compare.gte ||
+                bp == Compare.lt || bp == Compare.lte) {
+                return false;
+            }
+        }
+        return true;
     }
 
     public static void extractOrder(Step<?, ?> newStep,

--- a/hugegraph-server/hugegraph-test/src/main/java/org/apache/hugegraph/core/CountStrategyCoreTest.java
+++ b/hugegraph-server/hugegraph-test/src/main/java/org/apache/hugegraph/core/CountStrategyCoreTest.java
@@ -51,11 +51,13 @@ public class CountStrategyCoreTest extends BaseCoreTest {
     private void initTextRangeSchema(boolean withEdge) {
         SchemaManager schema = graph().schema();
         schema.propertyKey("vp4").asText().create();
+        schema.propertyKey("ep4").asText().create();
         schema.propertyKey("age").asInt().create();
         schema.vertexLabel("vl1").properties("vp4", "age")
               .nullableKeys("vp4", "age").create();
         if (withEdge) {
-            schema.edgeLabel("el2").link("vl1", "vl1").create();
+            schema.edgeLabel("el2").properties("ep4")
+                  .nullableKeys("ep4").link("vl1", "vl1").create();
         }
     }
 
@@ -200,6 +202,26 @@ public class CountStrategyCoreTest extends BaseCoreTest {
                                       .has("vp4", P.lt(""))
                                       .has("age", 2))
                              .select("v").count().next();
+
+        Assert.assertEquals(0L, direct);
+        Assert.assertEquals(direct, viaMatch);
+    }
+
+    @Test
+    public void testTextRangeFilterKeepsEdgeGraphHasStep() {
+        this.initTextRangeSchema(true);
+
+        Vertex v1 = graph().addVertex(T.label, "vl1", "vp4", "a", "age", 1);
+        Vertex v2 = graph().addVertex(T.label, "vl1", "vp4", "b", "age", 2);
+        v1.addEdge("el2", v2, "ep4", "a");
+        commitTx();
+
+        long direct = graph().traversal().E()
+                           .has("ep4", P.lt(""))
+                           .count().next();
+        long viaMatch = graph().traversal().E()
+                             .match(__.as("e").has("ep4", P.lt("")))
+                             .select("e").count().next();
 
         Assert.assertEquals(0L, direct);
         Assert.assertEquals(direct, viaMatch);

--- a/hugegraph-server/hugegraph-test/src/main/java/org/apache/hugegraph/core/CountStrategyCoreTest.java
+++ b/hugegraph-server/hugegraph-test/src/main/java/org/apache/hugegraph/core/CountStrategyCoreTest.java
@@ -175,11 +175,13 @@ public class CountStrategyCoreTest extends BaseCoreTest {
         commitTx();
 
         long direct = graph().traversal().V()
+                           .hasLabel("vl1")
                            .has("vp4", P.lt(""))
                            .has("age", 1)
                            .count().next();
         long viaMatch = graph().traversal().V()
-                             .match(__.as("v").has("vp4", P.lt(""))
+                             .match(__.as("v").hasLabel("vl1")
+                                      .has("vp4", P.lt(""))
                                       .has("age", 1))
                              .select("v").count().next();
 
@@ -197,12 +199,45 @@ public class CountStrategyCoreTest extends BaseCoreTest {
         commitTx();
 
         long direct = graph().traversal().V(v1.id()).out("el2")
+                           .hasLabel("vl1")
                            .has("vp4", P.lt(""))
                            .has("age", 2)
                            .count().next();
         long viaMatch = graph().traversal().V(v1.id()).out("el2")
-                             .match(__.as("v").has("vp4", P.lt(""))
+                             .match(__.as("v").hasLabel("vl1")
+                                      .has("vp4", P.lt(""))
                                       .has("age", 2))
+                             .select("v").count().next();
+
+        Assert.assertEquals(0L, direct);
+        Assert.assertEquals(direct, viaMatch);
+    }
+
+    @Test
+    public void testTextRangeFilterDoesNotExtractIndexFromOtherLabel() {
+        SchemaManager schema = graph().schema();
+        schema.propertyKey("vp4").asText().create();
+        schema.propertyKey("age").asInt().create();
+        schema.vertexLabel("vl1").properties("vp4", "age")
+              .nullableKeys("vp4", "age").create();
+        schema.vertexLabel("vl2").properties("vp4", "age")
+              .nullableKeys("vp4", "age").create();
+        schema.indexLabel("vl1ByAge").onV("vl1").range()
+              .by("age").create();
+
+        graph().addVertex(T.label, "vl2", "vp4", "a", "age", 1);
+        graph().addVertex(T.label, "vl2", "vp4", "b", "age", 2);
+        commitTx();
+
+        long direct = graph().traversal().V()
+                           .hasLabel("vl2")
+                           .has("vp4", P.lt(""))
+                           .has("age", 1)
+                           .count().next();
+        long viaMatch = graph().traversal().V()
+                             .match(__.as("v").hasLabel("vl2")
+                                      .has("vp4", P.lt(""))
+                                      .has("age", 1))
                              .select("v").count().next();
 
         Assert.assertEquals(0L, direct);

--- a/hugegraph-server/hugegraph-test/src/main/java/org/apache/hugegraph/core/CountStrategyCoreTest.java
+++ b/hugegraph-server/hugegraph-test/src/main/java/org/apache/hugegraph/core/CountStrategyCoreTest.java
@@ -49,11 +49,19 @@ public class CountStrategyCoreTest extends BaseCoreTest {
     }
 
     private void initTextRangeSchema(boolean withEdge) {
+        this.initTextRangeSchema(withEdge, false);
+    }
+
+    private void initTextRangeSchema(boolean withEdge, boolean withAgeIndex) {
         SchemaManager schema = graph().schema();
         schema.propertyKey("vp4").asText().create();
         schema.propertyKey("age").asInt().create();
         schema.vertexLabel("vl1").properties("vp4", "age")
               .nullableKeys("vp4", "age").create();
+        if (withAgeIndex) {
+            schema.indexLabel("vl1ByAge").onV("vl1").range()
+                  .by("age").create();
+        }
         if (withEdge) {
             schema.edgeLabel("el2").link("vl1", "vl1").create();
         }
@@ -160,7 +168,7 @@ public class CountStrategyCoreTest extends BaseCoreTest {
 
     @Test
     public void testTextRangeFilterDoesNotStopLaterGraphHasExtraction() {
-        this.initTextRangeSchema(false);
+        this.initTextRangeSchema(false, true);
 
         graph().addVertex(T.label, "vl1", "vp4", "a", "age", 1);
         graph().addVertex(T.label, "vl1", "vp4", "b", "age", 2);
@@ -181,7 +189,7 @@ public class CountStrategyCoreTest extends BaseCoreTest {
 
     @Test
     public void testTextRangeFilterDoesNotStopLaterVertexHasExtraction() {
-        this.initTextRangeSchema(true);
+        this.initTextRangeSchema(true, true);
 
         Vertex v1 = graph().addVertex(T.label, "vl1", "vp4", "a", "age", 1);
         Vertex v2 = graph().addVertex(T.label, "vl1", "vp4", "b", "age", 2);

--- a/hugegraph-server/hugegraph-test/src/main/java/org/apache/hugegraph/core/CountStrategyCoreTest.java
+++ b/hugegraph-server/hugegraph-test/src/main/java/org/apache/hugegraph/core/CountStrategyCoreTest.java
@@ -243,4 +243,59 @@ public class CountStrategyCoreTest extends BaseCoreTest {
         Assert.assertEquals(0L, direct);
         Assert.assertEquals(direct, viaMatch);
     }
+
+    @Test
+    public void testTextRangeFilterDoesNotExtractNonPrefixCompositeIndex() {
+        SchemaManager schema = graph().schema();
+        schema.propertyKey("vp4").asText().create();
+        schema.propertyKey("age").asInt().create();
+        schema.propertyKey("city").asText().create();
+        schema.vertexLabel("vl1").properties("vp4", "age", "city")
+              .nullableKeys("vp4", "age", "city").create();
+        schema.indexLabel("vl1ByCityAge").onV("vl1").secondary()
+              .by("city", "age").create();
+
+        graph().addVertex(T.label, "vl1", "vp4", "a", "age", 1,
+                          "city", "Beijing");
+        graph().addVertex(T.label, "vl1", "vp4", "b", "age", 2,
+                          "city", "Shanghai");
+        commitTx();
+
+        long direct = graph().traversal().V()
+                           .hasLabel("vl1")
+                           .has("vp4", P.lt(""))
+                           .has("age", 1)
+                           .count().next();
+        long viaMatch = graph().traversal().V()
+                             .match(__.as("v").hasLabel("vl1")
+                                      .has("vp4", P.lt(""))
+                                      .has("age", 1))
+                             .select("v").count().next();
+
+        Assert.assertEquals(0L, direct);
+        Assert.assertEquals(direct, viaMatch);
+    }
+
+    @Test
+    public void testTextRangeFilterDoesNotExtractNeqPredicate() {
+        this.initTextRangeSchema(false, true);
+
+        graph().addVertex(T.label, "vl1", "vp4", "a", "age", 1);
+        graph().addVertex(T.label, "vl1", "vp4", "b", "age", 2);
+        commitTx();
+
+        long direct = graph().traversal().V()
+                           .hasLabel("vl1")
+                           .has("vp4", P.lt(""))
+                           .has("age", P.neq(1))
+                           .count().next();
+        long viaMatch = graph().traversal().V()
+                             .match(__.as("v").hasLabel("vl1")
+                                      .has("vp4", P.lt(""))
+                                      .has("age", P.neq(1)))
+                             .select("v").count().next();
+
+        Assert.assertEquals(0L, direct);
+        Assert.assertEquals(direct, viaMatch);
+    }
 }

--- a/hugegraph-server/hugegraph-test/src/main/java/org/apache/hugegraph/core/CountStrategyCoreTest.java
+++ b/hugegraph-server/hugegraph-test/src/main/java/org/apache/hugegraph/core/CountStrategyCoreTest.java
@@ -49,19 +49,11 @@ public class CountStrategyCoreTest extends BaseCoreTest {
     }
 
     private void initTextRangeSchema(boolean withEdge) {
-        this.initTextRangeSchema(withEdge, false);
-    }
-
-    private void initTextRangeSchema(boolean withEdge, boolean withAgeIndex) {
         SchemaManager schema = graph().schema();
         schema.propertyKey("vp4").asText().create();
         schema.propertyKey("age").asInt().create();
         schema.vertexLabel("vl1").properties("vp4", "age")
               .nullableKeys("vp4", "age").create();
-        if (withAgeIndex) {
-            schema.indexLabel("vl1ByAge").onV("vl1").range()
-                  .by("age").create();
-        }
         if (withEdge) {
             schema.edgeLabel("el2").link("vl1", "vl1").create();
         }
@@ -167,8 +159,8 @@ public class CountStrategyCoreTest extends BaseCoreTest {
     }
 
     @Test
-    public void testTextRangeFilterDoesNotStopLaterGraphHasExtraction() {
-        this.initTextRangeSchema(false, true);
+    public void testTextRangeFilterKeepsMixedGraphHasStep() {
+        this.initTextRangeSchema(false);
 
         graph().addVertex(T.label, "vl1", "vp4", "a", "age", 1);
         graph().addVertex(T.label, "vl1", "vp4", "b", "age", 2);
@@ -190,8 +182,8 @@ public class CountStrategyCoreTest extends BaseCoreTest {
     }
 
     @Test
-    public void testTextRangeFilterDoesNotStopLaterVertexHasExtraction() {
-        this.initTextRangeSchema(true, true);
+    public void testTextRangeFilterKeepsMixedVertexHasStep() {
+        this.initTextRangeSchema(true);
 
         Vertex v1 = graph().addVertex(T.label, "vl1", "vp4", "a", "age", 1);
         Vertex v2 = graph().addVertex(T.label, "vl1", "vp4", "b", "age", 2);
@@ -213,89 +205,4 @@ public class CountStrategyCoreTest extends BaseCoreTest {
         Assert.assertEquals(direct, viaMatch);
     }
 
-    @Test
-    public void testTextRangeFilterDoesNotExtractIndexFromOtherLabel() {
-        SchemaManager schema = graph().schema();
-        schema.propertyKey("vp4").asText().create();
-        schema.propertyKey("age").asInt().create();
-        schema.vertexLabel("vl1").properties("vp4", "age")
-              .nullableKeys("vp4", "age").create();
-        schema.vertexLabel("vl2").properties("vp4", "age")
-              .nullableKeys("vp4", "age").create();
-        schema.indexLabel("vl1ByAge").onV("vl1").range()
-              .by("age").create();
-
-        graph().addVertex(T.label, "vl2", "vp4", "a", "age", 1);
-        graph().addVertex(T.label, "vl2", "vp4", "b", "age", 2);
-        commitTx();
-
-        long direct = graph().traversal().V()
-                           .hasLabel("vl2")
-                           .has("vp4", P.lt(""))
-                           .has("age", 1)
-                           .count().next();
-        long viaMatch = graph().traversal().V()
-                             .match(__.as("v").hasLabel("vl2")
-                                      .has("vp4", P.lt(""))
-                                      .has("age", 1))
-                             .select("v").count().next();
-
-        Assert.assertEquals(0L, direct);
-        Assert.assertEquals(direct, viaMatch);
-    }
-
-    @Test
-    public void testTextRangeFilterDoesNotExtractNonPrefixCompositeIndex() {
-        SchemaManager schema = graph().schema();
-        schema.propertyKey("vp4").asText().create();
-        schema.propertyKey("age").asInt().create();
-        schema.propertyKey("city").asText().create();
-        schema.vertexLabel("vl1").properties("vp4", "age", "city")
-              .nullableKeys("vp4", "age", "city").create();
-        schema.indexLabel("vl1ByCityAge").onV("vl1").secondary()
-              .by("city", "age").create();
-
-        graph().addVertex(T.label, "vl1", "vp4", "a", "age", 1,
-                          "city", "Beijing");
-        graph().addVertex(T.label, "vl1", "vp4", "b", "age", 2,
-                          "city", "Shanghai");
-        commitTx();
-
-        long direct = graph().traversal().V()
-                           .hasLabel("vl1")
-                           .has("vp4", P.lt(""))
-                           .has("age", 1)
-                           .count().next();
-        long viaMatch = graph().traversal().V()
-                             .match(__.as("v").hasLabel("vl1")
-                                      .has("vp4", P.lt(""))
-                                      .has("age", 1))
-                             .select("v").count().next();
-
-        Assert.assertEquals(0L, direct);
-        Assert.assertEquals(direct, viaMatch);
-    }
-
-    @Test
-    public void testTextRangeFilterDoesNotExtractNeqPredicate() {
-        this.initTextRangeSchema(false, true);
-
-        graph().addVertex(T.label, "vl1", "vp4", "a", "age", 1);
-        graph().addVertex(T.label, "vl1", "vp4", "b", "age", 2);
-        commitTx();
-
-        long direct = graph().traversal().V()
-                           .hasLabel("vl1")
-                           .has("vp4", P.lt(""))
-                           .has("age", P.neq(1))
-                           .count().next();
-        long viaMatch = graph().traversal().V()
-                             .match(__.as("v").hasLabel("vl1")
-                                      .has("vp4", P.lt(""))
-                                      .has("age", P.neq(1)))
-                             .select("v").count().next();
-
-        Assert.assertEquals(0L, direct);
-        Assert.assertEquals(direct, viaMatch);
-    }
 }

--- a/hugegraph-server/hugegraph-test/src/main/java/org/apache/hugegraph/core/CountStrategyCoreTest.java
+++ b/hugegraph-server/hugegraph-test/src/main/java/org/apache/hugegraph/core/CountStrategyCoreTest.java
@@ -130,12 +130,13 @@ public class CountStrategyCoreTest extends BaseCoreTest {
     public void testRepeatAfterTextRangeFilterWithEmptyResult() {
         SchemaManager schema = graph().schema();
         schema.propertyKey("vp4").asText().create();
-        schema.vertexLabel("vl1").properties("vp4")
-              .nullableKeys("vp4").create();
+        schema.propertyKey("age").asInt().create();
+        schema.vertexLabel("vl1").properties("vp4", "age")
+              .nullableKeys("vp4", "age").create();
         schema.edgeLabel("el2").link("vl1", "vl1").create();
 
-        Vertex v1 = graph().addVertex(T.label, "vl1", "vp4", "a");
-        Vertex v2 = graph().addVertex(T.label, "vl1", "vp4", "b");
+        Vertex v1 = graph().addVertex(T.label, "vl1", "vp4", "a", "age", 1);
+        Vertex v2 = graph().addVertex(T.label, "vl1", "vp4", "b", "age", 2);
         v1.addEdge("el2", v2);
         commitTx();
 
@@ -146,6 +147,58 @@ public class CountStrategyCoreTest extends BaseCoreTest {
                              .match(__.as("start").has("vp4", P.lt(""))
                                       .out("el2").as("m"))
                              .select("m").count().next();
+
+        Assert.assertEquals(0L, direct);
+        Assert.assertEquals(viaMatch, direct);
+    }
+
+    @Test
+    public void testTextRangeFilterDoesNotStopLaterGraphHasExtraction() {
+        SchemaManager schema = graph().schema();
+        schema.propertyKey("vp4").asText().create();
+        schema.propertyKey("age").asInt().create();
+        schema.vertexLabel("vl1").properties("vp4", "age")
+              .nullableKeys("vp4", "age").create();
+
+        graph().addVertex(T.label, "vl1", "vp4", "a", "age", 1);
+        graph().addVertex(T.label, "vl1", "vp4", "b", "age", 2);
+        commitTx();
+
+        long direct = graph().traversal().V()
+                           .has("vp4", P.lt(""))
+                           .has("age", 1)
+                           .count().next();
+        long viaMatch = graph().traversal().V()
+                             .match(__.as("v").has("vp4", P.lt(""))
+                                      .has("age", 1))
+                             .select("v").count().next();
+
+        Assert.assertEquals(0L, direct);
+        Assert.assertEquals(viaMatch, direct);
+    }
+
+    @Test
+    public void testTextRangeFilterDoesNotStopLaterVertexHasExtraction() {
+        SchemaManager schema = graph().schema();
+        schema.propertyKey("vp4").asText().create();
+        schema.propertyKey("age").asInt().create();
+        schema.vertexLabel("vl1").properties("vp4", "age")
+              .nullableKeys("vp4", "age").create();
+        schema.edgeLabel("el2").link("vl1", "vl1").create();
+
+        Vertex v1 = graph().addVertex(T.label, "vl1", "vp4", "a", "age", 1);
+        Vertex v2 = graph().addVertex(T.label, "vl1", "vp4", "b", "age", 2);
+        v1.addEdge("el2", v2);
+        commitTx();
+
+        long direct = graph().traversal().V(v1.id()).out("el2")
+                           .has("vp4", P.lt(""))
+                           .has("age", 2)
+                           .count().next();
+        long viaMatch = graph().traversal().V(v1.id()).out("el2")
+                             .match(__.as("v").has("vp4", P.lt(""))
+                                      .has("age", 2))
+                             .select("v").count().next();
 
         Assert.assertEquals(0L, direct);
         Assert.assertEquals(viaMatch, direct);

--- a/hugegraph-server/hugegraph-test/src/main/java/org/apache/hugegraph/core/CountStrategyCoreTest.java
+++ b/hugegraph-server/hugegraph-test/src/main/java/org/apache/hugegraph/core/CountStrategyCoreTest.java
@@ -48,6 +48,17 @@ public class CountStrategyCoreTest extends BaseCoreTest {
         commitTx();
     }
 
+    private void initTextRangeSchema(boolean withEdge) {
+        SchemaManager schema = graph().schema();
+        schema.propertyKey("vp4").asText().create();
+        schema.propertyKey("age").asInt().create();
+        schema.vertexLabel("vl1").properties("vp4", "age")
+              .nullableKeys("vp4", "age").create();
+        if (withEdge) {
+            schema.edgeLabel("el2").link("vl1", "vl1").create();
+        }
+    }
+
     @Test
     public void testWhereCountLtNegativeIsAlwaysFalse() {
         this.initSchema();
@@ -82,7 +93,7 @@ public class CountStrategyCoreTest extends BaseCoreTest {
                              .count().next();
 
         Assert.assertEquals(1L, direct);
-        Assert.assertEquals(viaMatch, direct);
+        Assert.assertEquals(direct, viaMatch);
     }
 
     @Test
@@ -128,12 +139,7 @@ public class CountStrategyCoreTest extends BaseCoreTest {
 
     @Test
     public void testRepeatAfterTextRangeFilterWithEmptyResult() {
-        SchemaManager schema = graph().schema();
-        schema.propertyKey("vp4").asText().create();
-        schema.propertyKey("age").asInt().create();
-        schema.vertexLabel("vl1").properties("vp4", "age")
-              .nullableKeys("vp4", "age").create();
-        schema.edgeLabel("el2").link("vl1", "vl1").create();
+        this.initTextRangeSchema(true);
 
         Vertex v1 = graph().addVertex(T.label, "vl1", "vp4", "a", "age", 1);
         Vertex v2 = graph().addVertex(T.label, "vl1", "vp4", "b", "age", 2);
@@ -149,16 +155,12 @@ public class CountStrategyCoreTest extends BaseCoreTest {
                              .select("m").count().next();
 
         Assert.assertEquals(0L, direct);
-        Assert.assertEquals(viaMatch, direct);
+        Assert.assertEquals(direct, viaMatch);
     }
 
     @Test
     public void testTextRangeFilterDoesNotStopLaterGraphHasExtraction() {
-        SchemaManager schema = graph().schema();
-        schema.propertyKey("vp4").asText().create();
-        schema.propertyKey("age").asInt().create();
-        schema.vertexLabel("vl1").properties("vp4", "age")
-              .nullableKeys("vp4", "age").create();
+        this.initTextRangeSchema(false);
 
         graph().addVertex(T.label, "vl1", "vp4", "a", "age", 1);
         graph().addVertex(T.label, "vl1", "vp4", "b", "age", 2);
@@ -174,17 +176,12 @@ public class CountStrategyCoreTest extends BaseCoreTest {
                              .select("v").count().next();
 
         Assert.assertEquals(0L, direct);
-        Assert.assertEquals(viaMatch, direct);
+        Assert.assertEquals(direct, viaMatch);
     }
 
     @Test
     public void testTextRangeFilterDoesNotStopLaterVertexHasExtraction() {
-        SchemaManager schema = graph().schema();
-        schema.propertyKey("vp4").asText().create();
-        schema.propertyKey("age").asInt().create();
-        schema.vertexLabel("vl1").properties("vp4", "age")
-              .nullableKeys("vp4", "age").create();
-        schema.edgeLabel("el2").link("vl1", "vl1").create();
+        this.initTextRangeSchema(true);
 
         Vertex v1 = graph().addVertex(T.label, "vl1", "vp4", "a", "age", 1);
         Vertex v2 = graph().addVertex(T.label, "vl1", "vp4", "b", "age", 2);
@@ -201,6 +198,6 @@ public class CountStrategyCoreTest extends BaseCoreTest {
                              .select("v").count().next();
 
         Assert.assertEquals(0L, direct);
-        Assert.assertEquals(viaMatch, direct);
+        Assert.assertEquals(direct, viaMatch);
     }
 }

--- a/hugegraph-server/hugegraph-test/src/main/java/org/apache/hugegraph/core/CountStrategyCoreTest.java
+++ b/hugegraph-server/hugegraph-test/src/main/java/org/apache/hugegraph/core/CountStrategyCoreTest.java
@@ -125,4 +125,29 @@ public class CountStrategyCoreTest extends BaseCoreTest {
 
         Assert.assertEquals(4L, count);
     }
+
+    @Test
+    public void testRepeatAfterTextRangeFilterWithEmptyResult() {
+        SchemaManager schema = graph().schema();
+        schema.propertyKey("vp4").asText().create();
+        schema.vertexLabel("vl1").properties("vp4")
+              .nullableKeys("vp4").create();
+        schema.edgeLabel("el2").link("vl1", "vl1").create();
+
+        Vertex v1 = graph().addVertex(T.label, "vl1", "vp4", "a");
+        Vertex v2 = graph().addVertex(T.label, "vl1", "vp4", "b");
+        v1.addEdge("el2", v2);
+        commitTx();
+
+        long direct = graph().traversal().V().has("vp4", P.lt(""))
+                           .repeat(__.out("el2")).emit().times(1)
+                           .count().next();
+        long viaMatch = graph().traversal().V()
+                             .match(__.as("start").has("vp4", P.lt(""))
+                                      .out("el2").as("m"))
+                             .select("m").count().next();
+
+        Assert.assertEquals(0L, direct);
+        Assert.assertEquals(viaMatch, direct);
+    }
 }

--- a/hugegraph-server/hugegraph-test/src/main/java/org/apache/hugegraph/traversal/optimize/TraversalUtilOptimizeTest.java
+++ b/hugegraph-server/hugegraph-test/src/main/java/org/apache/hugegraph/traversal/optimize/TraversalUtilOptimizeTest.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hugegraph.traversal.optimize;
+
+import org.apache.hugegraph.testutil.Assert;
+import org.apache.tinkerpop.gremlin.process.traversal.P;
+import org.apache.tinkerpop.gremlin.process.traversal.step.util.HasContainer;
+import org.junit.Test;
+
+public class TraversalUtilOptimizeTest {
+
+    @Test
+    public void testCanExtractHasContainerWithoutGraph() {
+        Assert.assertTrue(TraversalUtil.canExtractHasContainer(
+                null, new HasContainer("~label", P.eq("person"))));
+        Assert.assertFalse(TraversalUtil.canExtractHasContainer(
+                null, new HasContainer("name", P.eq("marko"))));
+    }
+}

--- a/hugegraph-server/hugegraph-test/src/main/java/org/apache/hugegraph/traversal/optimize/TraversalUtilOptimizeTest.java
+++ b/hugegraph-server/hugegraph-test/src/main/java/org/apache/hugegraph/traversal/optimize/TraversalUtilOptimizeTest.java
@@ -66,7 +66,7 @@ public class TraversalUtilOptimizeTest {
     }
 
     @Test
-    public void testCanExtractHasContainerWithPropertyIndex() {
+    public void testCanExtractHasContainerWithoutLabelContext() {
         HugeGraph graph = Mockito.mock(HugeGraph.class);
         PropertyKey age = propertyKey(1L, "age", DataType.INT);
         IndexLabel ageIndex = new IndexLabel(null, IdGenerator.of(2L),
@@ -76,7 +76,7 @@ public class TraversalUtilOptimizeTest {
         Mockito.when(graph.indexLabels())
                .thenReturn(Collections.singletonList(ageIndex));
 
-        Assert.assertTrue(TraversalUtil.canExtractHasContainer(
+        Assert.assertFalse(TraversalUtil.canExtractHasContainer(
                 graph, new HasContainer("age", P.eq(1))));
     }
 

--- a/hugegraph-server/hugegraph-test/src/main/java/org/apache/hugegraph/traversal/optimize/TraversalUtilOptimizeTest.java
+++ b/hugegraph-server/hugegraph-test/src/main/java/org/apache/hugegraph/traversal/optimize/TraversalUtilOptimizeTest.java
@@ -17,9 +17,16 @@
 
 package org.apache.hugegraph.traversal.optimize;
 
+import java.util.Collections;
+
 import org.apache.hugegraph.HugeGraph;
+import org.apache.hugegraph.backend.id.Id;
+import org.apache.hugegraph.backend.id.IdGenerator;
 import org.apache.hugegraph.exception.NotFoundException;
+import org.apache.hugegraph.schema.IndexLabel;
+import org.apache.hugegraph.schema.PropertyKey;
 import org.apache.hugegraph.testutil.Assert;
+import org.apache.hugegraph.type.define.DataType;
 import org.apache.tinkerpop.gremlin.process.traversal.P;
 import org.apache.tinkerpop.gremlin.process.traversal.step.util.HasContainer;
 import org.junit.Test;
@@ -31,6 +38,8 @@ public class TraversalUtilOptimizeTest {
     public void testCanExtractHasContainerWithoutGraph() {
         Assert.assertTrue(TraversalUtil.canExtractHasContainer(
                 null, new HasContainer("~label", P.eq("person"))));
+        Assert.assertTrue(TraversalUtil.canExtractHasContainer(
+                null, new HasContainer("~id", P.eq("1"))));
         Assert.assertFalse(TraversalUtil.canExtractHasContainer(
                 null, new HasContainer("name", P.eq("marko"))));
     }
@@ -43,5 +52,39 @@ public class TraversalUtilOptimizeTest {
 
         Assert.assertFalse(TraversalUtil.canExtractHasContainer(
                 graph, new HasContainer("missing", P.eq("marko"))));
+    }
+
+    @Test
+    public void testCanExtractHasContainerWithoutPropertyIndex() {
+        HugeGraph graph = Mockito.mock(HugeGraph.class);
+        PropertyKey age = propertyKey(1L, "age", DataType.INT);
+        Mockito.when(graph.propertyKey("age")).thenReturn(age);
+        Mockito.when(graph.indexLabels()).thenReturn(Collections.emptyList());
+
+        Assert.assertFalse(TraversalUtil.canExtractHasContainer(
+                graph, new HasContainer("age", P.eq(1))));
+    }
+
+    @Test
+    public void testCanExtractHasContainerWithPropertyIndex() {
+        HugeGraph graph = Mockito.mock(HugeGraph.class);
+        PropertyKey age = propertyKey(1L, "age", DataType.INT);
+        IndexLabel ageIndex = new IndexLabel(null, IdGenerator.of(2L),
+                                            "vl1ByAge");
+        ageIndex.indexFields(age.id());
+        Mockito.when(graph.propertyKey("age")).thenReturn(age);
+        Mockito.when(graph.indexLabels())
+               .thenReturn(Collections.singletonList(ageIndex));
+
+        Assert.assertTrue(TraversalUtil.canExtractHasContainer(
+                graph, new HasContainer("age", P.eq(1))));
+    }
+
+    private static PropertyKey propertyKey(long id, String name,
+                                           DataType dataType) {
+        Id keyId = IdGenerator.of(id);
+        PropertyKey key = new PropertyKey(null, keyId, name);
+        key.dataType(dataType);
+        return key;
     }
 }

--- a/hugegraph-server/hugegraph-test/src/main/java/org/apache/hugegraph/traversal/optimize/TraversalUtilOptimizeTest.java
+++ b/hugegraph-server/hugegraph-test/src/main/java/org/apache/hugegraph/traversal/optimize/TraversalUtilOptimizeTest.java
@@ -17,10 +17,13 @@
 
 package org.apache.hugegraph.traversal.optimize;
 
+import org.apache.hugegraph.HugeGraph;
+import org.apache.hugegraph.exception.NotFoundException;
 import org.apache.hugegraph.testutil.Assert;
 import org.apache.tinkerpop.gremlin.process.traversal.P;
 import org.apache.tinkerpop.gremlin.process.traversal.step.util.HasContainer;
 import org.junit.Test;
+import org.mockito.Mockito;
 
 public class TraversalUtilOptimizeTest {
 
@@ -30,5 +33,15 @@ public class TraversalUtilOptimizeTest {
                 null, new HasContainer("~label", P.eq("person"))));
         Assert.assertFalse(TraversalUtil.canExtractHasContainer(
                 null, new HasContainer("name", P.eq("marko"))));
+    }
+
+    @Test
+    public void testCanExtractHasContainerWithMissingPropertyKey() {
+        HugeGraph graph = Mockito.mock(HugeGraph.class);
+        Mockito.when(graph.propertyKey("missing"))
+               .thenThrow(new NotFoundException("missing"));
+
+        Assert.assertFalse(TraversalUtil.canExtractHasContainer(
+                graph, new HasContainer("missing", P.eq("marko"))));
     }
 }

--- a/hugegraph-server/hugegraph-test/src/main/java/org/apache/hugegraph/traversal/optimize/TraversalUtilOptimizeTest.java
+++ b/hugegraph-server/hugegraph-test/src/main/java/org/apache/hugegraph/traversal/optimize/TraversalUtilOptimizeTest.java
@@ -78,6 +78,10 @@ public class TraversalUtilOptimizeTest {
 
         Assert.assertFalse(TraversalUtil.canExtractHasContainer(
                 graph, new HasContainer("name", P.lt(""))));
+        Assert.assertFalse(TraversalUtil.canExtractHasContainer(
+                graph, new HasContainer("name", P.gte("marko"))));
+        Assert.assertFalse(TraversalUtil.canExtractHasContainer(
+                graph, new HasContainer("name", P.between("josh", "marko"))));
         Assert.assertTrue(TraversalUtil.canExtractHasContainer(
                 graph, new HasContainer("name", P.eq("marko"))));
     }
@@ -90,6 +94,37 @@ public class TraversalUtilOptimizeTest {
 
         Traversal.Admin<?, ?> traversal = traversal(__.V()
                                                      .has("name", P.lt("marko")),
+                                                   graph);
+        HugeGraphStep<?, ?> newStep = replaceGraphStep(traversal);
+
+        TraversalUtil.extractHasContainer(newStep, traversal);
+
+        Assert.assertTrue(newStep.getHasContainers().isEmpty());
+        Assert.assertTrue(hasStepExists(traversal));
+    }
+
+    @Test
+    public void testExtractHasContainerKeepsTextRangeWithoutGraph() {
+        Traversal.Admin<?, ?> traversal = __.V()
+                                           .has("name", P.lt("marko"))
+                                           .asAdmin();
+        HugeGraphStep<?, ?> newStep = replaceGraphStep(traversal);
+
+        TraversalUtil.extractHasContainer(newStep, traversal);
+
+        Assert.assertTrue(newStep.getHasContainers().isEmpty());
+        Assert.assertTrue(hasStepExists(traversal));
+    }
+
+    @Test
+    public void testExtractHasContainerKeepsTextBetweenGraphHasStep() {
+        HugeGraph graph = Mockito.mock(HugeGraph.class);
+        PropertyKey name = propertyKey(1L, "name", DataType.TEXT);
+        Mockito.when(graph.propertyKey("name")).thenReturn(name);
+
+        Traversal.Admin<?, ?> traversal = traversal(__.V()
+                                                     .has("name", P.between(
+                                                             "josh", "marko")),
                                                    graph);
         HugeGraphStep<?, ?> newStep = replaceGraphStep(traversal);
 

--- a/hugegraph-server/hugegraph-test/src/main/java/org/apache/hugegraph/traversal/optimize/TraversalUtilOptimizeTest.java
+++ b/hugegraph-server/hugegraph-test/src/main/java/org/apache/hugegraph/traversal/optimize/TraversalUtilOptimizeTest.java
@@ -25,7 +25,16 @@ import org.apache.hugegraph.schema.PropertyKey;
 import org.apache.hugegraph.testutil.Assert;
 import org.apache.hugegraph.type.define.DataType;
 import org.apache.tinkerpop.gremlin.process.traversal.P;
+import org.apache.tinkerpop.gremlin.process.traversal.Step;
+import org.apache.tinkerpop.gremlin.process.traversal.Traversal;
+import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversal;
+import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__;
+import org.apache.tinkerpop.gremlin.process.traversal.step.filter.HasStep;
+import org.apache.tinkerpop.gremlin.process.traversal.step.map.GraphStep;
+import org.apache.tinkerpop.gremlin.process.traversal.step.map.VertexStep;
 import org.apache.tinkerpop.gremlin.process.traversal.step.util.HasContainer;
+import org.apache.tinkerpop.gremlin.process.traversal.util.TraversalHelper;
+import org.apache.tinkerpop.gremlin.structure.Vertex;
 import org.junit.Test;
 import org.mockito.Mockito;
 
@@ -73,11 +82,121 @@ public class TraversalUtilOptimizeTest {
                 graph, new HasContainer("name", P.eq("marko"))));
     }
 
+    @Test
+    public void testExtractHasContainerKeepsTextRangeGraphHasStep() {
+        HugeGraph graph = Mockito.mock(HugeGraph.class);
+        PropertyKey name = propertyKey(1L, "name", DataType.TEXT);
+        Mockito.when(graph.propertyKey("name")).thenReturn(name);
+
+        Traversal.Admin<?, ?> traversal = traversal(__.V()
+                                                     .has("name", P.lt("marko")),
+                                                   graph);
+        HugeGraphStep<?, ?> newStep = replaceGraphStep(traversal);
+
+        TraversalUtil.extractHasContainer(newStep, traversal);
+
+        Assert.assertTrue(newStep.getHasContainers().isEmpty());
+        Assert.assertTrue(hasStepExists(traversal));
+    }
+
+    @Test
+    public void testExtractHasContainerRemovesSafeGraphHasStep() {
+        HugeGraph graph = Mockito.mock(HugeGraph.class);
+        PropertyKey age = propertyKey(1L, "age", DataType.INT);
+        Mockito.when(graph.propertyKey("age")).thenReturn(age);
+
+        Traversal.Admin<?, ?> traversal = traversal(__.V().has("age", 18),
+                                                   graph);
+        HugeGraphStep<?, ?> newStep = replaceGraphStep(traversal);
+
+        TraversalUtil.extractHasContainer(newStep, traversal);
+
+        Assert.assertEquals(1, newStep.getHasContainers().size());
+        Assert.assertFalse(hasStepExists(traversal));
+    }
+
+    @Test
+    public void testExtractHasContainerKeepsTextRangeVertexHasStep() {
+        HugeGraph graph = Mockito.mock(HugeGraph.class);
+        PropertyKey name = propertyKey(1L, "name", DataType.TEXT);
+        Mockito.when(graph.propertyKey("name")).thenReturn(name);
+
+        Traversal.Admin<?, ?> traversal = traversal(__.V().out()
+                                                     .has("name", P.lt("marko")),
+                                                   graph);
+        HugeVertexStep<?> newStep = replaceVertexStep(traversal);
+
+        TraversalUtil.extractHasContainer(newStep, traversal);
+
+        Assert.assertTrue(newStep.getHasContainers().isEmpty());
+        Assert.assertTrue(hasStepExists(traversal));
+    }
+
+    @Test
+    public void testExtractHasContainerRemovesSafeVertexHasStep() {
+        HugeGraph graph = Mockito.mock(HugeGraph.class);
+        PropertyKey age = propertyKey(1L, "age", DataType.INT);
+        Mockito.when(graph.propertyKey("age")).thenReturn(age);
+
+        Traversal.Admin<?, ?> traversal = traversal(__.V().out().has("age", 18),
+                                                   graph);
+        HugeVertexStep<?> newStep = replaceVertexStep(traversal);
+
+        TraversalUtil.extractHasContainer(newStep, traversal);
+
+        Assert.assertEquals(1, newStep.getHasContainers().size());
+        Assert.assertFalse(hasStepExists(traversal));
+    }
+
     private static PropertyKey propertyKey(long id, String name,
                                            DataType dataType) {
         Id keyId = IdGenerator.of(id);
         PropertyKey key = new PropertyKey(null, keyId, name);
         key.dataType(dataType);
         return key;
+    }
+
+    private static Traversal.Admin<?, ?> traversal(GraphTraversal<?, ?> traversal,
+                                                   HugeGraph graph) {
+        Traversal.Admin<?, ?> admin = traversal.asAdmin();
+        admin.setGraph(graph);
+        return admin;
+    }
+
+    private static HugeGraphStep<?, ?> replaceGraphStep(Traversal.Admin<?, ?> traversal) {
+        GraphStep<?, ?> origin = (GraphStep<?, ?>) traversal.getStartStep();
+        HugeGraphStep<?, ?> newStep = new HugeGraphStep<>(origin);
+        replaceStep(origin, newStep, traversal);
+        return newStep;
+    }
+
+    @SuppressWarnings({"rawtypes", "unchecked"})
+    private static HugeVertexStep<?> replaceVertexStep(Traversal.Admin<?, ?> traversal) {
+        VertexStep<Vertex> origin = null;
+        for (Step<?, ?> step : traversal.getSteps()) {
+            if (step instanceof VertexStep) {
+                origin = (VertexStep) step;
+                break;
+            }
+        }
+        Assert.assertNotNull(origin);
+        HugeVertexStep<?> newStep = new HugeVertexStep<>(origin);
+        replaceStep(origin, newStep, traversal);
+        return newStep;
+    }
+
+    @SuppressWarnings({"rawtypes", "unchecked"})
+    private static void replaceStep(Step<?, ?> origin, Step<?, ?> newStep,
+                                    Traversal.Admin<?, ?> traversal) {
+        TraversalHelper.replaceStep((Step) origin, (Step) newStep, traversal);
+    }
+
+    private static boolean hasStepExists(Traversal.Admin<?, ?> traversal) {
+        for (Step<?, ?> step : traversal.getSteps()) {
+            if (step instanceof HasStep) {
+                return true;
+            }
+        }
+        return false;
     }
 }

--- a/hugegraph-server/hugegraph-test/src/main/java/org/apache/hugegraph/traversal/optimize/TraversalUtilOptimizeTest.java
+++ b/hugegraph-server/hugegraph-test/src/main/java/org/apache/hugegraph/traversal/optimize/TraversalUtilOptimizeTest.java
@@ -17,13 +17,10 @@
 
 package org.apache.hugegraph.traversal.optimize;
 
-import java.util.Collections;
-
 import org.apache.hugegraph.HugeGraph;
 import org.apache.hugegraph.backend.id.Id;
 import org.apache.hugegraph.backend.id.IdGenerator;
 import org.apache.hugegraph.exception.NotFoundException;
-import org.apache.hugegraph.schema.IndexLabel;
 import org.apache.hugegraph.schema.PropertyKey;
 import org.apache.hugegraph.testutil.Assert;
 import org.apache.hugegraph.type.define.DataType;
@@ -55,29 +52,25 @@ public class TraversalUtilOptimizeTest {
     }
 
     @Test
-    public void testCanExtractHasContainerWithoutPropertyIndex() {
+    public void testCanExtractHasContainerWithNonTextProperty() {
         HugeGraph graph = Mockito.mock(HugeGraph.class);
         PropertyKey age = propertyKey(1L, "age", DataType.INT);
         Mockito.when(graph.propertyKey("age")).thenReturn(age);
-        Mockito.when(graph.indexLabels()).thenReturn(Collections.emptyList());
 
-        Assert.assertFalse(TraversalUtil.canExtractHasContainer(
+        Assert.assertTrue(TraversalUtil.canExtractHasContainer(
                 graph, new HasContainer("age", P.eq(1))));
     }
 
     @Test
-    public void testCanExtractHasContainerWithoutLabelContext() {
+    public void testCanExtractHasContainerWithTextRangePredicate() {
         HugeGraph graph = Mockito.mock(HugeGraph.class);
-        PropertyKey age = propertyKey(1L, "age", DataType.INT);
-        IndexLabel ageIndex = new IndexLabel(null, IdGenerator.of(2L),
-                                            "vl1ByAge");
-        ageIndex.indexFields(age.id());
-        Mockito.when(graph.propertyKey("age")).thenReturn(age);
-        Mockito.when(graph.indexLabels())
-               .thenReturn(Collections.singletonList(ageIndex));
+        PropertyKey name = propertyKey(1L, "name", DataType.TEXT);
+        Mockito.when(graph.propertyKey("name")).thenReturn(name);
 
         Assert.assertFalse(TraversalUtil.canExtractHasContainer(
-                graph, new HasContainer("age", P.eq(1))));
+                graph, new HasContainer("name", P.lt(""))));
+        Assert.assertTrue(TraversalUtil.canExtractHasContainer(
+                graph, new HasContainer("name", P.eq("marko"))));
     }
 
     private static PropertyKey propertyKey(long id, String name,

--- a/hugegraph-server/hugegraph-test/src/main/java/org/apache/hugegraph/unit/UnitTestSuite.java
+++ b/hugegraph-server/hugegraph-test/src/main/java/org/apache/hugegraph/unit/UnitTestSuite.java
@@ -19,6 +19,7 @@ package org.apache.hugegraph.unit;
 
 import org.apache.hugegraph.core.RoleElectionStateMachineTest;
 import org.apache.hugegraph.meta.MetaManagerSchemaCacheClearEventTest;
+import org.apache.hugegraph.traversal.optimize.TraversalUtilOptimizeTest;
 import org.apache.hugegraph.unit.api.filter.LoadDetectFilterTest;
 import org.apache.hugegraph.unit.api.filter.PathFilterTest;
 import org.apache.hugegraph.unit.api.gremlin.GremlinQueryAPITest;
@@ -126,6 +127,7 @@ import org.junit.runners.Suite;
         ExceptionTest.class,
         BackendStoreInfoTest.class,
         TraversalUtilTest.class,
+        TraversalUtilOptimizeTest.class,
         PageStateTest.class,
         SystemSchemaStoreTest.class,
         ServerInfoManagerTest.class,

--- a/hugegraph-server/hugegraph-test/src/main/java/org/apache/hugegraph/unit/core/TraversalUtilTest.java
+++ b/hugegraph-server/hugegraph-test/src/main/java/org/apache/hugegraph/unit/core/TraversalUtilTest.java
@@ -17,14 +17,30 @@
 
 package org.apache.hugegraph.unit.core;
 
+import java.lang.reflect.Method;
+
 import org.apache.hugegraph.HugeException;
+import org.apache.hugegraph.HugeGraph;
 import org.apache.hugegraph.testutil.Assert;
 import org.apache.hugegraph.traversal.optimize.TraversalUtil;
 import org.apache.hugegraph.util.DateUtil;
 import org.apache.tinkerpop.gremlin.process.traversal.P;
+import org.apache.tinkerpop.gremlin.process.traversal.step.util.HasContainer;
 import org.junit.Test;
 
 public class TraversalUtilTest {
+
+    @Test
+    public void testCanExtractHasContainerWithoutGraph() throws Exception {
+        Method method = TraversalUtil.class.getDeclaredMethod(
+                "canExtractHasContainer", HugeGraph.class, HasContainer.class);
+        method.setAccessible(true);
+
+        Assert.assertTrue((Boolean) method.invoke(
+                null, null, new HasContainer("~label", P.eq("person"))));
+        Assert.assertFalse((Boolean) method.invoke(
+                null, null, new HasContainer("name", P.eq("marko"))));
+    }
 
     @Test
     public void testParsePredicate() {

--- a/hugegraph-server/hugegraph-test/src/main/java/org/apache/hugegraph/unit/core/TraversalUtilTest.java
+++ b/hugegraph-server/hugegraph-test/src/main/java/org/apache/hugegraph/unit/core/TraversalUtilTest.java
@@ -17,30 +17,14 @@
 
 package org.apache.hugegraph.unit.core;
 
-import java.lang.reflect.Method;
-
 import org.apache.hugegraph.HugeException;
-import org.apache.hugegraph.HugeGraph;
 import org.apache.hugegraph.testutil.Assert;
 import org.apache.hugegraph.traversal.optimize.TraversalUtil;
 import org.apache.hugegraph.util.DateUtil;
 import org.apache.tinkerpop.gremlin.process.traversal.P;
-import org.apache.tinkerpop.gremlin.process.traversal.step.util.HasContainer;
 import org.junit.Test;
 
 public class TraversalUtilTest {
-
-    @Test
-    public void testCanExtractHasContainerWithoutGraph() throws Exception {
-        Method method = TraversalUtil.class.getDeclaredMethod(
-                "canExtractHasContainer", HugeGraph.class, HasContainer.class);
-        method.setAccessible(true);
-
-        Assert.assertTrue((Boolean) method.invoke(
-                null, null, new HasContainer("~label", P.eq("person"))));
-        Assert.assertFalse((Boolean) method.invoke(
-                null, null, new HasContainer("name", P.eq("marko"))));
-    }
 
     @Test
     public void testParsePredicate() {


### PR DESCRIPTION
<!-- 
  Thank you very much for contributing to Apache HugeGraph, we are happy that you want to help us improve it!

  Here are some tips for you:
    1. If this is your first time, please read the [contributing guidelines](https://github.com/apache/hugegraph/blob/master/CONTRIBUTING.md)

    2. If a PR fix/close an issue, type the message "close xxx" (xxx is the link of related 
issue) in the content, GitHub will auto link it (Required)

    3. Name the PR title in "Google Commit Format", start with "feat | fix | perf | refactor | doc | chore", 
      such like: "feat(core): support the PageRank algorithm" or "fix: wrong break in the compute loop" (module is optional)
      skip it if you are unsure about which is the best component.

    4. One PR address one issue, better not to mix up multiple issues.

    5. Put an `x` in the `[ ]` to mark the item as CHECKED. `[x]` (or click it directly after 
published)
-->

## Purpose of the PR
- close #2935

This PR fixes the query-planning path exposed by #2935.

For top-level traversals like `g.V().has("vp4", P.lt("")).repeat(...).count()`,
HugeGraph may extract the text range predicate into a backend query. However,
range predicates on text properties should not be planned as backend range
index queries. This can make the direct traversal fail while an equivalent
`match()` traversal returns normally.

This change keeps such text range predicates in the traversal layer instead of
pushing them down to the backend query, making the direct traversal consistent
with the equivalent `match()` form.

<!--
Please explain more context in this section, clarify why the changes are needed. 
e.g:
- If you propose a new API, clarify the use case for a new API.
- If you fix a bug, you can clarify why it is a bug, and should be associated with an issue.
-->

## Main Changes

- Avoid extracting `Text` property predicates with `gt/gte/lt/lte` into
  `HugeGraphStep` / `HugeVertexStep` backend queries.
- Preserve normal extraction for system properties and non-text property
  predicates.
- Add a regression test for the reported traversal shape:
  `has("vp4", P.lt("")).repeat(__.out("el2")).emit().times(1).count()`.
- Verify that the direct traversal returns the same result as the equivalent
  `match()` traversal.

<!-- Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. These change logs are helpful for better and faster reviews.)

For example:

- If you introduce a new feature, please show detailed design here or add the link of design documentation.
- If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
- If there is a discussion in the mailing list, please add the link. -->

## Verifying these changes

<!-- Please pick the proper options below -->

- [ ] Trivial rework / code cleanup without any test coverage. (No Need)
- [ ] Already covered by existing tests, such as *(please modify tests here)*.
- [x] Need tests and can be verified as follows:
      - `mvn -pl hugegraph-server/hugegraph-test -am -P core-test,memory -Dtest=CountStrategyCoreTest#testRepeatAfterTextRangeFilterWithEmptyResult -DfailIfNoTests=false "-Drat.skip=true" "-Dcheckstyle.skip=true" test`
    - `mvn -pl hugegraph-server/hugegraph-test -am -P core-test,rocksdb -Dtest=CountStrategyCoreTest#testRepeatAfterTextRangeFilterWithEmptyResult -DfailIfNoTests=false "-Drat.skip=true" "-Dcheckstyle.skip=true" test`


## Does this PR potentially affect the following parts?

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ]  Dependencies ([add/update license](https://hugegraph.apache.org/docs/contribution-guidelines/contribute/#321-check-licenses) info & [regenerate_known_dependencies.sh](../install-dist/scripts/dependency/regenerate_known_dependencies.sh)) <!-- Don't forget to add/update the info in "LICENSE" & "NOTICE" files (both in root & dist module) -->
- [ ]  Modify configurations
- [ ]  The public API
- [ ]  Other affects (typed here)
- [x]  Nope


## Documentation Status

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ]  `Doc - TODO` <!-- Your PR changes impact docs and you will update later -->
- [ ]  `Doc - Done` <!-- Related docs have been already added or updated -->
- [x]  `Doc - No Need` <!-- Your PR changes don't impact/need docs -->
