### PR TITLE
fix(core): align count strategy connective steps

### DIFF
--- a/hugegraph-server/hugegraph-core/src/main/java/org/apache/hugegraph/traversal/optimize/HugeCountStrategy.java
+++ b/hugegraph-server/hugegraph-core/src/main/java/org/apache/hugegraph/traversal/optimize/HugeCountStrategy.java
@@ -190,19 +190,17 @@ public final class HugeCountStrategy
                         traversal.asAdmin().removeStep(curr);
                         size -= 2;
                         if (!dismissCountIs) {
-                            final TraversalParent p;
-                            if ((p = traversal.getParent()) instanceof FilterStep &&
-                                !(p instanceof ConnectiveStep)) {
-                                final Step<?, ?> filterStep = parent.asStep();
-                                final Traversal.Admin parentTraversal =
-                                        filterStep.getTraversal();
-                                final Step notStep = new NotStep<>(
-                                        parentTraversal,
-                                        traversal.getSteps().isEmpty() ?
-                                        __.identity() : traversal);
-                                filterStep.getLabels().forEach(notStep::addLabel);
+                            if (parent instanceof ConnectiveStep) {
+                                final Step<?, ?> notStep = this.transformToNotStep(
+                                        traversal, parent);
+                                TraversalHelper.removeAllSteps(traversal);
+                                traversal.addStep(notStep);
+                            } else if (parent instanceof FilterStep) {
+                                final Step filterStep = parent.asStep();
+                                final Step<?, ?> notStep = this.transformToNotStep(
+                                        traversal, parent);
                                 TraversalHelper.replaceStep(filterStep, notStep,
-                                                            parentTraversal);
+                                                            filterStep.getTraversal());
                             } else {
                                 final Traversal.Admin inner;
                                 if (prev != null) {
@@ -254,6 +252,17 @@ public final class HugeCountStrategy
             }
             prev = curr;
         }
+    }
+
+    private Step<?, ?> transformToNotStep(final Traversal.Admin<?, ?> traversal,
+                                          final TraversalParent parent) {
+        final Step<?, ?> filterStep = parent.asStep();
+        final Traversal.Admin<?, ?> parentTraversal = filterStep.getTraversal();
+        final Step<?, ?> notStep = new NotStep<>(
+                parentTraversal,
+                traversal.getSteps().isEmpty() ? __.identity() : traversal.clone());
+        filterStep.getLabels().forEach(notStep::addLabel);
+        return notStep;
     }
 
     private boolean doStrategy(final Step step) {

--- a/hugegraph-server/hugegraph-test/src/main/java/org/apache/hugegraph/core/CountStrategyCoreTest.java
+++ b/hugegraph-server/hugegraph-test/src/main/java/org/apache/hugegraph/core/CountStrategyCoreTest.java
@@ -37,10 +37,11 @@ public class CountStrategyCoreTest extends BaseCoreTest {
     private void initSchema() {
         SchemaManager schema = graph().schema();
         schema.propertyKey("name").asText().create();
-        schema.vertexLabel("person").properties("name")
-              .nullableKeys("name").create();
-        schema.vertexLabel("software").properties("name")
-              .nullableKeys("name").create();
+        schema.propertyKey("none").asText().create();
+        schema.vertexLabel("person").properties("name", "none")
+              .nullableKeys("name", "none").create();
+        schema.vertexLabel("software").properties("name", "none")
+              .nullableKeys("name", "none").create();
         schema.edgeLabel("knows").link("person", "person").create();
         schema.edgeLabel("created").link("person", "software").create();
     }
@@ -509,5 +510,59 @@ public class CountStrategyCoreTest extends BaseCoreTest {
         Assert.assertEquals(0, graphStep.getHasContainers().size());
         Assert.assertTrue(hasRemainingHasStep(traversal, "vp2"));
         Assert.assertEquals(1L, traversal.next());
+    }
+
+    @Test
+    public void testConnectiveAndCountIsZero() {
+        this.initSchema();
+        this.initGraph();
+
+        long count = graph().traversal().V()
+                            .filter(__.and(__.out().count().is(0),
+                                           __.in().count().is(0)))
+                            .count().next();
+
+        Assert.assertEquals(0L, count);
+    }
+
+    @Test
+    public void testConnectiveOrCountIsZero() {
+        this.initSchema();
+        this.initGraph();
+
+        long count = graph().traversal().V()
+                            .filter(__.or(__.out().count().is(0),
+                                          __.in().count().is(0)))
+                            .count().next();
+
+        Assert.assertEquals(3L, count);
+    }
+
+    @Test
+    public void testWhereOrWithMultiStepCountIsZero() {
+        this.initSchema();
+        this.initGraph();
+
+        long count = graph().traversal().V()
+                            .where(__.or(__.out("created").out("knows")
+                                           .count().is(0),
+                                         __.has("none")))
+                            .count().next();
+
+        Assert.assertEquals(3L, count);
+    }
+
+    @Test
+    public void testWhereOrWithMultipleCountIsZero() {
+        this.initSchema();
+        this.initGraph();
+
+        long count = graph().traversal().V()
+                            .where(__.or(__.out("created").out("knows")
+                                           .count().is(0),
+                                         __.has("none").count().is(0)))
+                            .count().next();
+
+        Assert.assertEquals(3L, count);
     }
 }


### PR DESCRIPTION
<!-- 
  Thank you very much for contributing to Apache HugeGraph, we are happy that you want to help us improve it!

  Here are some tips for you:
    1. If this is your first time, please read the [contributing guidelines](https://github.com/apache/hugegraph/blob/master/CONTRIBUTING.md)

    2. If a PR fix/close an issue, type the message "close xxx" (xxx is the link of related 
issue) in the content, GitHub will auto link it (Required)

    3. Name the PR title in "Google Commit Format", start with "feat | fix | perf | refactor | doc | chore", 
      such like: "feat(core): support the PageRank algorithm" or "fix: wrong break in the compute loop" (module is optional)
      skip it if you are unsure about which is the best component.

    4. One PR address one issue, better not to mix up multiple issues.

    5. Put an `x` in the `[ ]` to mark the item as CHECKED. `[x]` (or click it directly after 
published)
-->

## Purpose of the PR

- close #2995<!-- or use "fix #xxx", "xxx" is the ID-link of related issue, e.g: close #1024 -->

PR #2993 introduced `HugeCountStrategy` to guard HugeGraph against unsafe negative-bound `count().is(P)` optimizations.

This follow-up ports the upstream TINKERPOP-2911 `ConnectiveStep` handling into HugeGraph's local strategy, so `and()` / `or()` child traversals are rewritten consistently with upstream `CountStrategy`.

<!--
Please explain more context in this section, clarify why the changes are needed. 
e.g:
- If you propose a new API, clarify the use case for a new API.
- If you fix a bug, you can clarify why it is a bug, and should be associated with an issue.
-->

## Main Changes

- Handle `ConnectiveStep` separately when converting `count().is(0)` into `not(...)`
- Wrap the whole child traversal in `not(...)` using a cloned traversal, instead of only rewriting the tail step
- Reuse the same helper for `FilterStep` conversion
- Keep the existing negative-bound safeguards from PR #2993 unchanged
- Add regression coverage for connective `and()` / `or()` traversal shapes, including multi-step `where(or(...))` cases


<!-- Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. These change logs are helpful for better and faster reviews.)

For example:

- If you introduce a new feature, please show detailed design here or add the link of design documentation.
- If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
- If there is a discussion in the mailing list, please add the link. -->

## Verifying these changes

<!-- Please pick the proper options below -->

- [ ] Trivial rework / code cleanup without any test coverage. (No Need)
- [ ] Already covered by existing tests, such as *(please modify tests here)*.
- [ ] Need tests and can be verified as follows:
    - xxx

## Does this PR potentially affect the following parts?

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ]  Dependencies ([add/update license](https://hugegraph.apache.org/docs/contribution-guidelines/contribute/#321-check-licenses) info & [regenerate_known_dependencies.sh](../install-dist/scripts/dependency/regenerate_known_dependencies.sh)) <!-- Don't forget to add/update the info in "LICENSE" & "NOTICE" files (both in root & dist module) -->
- [ ]  Modify configurations
- [ ]  The public API
- [ ]  Other affects (typed here)
- [x]  Nope


## Documentation Status

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ]  `Doc - TODO` <!-- Your PR changes impact docs and you will update later -->
- [ ]  `Doc - Done` <!-- Related docs have been already added or updated -->
- [x]  `Doc - No Need` <!-- Your PR changes don't impact/need docs -->
