### PR TITLE
ci: add codecov.yml with 0.5% threshold to avoid false failures on shell-only PRs

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,12 @@
+ignore:  
+  - "**/*.sh"  
+  - "hugegraph-server/hugegraph-dist/src/assembly/travis/**"  
+  
+coverage:  
+  status:  
+    project:  
+      default:  
+        threshold: 0.5%  
+    patch:  
+      default:  
+        threshold: 0.5%

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,12 +1,29 @@
-ignore:  
-  - "**/*.sh"  
-  - "hugegraph-server/hugegraph-dist/src/assembly/travis/**"  
-  
-coverage:  
-  status:  
-    project:  
-      default:  
-        threshold: 0.5%  
-    patch:  
-      default:  
+#  
+# Licensed to the Apache Software Foundation (ASF) under one or more  
+# contributor license agreements.  See the NOTICE file distributed with  
+# this work for additional information regarding copyright ownership.  
+# The ASF licenses this file to You under the Apache License, Version 2.0  
+# (the "License"); you may not use this file except in compliance with  
+# the License.  You may obtain a copy of the License at  
+#  
+#     http://www.apache.org/licenses/LICENSE-2.0  
+#  
+# Unless required by applicable law or agreed to in writing, software  
+# distributed under the License is distributed on an "AS IS" BASIS,  
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  
+# See the License for the specific language governing permissions and  
+# limitations under the License.  
+#  
+
+ignore:
+  - "**/*.sh"
+  - "hugegraph-server/hugegraph-dist/src/assembly/travis/**"
+
+coverage:
+  status:
+    project:
+      default:
+        threshold: 0.5%
+    patch:
+      default:
         threshold: 0.5%


### PR DESCRIPTION
## Purpose of the PR

- relates to #3043

Shell scripts and test scripts added in recent PRs (`test-start-hugegraph.sh`, `test-start-hugegraph-pd.sh`, `test-start-hugegraph-store.sh`) have no Java coverage. Codecov reports a large coverage drop and fails the PR check even though actual Java coverage is unchanged.

## Main Changes

- Add `codecov.yml` at repo root:
  - `ignore` block excludes all `*.sh` files and the `travis/` scripts directory from coverage calculation
  - `threshold: 0.5%` for both project and patch so small rounding noise doesn't fail the check

## Does this PR potentially affect the following parts?

- [ ] Dependencies
- [ ] Modify configurations
- [ ] The public API
- [ ] Other affects
- [x] Nope

## Documentation Status

- [x] `Doc - No Need`