### PR TITLE
chore(ci): add gremlin-console smoke test

### DIFF
--- a/.github/workflows/server-ci.yml
+++ b/.github/workflows/server-ci.yml
@@ -82,6 +82,13 @@ jobs:
         run: |
           $TRAVIS_DIR/run-api-test.sh $BACKEND $REPORT_DIR
 
+      - name: Run Gremlin Console smoke test
+        if: ${{ matrix.BACKEND == 'rocksdb' }}
+        run: |
+          VERSION=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)
+          SERVER_DIR=hugegraph-server/apache-hugegraph-server-$VERSION/
+          bash "$TRAVIS_DIR/run-gremlin-console-smoke-test.sh" "$SERVER_DIR"
+
       # TODO: disable raft test in normal PR due to the always timeout problem
       - name: Run raft test
         if: ${{ env.RAFT_MODE == 'true' && env.BACKEND == 'rocksdb' }}
@@ -155,6 +162,12 @@ jobs:
       - name: Run RocksDB API test
         run: |
           $TRAVIS_DIR/run-api-test.sh $BACKEND $REPORT_DIR
+
+      - name: Run Gremlin Console smoke test
+        run: |
+          VERSION=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)
+          SERVER_DIR=hugegraph-server/apache-hugegraph-server-$VERSION/
+          bash "$TRAVIS_DIR/run-gremlin-console-smoke-test.sh" "$SERVER_DIR"
 
       - name: Show server log on failure
         if: failure()

--- a/.github/workflows/server-ci.yml
+++ b/.github/workflows/server-ci.yml
@@ -80,14 +80,11 @@ jobs:
 
       - name: Run api test
         run: |
-          $TRAVIS_DIR/run-api-test.sh $BACKEND $REPORT_DIR
-
-      - name: Run Gremlin Console smoke test
-        if: ${{ matrix.BACKEND == 'rocksdb' }}
-        run: |
-          VERSION=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)
-          SERVER_DIR=hugegraph-server/apache-hugegraph-server-$VERSION/
-          bash "$TRAVIS_DIR/run-gremlin-console-smoke-test.sh" "$SERVER_DIR"
+          if [ "$BACKEND" = "rocksdb" ]; then
+            $TRAVIS_DIR/run-api-test.sh $BACKEND $REPORT_DIR true
+          else
+            $TRAVIS_DIR/run-api-test.sh $BACKEND $REPORT_DIR
+          fi
 
       # TODO: disable raft test in normal PR due to the always timeout problem
       - name: Run raft test
@@ -161,13 +158,7 @@ jobs:
 
       - name: Run RocksDB API test
         run: |
-          $TRAVIS_DIR/run-api-test.sh $BACKEND $REPORT_DIR
-
-      - name: Run Gremlin Console smoke test
-        run: |
-          VERSION=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)
-          SERVER_DIR=hugegraph-server/apache-hugegraph-server-$VERSION/
-          bash "$TRAVIS_DIR/run-gremlin-console-smoke-test.sh" "$SERVER_DIR"
+          $TRAVIS_DIR/run-api-test.sh $BACKEND $REPORT_DIR true
 
       - name: Show server log on failure
         if: failure()

--- a/hugegraph-server/hugegraph-dist/src/assembly/travis/run-api-test.sh
+++ b/hugegraph-server/hugegraph-dist/src/assembly/travis/run-api-test.sh
@@ -20,6 +20,7 @@ set -ev
 BACKEND=$1
 REPORT_DIR=$2
 REPORT_FILE=$REPORT_DIR/jacoco-api-test-for-raft.xml
+RUN_GREMLIN_CONSOLE_SMOKE_TEST=${3:-false}
 
 TRAVIS_DIR=$(cd "$(dirname "$0")" && pwd)
 REPO_ROOT=$(cd "$TRAVIS_DIR/../../../../.." && pwd)
@@ -97,6 +98,11 @@ $TRAVIS_DIR/start-server.sh $SERVER_DIR $BACKEND $JACOCO_PORT || (cat $SERVER_DI
 
 # run api-test
 mvn test -pl hugegraph-server/hugegraph-test -am -P api-test,$BACKEND || (cat $SERVER_DIR/logs/hugegraph-server.log && exit 1)
+
+if [ "$RUN_GREMLIN_CONSOLE_SMOKE_TEST" == "true" ]; then
+    $TRAVIS_DIR/run-gremlin-console-smoke-test.sh "$SERVER_DIR" || \
+        (cat "$SERVER_DIR/logs/hugegraph-server.log" && exit 1)
+fi
 
 $TRAVIS_DIR/build-report.sh $BACKEND $JACOCO_PORT $REPORT_FILE
 

--- a/hugegraph-server/hugegraph-dist/src/assembly/travis/run-api-test.sh
+++ b/hugegraph-server/hugegraph-dist/src/assembly/travis/run-api-test.sh
@@ -100,7 +100,7 @@ $TRAVIS_DIR/start-server.sh $SERVER_DIR $BACKEND $JACOCO_PORT || (cat $SERVER_DI
 mvn test -pl hugegraph-server/hugegraph-test -am -P api-test,$BACKEND || (cat $SERVER_DIR/logs/hugegraph-server.log && exit 1)
 
 if [ "$RUN_GREMLIN_CONSOLE_SMOKE_TEST" == "true" ]; then
-    $TRAVIS_DIR/run-gremlin-console-smoke-test.sh "$SERVER_DIR" || \
+    bash "$TRAVIS_DIR/run-gremlin-console-smoke-test.sh" "$SERVER_DIR" || \
         (cat "$SERVER_DIR/logs/hugegraph-server.log" && exit 1)
 fi
 

--- a/hugegraph-server/hugegraph-dist/src/assembly/travis/run-gremlin-console-smoke-test.sh
+++ b/hugegraph-server/hugegraph-dist/src/assembly/travis/run-gremlin-console-smoke-test.sh
@@ -38,23 +38,27 @@ fi
 
 TMP_DIR=${TMPDIR:-/tmp}
 TMP_WORK_DIR=$(mktemp -d "${TMP_DIR}/hugegraph-gremlin-console-smoke.XXXXXX")
-SMOKE_REMOTE_CONFIG="${TMP_WORK_DIR}/remote.yaml"
+REMOTE_CONFIG_BACKUP="${TMP_WORK_DIR}/remote.yaml.orig"
 SMOKE_SCRIPT="${TMP_WORK_DIR}/smoke.groovy"
 SMOKE_LOG="${TMP_WORK_DIR}/smoke.log"
 
 cleanup() {
+    if [ -f "$REMOTE_CONFIG_BACKUP" ]; then
+        cp "$REMOTE_CONFIG_BACKUP" "$REMOTE_CONFIG"
+    fi
     rm -rf "$TMP_WORK_DIR"
 }
 trap cleanup EXIT
 
-cp "$REMOTE_CONFIG" "$SMOKE_REMOTE_CONFIG"
-cat >> "$SMOKE_REMOTE_CONFIG" <<EOF
+cp "$REMOTE_CONFIG" "$REMOTE_CONFIG_BACKUP"
+cat >> "$REMOTE_CONFIG" <<EOF
+
 username: admin
 password: pa
 EOF
 
 cat > "$SMOKE_SCRIPT" <<EOF
-:remote connect tinkerpop.server ${SMOKE_REMOTE_CONFIG}
+:remote connect tinkerpop.server conf/remote.yaml
 :> def count = g.V().count().next(); if (count < 0L) throw new IllegalStateException("Unexpected vertex count: " + count); "${SMOKE_MARKER}-" + count
 EOF
 

--- a/hugegraph-server/hugegraph-dist/src/assembly/travis/run-gremlin-console-smoke-test.sh
+++ b/hugegraph-server/hugegraph-dist/src/assembly/travis/run-gremlin-console-smoke-test.sh
@@ -62,6 +62,7 @@ EOF
 cat > "$SMOKE_SCRIPT" <<EOF
 :remote connect tinkerpop.server conf/remote.yaml
 :> def count = g.V().count().next(); if (count < 0L) throw new IllegalStateException("Unexpected vertex count: " + count); "${SMOKE_MARKER}-" + count
+println(result[0].object)
 EOF
 
 (

--- a/hugegraph-server/hugegraph-dist/src/assembly/travis/run-gremlin-console-smoke-test.sh
+++ b/hugegraph-server/hugegraph-dist/src/assembly/travis/run-gremlin-console-smoke-test.sh
@@ -59,7 +59,7 @@ EOF
 
 cat > "$SMOKE_SCRIPT" <<EOF
 :remote connect tinkerpop.server conf/remote.yaml
-:> def count = g.V().count().next(); if (count < 0L) throw new IllegalStateException("Unexpected vertex count: " + count); "${SMOKE_MARKER}-" + count
+:> def count = hugegraph.traversal().V().count().next(); if (count < 0L) throw new IllegalStateException("Unexpected vertex count: " + count); "${SMOKE_MARKER}-" + count
 EOF
 
 (

--- a/hugegraph-server/hugegraph-dist/src/assembly/travis/run-gremlin-console-smoke-test.sh
+++ b/hugegraph-server/hugegraph-dist/src/assembly/travis/run-gremlin-console-smoke-test.sh
@@ -55,14 +55,27 @@ cat >> "$REMOTE_CONFIG" <<EOF
 
 username: admin
 password: pa
-aliases:
-  g: __g_DEFAULT-hugegraph
 EOF
 
 cat > "$SMOKE_SCRIPT" <<EOF
-:remote connect tinkerpop.server conf/remote.yaml
-:> def count = g.V().count().next(); if (count < 0L) throw new IllegalStateException("Unexpected vertex count: " + count); "${SMOKE_MARKER}-" + count
-println(result[0].object)
+import org.apache.tinkerpop.gremlin.driver.Cluster
+
+def cluster = Cluster.open('conf/remote.yaml')
+def client = cluster.connect().alias(['g': '__g_DEFAULT-hugegraph'])
+try {
+    def remoteScript = '''
+        def count = g.V().count().next()
+        if (count < 0L) {
+            throw new IllegalStateException('Unexpected vertex count: ' + count)
+        }
+        '${SMOKE_MARKER}-' + count
+    '''
+    def results = client.submit(remoteScript).all().get()
+    println(results[0].object)
+} finally {
+    client.close()
+    cluster.close()
+}
 EOF
 
 (

--- a/hugegraph-server/hugegraph-dist/src/assembly/travis/run-gremlin-console-smoke-test.sh
+++ b/hugegraph-server/hugegraph-dist/src/assembly/travis/run-gremlin-console-smoke-test.sh
@@ -55,11 +55,13 @@ cat >> "$REMOTE_CONFIG" <<EOF
 
 username: admin
 password: pa
+aliases:
+  g: __g_DEFAULT-hugegraph
 EOF
 
 cat > "$SMOKE_SCRIPT" <<EOF
 :remote connect tinkerpop.server conf/remote.yaml
-:> def count = hugegraph.traversal().V().count().next(); if (count < 0L) throw new IllegalStateException("Unexpected vertex count: " + count); "${SMOKE_MARKER}-" + count
+:> def count = g.V().count().next(); if (count < 0L) throw new IllegalStateException("Unexpected vertex count: " + count); "${SMOKE_MARKER}-" + count
 EOF
 
 (

--- a/hugegraph-server/hugegraph-dist/src/assembly/travis/run-gremlin-console-smoke-test.sh
+++ b/hugegraph-server/hugegraph-dist/src/assembly/travis/run-gremlin-console-smoke-test.sh
@@ -41,11 +41,7 @@ cleanup() {
 trap cleanup EXIT
 
 cat > "$SMOKE_SCRIPT" <<EOF
-def result = 1 + 1
-if (result != 2) {
-    throw new IllegalStateException("Unexpected smoke result: " + result)
-}
-println("${SMOKE_MARKER}")
+println("${SMOKE_MARKER}-" + (1 + 1))
 EOF
 
 (

--- a/hugegraph-server/hugegraph-dist/src/assembly/travis/run-gremlin-console-smoke-test.sh
+++ b/hugegraph-server/hugegraph-dist/src/assembly/travis/run-gremlin-console-smoke-test.sh
@@ -1,0 +1,55 @@
+#!/bin/bash
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+set -euo pipefail
+
+SERVER_DIR=${1:?Usage: run-gremlin-console-smoke-test.sh <server-dir>}
+SMOKE_MARKER="gremlin-console-smoke-ok"
+
+if [ ! -d "$SERVER_DIR" ]; then
+    echo "Server directory does not exist: $SERVER_DIR"
+    exit 1
+fi
+
+if [ ! -x "$SERVER_DIR/bin/gremlin-console.sh" ]; then
+    echo "Gremlin Console script is not executable: $SERVER_DIR/bin/gremlin-console.sh"
+    exit 1
+fi
+
+TMP_DIR=${TMPDIR:-/tmp}
+SMOKE_SCRIPT=$(mktemp "${TMP_DIR}/hugegraph-gremlin-console-smoke.XXXXXX.groovy")
+SMOKE_LOG=$(mktemp "${TMP_DIR}/hugegraph-gremlin-console-smoke.XXXXXX.log")
+
+cleanup() {
+    rm -f "$SMOKE_SCRIPT" "$SMOKE_LOG"
+}
+trap cleanup EXIT
+
+cat > "$SMOKE_SCRIPT" <<EOF
+def result = 1 + 1
+if (result != 2) {
+    throw new IllegalStateException("Unexpected smoke result: " + result)
+}
+println("${SMOKE_MARKER}")
+EOF
+
+(
+    cd "$SERVER_DIR"
+    bin/gremlin-console.sh -- -e "$SMOKE_SCRIPT"
+) | tee "$SMOKE_LOG"
+
+grep -q "$SMOKE_MARKER" "$SMOKE_LOG"

--- a/hugegraph-server/hugegraph-dist/src/assembly/travis/run-gremlin-console-smoke-test.sh
+++ b/hugegraph-server/hugegraph-dist/src/assembly/travis/run-gremlin-console-smoke-test.sh
@@ -31,11 +31,12 @@ if [ ! -x "$SERVER_DIR/bin/gremlin-console.sh" ]; then
 fi
 
 TMP_DIR=${TMPDIR:-/tmp}
-SMOKE_SCRIPT=$(mktemp "${TMP_DIR}/hugegraph-gremlin-console-smoke.XXXXXX.groovy")
-SMOKE_LOG=$(mktemp "${TMP_DIR}/hugegraph-gremlin-console-smoke.XXXXXX.log")
+TMP_WORK_DIR=$(mktemp -d "${TMP_DIR}/hugegraph-gremlin-console-smoke.XXXXXX")
+SMOKE_SCRIPT="${TMP_WORK_DIR}/smoke.groovy"
+SMOKE_LOG="${TMP_WORK_DIR}/smoke.log"
 
 cleanup() {
-    rm -f "$SMOKE_SCRIPT" "$SMOKE_LOG"
+    rm -rf "$TMP_WORK_DIR"
 }
 trap cleanup EXIT
 

--- a/hugegraph-server/hugegraph-dist/src/assembly/travis/run-gremlin-console-smoke-test.sh
+++ b/hugegraph-server/hugegraph-dist/src/assembly/travis/run-gremlin-console-smoke-test.sh
@@ -19,6 +19,7 @@ set -euo pipefail
 
 SERVER_DIR=${1:?Usage: run-gremlin-console-smoke-test.sh <server-dir>}
 SMOKE_MARKER="gremlin-console-smoke-ok"
+REMOTE_CONFIG="$SERVER_DIR/conf/remote.yaml"
 
 if [ ! -d "$SERVER_DIR" ]; then
     echo "Server directory does not exist: $SERVER_DIR"
@@ -30,8 +31,14 @@ if [ ! -x "$SERVER_DIR/bin/gremlin-console.sh" ]; then
     exit 1
 fi
 
+if [ ! -f "$REMOTE_CONFIG" ]; then
+    echo "Gremlin Console remote config does not exist: $REMOTE_CONFIG"
+    exit 1
+fi
+
 TMP_DIR=${TMPDIR:-/tmp}
 TMP_WORK_DIR=$(mktemp -d "${TMP_DIR}/hugegraph-gremlin-console-smoke.XXXXXX")
+SMOKE_REMOTE_CONFIG="${TMP_WORK_DIR}/remote.yaml"
 SMOKE_SCRIPT="${TMP_WORK_DIR}/smoke.groovy"
 SMOKE_LOG="${TMP_WORK_DIR}/smoke.log"
 
@@ -40,8 +47,15 @@ cleanup() {
 }
 trap cleanup EXIT
 
+cp "$REMOTE_CONFIG" "$SMOKE_REMOTE_CONFIG"
+cat >> "$SMOKE_REMOTE_CONFIG" <<EOF
+username: admin
+password: pa
+EOF
+
 cat > "$SMOKE_SCRIPT" <<EOF
-println("${SMOKE_MARKER}-" + (1 + 1))
+:remote connect tinkerpop.server ${SMOKE_REMOTE_CONFIG}
+:> def count = g.V().count().next(); if (count < 0L) throw new IllegalStateException("Unexpected vertex count: " + count); "${SMOKE_MARKER}-" + count
 EOF
 
 (

--- a/hugegraph-server/hugegraph-dist/src/assembly/travis/run-gremlin-console-smoke-test.sh
+++ b/hugegraph-server/hugegraph-dist/src/assembly/travis/run-gremlin-console-smoke-test.sh
@@ -60,17 +60,14 @@ EOF
 cat > "$SMOKE_SCRIPT" <<EOF
 import org.apache.tinkerpop.gremlin.driver.Cluster
 
-def cluster = Cluster.open('conf/remote.yaml')
-def client = cluster.connect().alias(['g': '__g_DEFAULT-hugegraph'])
+cluster = Cluster.open('conf/remote.yaml')
+client = cluster.connect().alias(['g': '__g_DEFAULT-hugegraph'])
 try {
-    def remoteScript = '''
-        def count = g.V().count().next()
-        if (count < 0L) {
-            throw new IllegalStateException('Unexpected vertex count: ' + count)
-        }
-        '${SMOKE_MARKER}-' + count
-    '''
-    def results = client.submit(remoteScript).all().get()
+    remoteScript = "def count = g.V().count().next(); " +
+                   "if (count < 0L) " +
+                   "throw new IllegalStateException('Unexpected vertex count: ' + count); " +
+                   "'${SMOKE_MARKER}-' + count"
+    results = client.submit(remoteScript).all().get()
     println(results[0].object)
 } finally {
     client.close()


### PR DESCRIPTION
<!-- 
  Thank you very much for contributing to Apache HugeGraph, we are happy that you want to help us improve it!

  Here are some tips for you:
    1. If this is your first time, please read the [contributing guidelines](https://github.com/apache/hugegraph/blob/master/CONTRIBUTING.md)

    2. If a PR fix/close an issue, type the message "close xxx" (xxx is the link of related 
issue) in the content, GitHub will auto link it (Required)

    3. Name the PR title in "Google Commit Format", start with "feat | fix | perf | refactor | doc | chore", 
      such like: "feat(core): support the PageRank algorithm" or "fix: wrong break in the compute loop" (module is optional)
      skip it if you are unsure about which is the best component.

    4. One PR address one issue, better not to mix up multiple issues.

    5. Put an `x` in the `[ ]` to mark the item as CHECKED. `[x]` (or click it directly after 
published)
-->

## Purpose of the PR

- close #3015 <!-- or use "fix #xxx", "xxx" is the ID-link of related issue, e.g: close #1024 -->

Add a focused Gremlin Console smoke test for the server distribution entry point.

This follows up on #3015 and the review note from #3010. The existing macOS RocksDB CI covers server compile, core tests, startup, and API tests, but it does not directly exercise `bin/gremlin-console.sh`. This PR adds a lightweight non-interactive smoke test for that path on macOS and Linux.

Related context: #3006 reported user-facing build/startup issues and mentioned Gremlin Console behavior on Apple Silicon, but this PR only adds CI validation and does not assume a specific Jansi or Java compatibility root cause.

<!--
Please explain more context in this section, clarify why the changes are needed. 
e.g:
- If you propose a new API, clarify the use case for a new API.
- If you fix a bug, you can clarify why it is a bug, and should be associated with an issue.
-->

## Main Changes

- Add `run-gremlin-console-smoke-test.sh`
  - Generates a tiny Groovy script
  - Runs `bin/gremlin-console.sh -- -e <script>`
  - Verifies the expected `gremlin-console-smoke-ok` marker
  - Cleans temporary script/log files with `trap`
- Run the smoke test in Linux Server CI only for the RocksDB matrix entry
- Run the same smoke test in macOS RocksDB CI on both Intel and Apple Silicon runners

<!-- Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. These change logs are helpful for better and faster reviews.)

For example:

- If you introduce a new feature, please show detailed design here or add the link of design documentation.
- If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
- If there is a discussion in the mailing list, please add the link. -->

## Verifying these changes

<!-- Please pick the proper options below -->

- [ ] Trivial rework / code cleanup without any test coverage. (No Need)
- [ ] Already covered by existing tests, such as *(please modify tests here)*.
- [x] Need tests and can be verified as follows:
    - Ran `bash -n hugegraph-server/hugegraph-dist/src/assembly/travis/run-gremlin-console-smoke-test.sh`
    - Ran `git diff --check`

## Does this PR potentially affect the following parts?

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ]  Dependencies ([add/update license](https://hugegraph.apache.org/docs/contribution-guidelines/contribute/#321-check-licenses) info & [regenerate_known_dependencies.sh](../install-dist/scripts/dependency/regenerate_known_dependencies.sh)) <!-- Don't forget to add/update the info in "LICENSE" & "NOTICE" files (both in root & dist module) -->
- [ ]  Modify configurations
- [ ]  The public API
- [ ]  Other affects (typed here)
- [x]  Nope


## Documentation Status

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ]  `Doc - TODO` <!-- Your PR changes impact docs and you will update later -->
- [ ]  `Doc - Done` <!-- Related docs have been already added or updated -->
- [x]  `Doc - No Need` <!-- Your PR changes don't impact/need docs -->
