### PR TITLE
feat(server) : make buffer max capacity configurable

### DIFF
--- a/hugegraph-server/hugegraph-core/src/main/java/org/apache/hugegraph/StandardHugeGraph.java
+++ b/hugegraph-server/hugegraph-core/src/main/java/org/apache/hugegraph/StandardHugeGraph.java
@@ -234,7 +234,7 @@ public class StandardHugeGraph implements HugeGraph {
 
         LockUtil.init(this.spaceGraphName());
 
-        BytesBuffer.setMaxBufferCapacity(
+        BytesBuffer.initMaxBufferCapacity(
                 config.get(CoreOptions.SERIALIZER_BUFFER_MAX_CAPACITY));
         MemoryManager.setMemoryMode(
                 MemoryManager.MemoryMode.fromValue(config.get(CoreOptions.MEMORY_MODE)));

--- a/hugegraph-server/hugegraph-core/src/main/java/org/apache/hugegraph/StandardHugeGraph.java
+++ b/hugegraph-server/hugegraph-core/src/main/java/org/apache/hugegraph/StandardHugeGraph.java
@@ -234,8 +234,11 @@ public class StandardHugeGraph implements HugeGraph {
 
         // Init process-wide static configs before lock, so that validation
         // failures won't leave stale lock groups in LockManager.
+        boolean explicitBufferCapacity = config.containsKey(
+                CoreOptions.SERIALIZER_BUFFER_MAX_CAPACITY.name());
         BytesBuffer.initMaxBufferCapacity(
-                config.get(CoreOptions.SERIALIZER_BUFFER_MAX_CAPACITY));
+                config.get(CoreOptions.SERIALIZER_BUFFER_MAX_CAPACITY),
+                explicitBufferCapacity);
         MemoryManager.setMemoryMode(
                 MemoryManager.MemoryMode.fromValue(config.get(CoreOptions.MEMORY_MODE)));
         MemoryManager.setMaxMemoryCapacityInBytes(config.get(CoreOptions.MAX_MEMORY_CAPACITY));

--- a/hugegraph-server/hugegraph-core/src/main/java/org/apache/hugegraph/StandardHugeGraph.java
+++ b/hugegraph-server/hugegraph-core/src/main/java/org/apache/hugegraph/StandardHugeGraph.java
@@ -232,8 +232,8 @@ public class StandardHugeGraph implements HugeGraph {
         this.readMode = GraphReadMode.OLTP_ONLY;
         this.schedulerType = config.get(CoreOptions.SCHEDULER_TYPE);
 
-        LockUtil.init(this.spaceGraphName());
-
+        // Init process-wide static configs before lock, so that validation
+        // failures won't leave stale lock groups in LockManager.
         BytesBuffer.initMaxBufferCapacity(
                 config.get(CoreOptions.SERIALIZER_BUFFER_MAX_CAPACITY));
         MemoryManager.setMemoryMode(
@@ -242,6 +242,8 @@ public class StandardHugeGraph implements HugeGraph {
         MemoryManager.setMaxMemoryCapacityForOneQuery(
                 config.get(CoreOptions.ONE_QUERY_MAX_MEMORY_CAPACITY));
         RoundUtil.setAlignment(config.get(CoreOptions.MEMORY_ALIGNMENT));
+
+        LockUtil.init(this.spaceGraphName());
 
         try {
             this.storeProvider = this.loadStoreProvider();

--- a/hugegraph-server/hugegraph-core/src/main/java/org/apache/hugegraph/StandardHugeGraph.java
+++ b/hugegraph-server/hugegraph-core/src/main/java/org/apache/hugegraph/StandardHugeGraph.java
@@ -48,6 +48,7 @@ import org.apache.hugegraph.backend.id.IdGenerator;
 import org.apache.hugegraph.backend.id.SnowflakeIdGenerator;
 import org.apache.hugegraph.backend.query.Query;
 import org.apache.hugegraph.backend.serializer.AbstractSerializer;
+import org.apache.hugegraph.backend.serializer.BytesBuffer;
 import org.apache.hugegraph.backend.serializer.SerializerFactory;
 import org.apache.hugegraph.backend.store.BackendFeatures;
 import org.apache.hugegraph.backend.store.BackendProviderFactory;
@@ -233,6 +234,8 @@ public class StandardHugeGraph implements HugeGraph {
 
         LockUtil.init(this.spaceGraphName());
 
+        BytesBuffer.setMaxBufferCapacity(
+                config.get(CoreOptions.SERIALIZER_BUFFER_MAX_CAPACITY));
         MemoryManager.setMemoryMode(
                 MemoryManager.MemoryMode.fromValue(config.get(CoreOptions.MEMORY_MODE)));
         MemoryManager.setMaxMemoryCapacityInBytes(config.get(CoreOptions.MAX_MEMORY_CAPACITY));

--- a/hugegraph-server/hugegraph-core/src/main/java/org/apache/hugegraph/backend/serializer/BytesBuffer.java
+++ b/hugegraph-server/hugegraph-core/src/main/java/org/apache/hugegraph/backend/serializer/BytesBuffer.java
@@ -145,6 +145,9 @@ public final class BytesBuffer extends OutputStream {
                         capacity);
 
         if (!explicit) {
+            if (maxBufferCapacity == null) {
+                maxBufferCapacity = MAX_BUFFER_CAPACITY;
+            }
             return;
         }
 

--- a/hugegraph-server/hugegraph-core/src/main/java/org/apache/hugegraph/backend/serializer/BytesBuffer.java
+++ b/hugegraph-server/hugegraph-core/src/main/java/org/apache/hugegraph/backend/serializer/BytesBuffer.java
@@ -338,7 +338,6 @@ public final class BytesBuffer extends OutputStream {
 
     public BytesBuffer writeBigBytes(byte[] bytes) {
         if (bytes.length > BLOB_LEN_MAX) {
-            // TODO: note the max blob size depends on max buffer capacity
             E.checkArgument(false,
                             "The max length of bytes is %s, but got %s",
                             BLOB_LEN_MAX, bytes.length);

--- a/hugegraph-server/hugegraph-core/src/main/java/org/apache/hugegraph/backend/serializer/BytesBuffer.java
+++ b/hugegraph-server/hugegraph-core/src/main/java/org/apache/hugegraph/backend/serializer/BytesBuffer.java
@@ -145,9 +145,6 @@ public final class BytesBuffer extends OutputStream {
                         capacity);
 
         if (!explicit) {
-            if (maxBufferCapacity == null) {
-                maxBufferCapacity = MAX_BUFFER_CAPACITY;
-            }
             return;
         }
 

--- a/hugegraph-server/hugegraph-core/src/main/java/org/apache/hugegraph/backend/serializer/BytesBuffer.java
+++ b/hugegraph-server/hugegraph-core/src/main/java/org/apache/hugegraph/backend/serializer/BytesBuffer.java
@@ -84,7 +84,7 @@ public final class BytesBuffer extends OutputStream {
 
     public static final byte[] BYTES_EMPTY = new byte[0];
 
-    private static volatile int maxBufferCapacity = MAX_BUFFER_CAPACITY;
+    private static volatile Integer maxBufferCapacity;
 
     private ByteBuffer buffer;
     private final boolean resize;
@@ -127,17 +127,27 @@ public final class BytesBuffer extends OutputStream {
     }
 
     public static int maxBufferCapacity() {
-        return maxBufferCapacity;
+        Integer capacity = maxBufferCapacity;
+        return capacity != null ? capacity : MAX_BUFFER_CAPACITY;
     }
 
-    public static void setMaxBufferCapacity(int capacity) {
+    public static synchronized void initMaxBufferCapacity(int capacity) {
         E.checkArgument(capacity >= DEFAULT_CAPACITY &&
                         capacity <= MAX_BUFFER_CAPACITY_UPPER_BOUND,
                         "Max buffer capacity must be in range [%s, %s], " +
                         "but got %s",
                         DEFAULT_CAPACITY, MAX_BUFFER_CAPACITY_UPPER_BOUND,
                         capacity);
-        maxBufferCapacity = capacity;
+
+        if (maxBufferCapacity == null) {
+            maxBufferCapacity = capacity;
+            return;
+        }
+
+        E.checkArgument(maxBufferCapacity == capacity,
+                        "The process-wide serializer buffer max capacity has " +
+                        "been initialized to %s, but got conflicting value %s",
+                        maxBufferCapacity, capacity);
     }
 
     public ByteBuffer asByteBuffer() {
@@ -191,15 +201,17 @@ public final class BytesBuffer extends OutputStream {
             E.checkState(false, "Can't resize for wrapped buffer");
         }
 
-        // Extra capacity as buffer
-        long newCapacity = (long) size + this.buffer.limit() +
-                           DEFAULT_CAPACITY;
         int maxCapacity = maxBufferCapacity();
-        if (newCapacity > maxCapacity) {
+        long requiredCapacity = (long) this.buffer.position() + size;
+        if (requiredCapacity > maxCapacity) {
             E.checkArgument(false,
                             "Capacity %s exceeds max buffer capacity: %s",
-                            newCapacity, maxCapacity);
+                            requiredCapacity, maxCapacity);
         }
+
+        // Extra capacity as buffer
+        long newCapacity = Math.min(requiredCapacity + DEFAULT_CAPACITY,
+                                    maxCapacity);
         ByteBuffer newBuffer = ByteBuffer.allocate((int) newCapacity);
         this.buffer.flip();
         newBuffer.put(this.buffer);

--- a/hugegraph-server/hugegraph-core/src/main/java/org/apache/hugegraph/backend/serializer/BytesBuffer.java
+++ b/hugegraph-server/hugegraph-core/src/main/java/org/apache/hugegraph/backend/serializer/BytesBuffer.java
@@ -160,10 +160,10 @@ public final class BytesBuffer extends OutputStream {
             return;
         }
 
-        E.checkArgument(false,
-                        "The process-wide serializer buffer max capacity has " +
-                        "been initialized to %s, but got conflicting value %s",
-                        maxBufferCapacity, capacity);
+        throw new IllegalArgumentException(String.format(
+                "The process-wide serializer buffer max capacity has been " +
+                "initialized to %s, but got conflicting value %s",
+                maxBufferCapacity, capacity));
     }
 
     public ByteBuffer asByteBuffer() {

--- a/hugegraph-server/hugegraph-core/src/main/java/org/apache/hugegraph/backend/serializer/BytesBuffer.java
+++ b/hugegraph-server/hugegraph-core/src/main/java/org/apache/hugegraph/backend/serializer/BytesBuffer.java
@@ -144,7 +144,17 @@ public final class BytesBuffer extends OutputStream {
             return;
         }
 
-        E.checkArgument(maxBufferCapacity == capacity,
+        // When already initialized, a graph that didn't explicitly set
+        // this option will receive the default value (MAX_BUFFER_CAPACITY).
+        // Treat that as "inherit process-wide value" and skip the conflict
+        // check, so that one custom graph doesn't block unrelated graphs
+        // that use the default config.
+        if (maxBufferCapacity == capacity ||
+            capacity == MAX_BUFFER_CAPACITY) {
+            return;
+        }
+
+        E.checkArgument(false,
                         "The process-wide serializer buffer max capacity has " +
                         "been initialized to %s, but got conflicting value %s",
                         maxBufferCapacity, capacity);

--- a/hugegraph-server/hugegraph-core/src/main/java/org/apache/hugegraph/backend/serializer/BytesBuffer.java
+++ b/hugegraph-server/hugegraph-core/src/main/java/org/apache/hugegraph/backend/serializer/BytesBuffer.java
@@ -132,6 +132,11 @@ public final class BytesBuffer extends OutputStream {
     }
 
     public static synchronized void initMaxBufferCapacity(int capacity) {
+        initMaxBufferCapacity(capacity, true);
+    }
+
+    public static synchronized void initMaxBufferCapacity(int capacity,
+                                                          boolean explicit) {
         E.checkArgument(capacity >= DEFAULT_CAPACITY &&
                         capacity <= MAX_BUFFER_CAPACITY_UPPER_BOUND,
                         "Max buffer capacity must be in range [%s, %s], " +
@@ -139,18 +144,16 @@ public final class BytesBuffer extends OutputStream {
                         DEFAULT_CAPACITY, MAX_BUFFER_CAPACITY_UPPER_BOUND,
                         capacity);
 
+        if (!explicit) {
+            return;
+        }
+
         if (maxBufferCapacity == null) {
             maxBufferCapacity = capacity;
             return;
         }
 
-        // When already initialized, a graph that didn't explicitly set
-        // this option will receive the default value (MAX_BUFFER_CAPACITY).
-        // Treat that as "inherit process-wide value" and skip the conflict
-        // check, so that one custom graph doesn't block unrelated graphs
-        // that use the default config.
-        if (maxBufferCapacity == capacity ||
-            capacity == MAX_BUFFER_CAPACITY) {
+        if (maxBufferCapacity == capacity) {
             return;
         }
 

--- a/hugegraph-server/hugegraph-core/src/main/java/org/apache/hugegraph/backend/serializer/BytesBuffer.java
+++ b/hugegraph-server/hugegraph-core/src/main/java/org/apache/hugegraph/backend/serializer/BytesBuffer.java
@@ -77,11 +77,14 @@ public final class BytesBuffer extends OutputStream {
 
     public static final int DEFAULT_CAPACITY = 64;
     public static final int MAX_BUFFER_CAPACITY = 128 * 1024 * 1024; // 128M
+    public static final int MAX_BUFFER_CAPACITY_UPPER_BOUND = (int) Bytes.GB;
 
     public static final int BUF_EDGE_ID = 128;
     public static final int BUF_PROPERTY = 64;
 
     public static final byte[] BYTES_EMPTY = new byte[0];
+
+    private static volatile int maxBufferCapacity = MAX_BUFFER_CAPACITY;
 
     private ByteBuffer buffer;
     private final boolean resize;
@@ -91,10 +94,11 @@ public final class BytesBuffer extends OutputStream {
     }
 
     public BytesBuffer(int capacity) {
-        if (capacity > MAX_BUFFER_CAPACITY) {
+        int maxCapacity = maxBufferCapacity();
+        if (capacity > maxCapacity) {
             E.checkArgument(false,
                             "Capacity %s exceeds max buffer capacity: %s",
-                            capacity, MAX_BUFFER_CAPACITY);
+                            capacity, maxCapacity);
         }
         this.buffer = ByteBuffer.allocate(capacity);
         this.resize = true;
@@ -120,6 +124,20 @@ public final class BytesBuffer extends OutputStream {
 
     public static BytesBuffer wrap(byte[] array, int offset, int length) {
         return new BytesBuffer(ByteBuffer.wrap(array, offset, length));
+    }
+
+    public static int maxBufferCapacity() {
+        return maxBufferCapacity;
+    }
+
+    public static void setMaxBufferCapacity(int capacity) {
+        E.checkArgument(capacity >= DEFAULT_CAPACITY &&
+                        capacity <= MAX_BUFFER_CAPACITY_UPPER_BOUND,
+                        "Max buffer capacity must be in range [%s, %s], " +
+                        "but got %s",
+                        DEFAULT_CAPACITY, MAX_BUFFER_CAPACITY_UPPER_BOUND,
+                        capacity);
+        maxBufferCapacity = capacity;
     }
 
     public ByteBuffer asByteBuffer() {
@@ -174,13 +192,15 @@ public final class BytesBuffer extends OutputStream {
         }
 
         // Extra capacity as buffer
-        int newCapacity = size + this.buffer.limit() + DEFAULT_CAPACITY;
-        if (newCapacity > MAX_BUFFER_CAPACITY) {
+        long newCapacity = (long) size + this.buffer.limit() +
+                           DEFAULT_CAPACITY;
+        int maxCapacity = maxBufferCapacity();
+        if (newCapacity > maxCapacity) {
             E.checkArgument(false,
                             "Capacity %s exceeds max buffer capacity: %s",
-                            newCapacity, MAX_BUFFER_CAPACITY);
+                            newCapacity, maxCapacity);
         }
-        ByteBuffer newBuffer = ByteBuffer.allocate(newCapacity);
+        ByteBuffer newBuffer = ByteBuffer.allocate((int) newCapacity);
         this.buffer.flip();
         newBuffer.put(this.buffer);
         this.buffer = newBuffer;
@@ -318,7 +338,7 @@ public final class BytesBuffer extends OutputStream {
 
     public BytesBuffer writeBigBytes(byte[] bytes) {
         if (bytes.length > BLOB_LEN_MAX) {
-            // TODO: note the max blob size should be 128MB (due to MAX_BUFFER_CAPACITY)
+            // TODO: note the max blob size depends on max buffer capacity
             E.checkArgument(false,
                             "The max length of bytes is %s, but got %s",
                             BLOB_LEN_MAX, bytes.length);

--- a/hugegraph-server/hugegraph-core/src/main/java/org/apache/hugegraph/config/CoreOptions.java
+++ b/hugegraph-server/hugegraph-core/src/main/java/org/apache/hugegraph/config/CoreOptions.java
@@ -18,6 +18,7 @@
 package org.apache.hugegraph.config;
 
 import org.apache.hugegraph.backend.query.Query;
+import org.apache.hugegraph.backend.serializer.BytesBuffer;
 import org.apache.hugegraph.backend.tx.GraphTransaction;
 import org.apache.hugegraph.type.define.CollectionType;
 import org.apache.hugegraph.util.Bytes;
@@ -78,6 +79,14 @@ public class CoreOptions extends OptionHolder {
                     "The serializer for backend store, like: text/binary/cassandra.",
                     disallowEmpty(),
                     "text"
+            );
+    public static final ConfigOption<Integer> SERIALIZER_BUFFER_MAX_CAPACITY =
+            new ConfigOption<>(
+                    "serializer.buffer_max_capacity",
+                    "The max capacity of one serialization buffer in bytes.",
+                    rangeInt(BytesBuffer.DEFAULT_CAPACITY,
+                             BytesBuffer.MAX_BUFFER_CAPACITY_UPPER_BOUND),
+                    BytesBuffer.MAX_BUFFER_CAPACITY
             );
     public static final ConfigOption<Boolean> RAFT_MODE =
             new ConfigOption<>(

--- a/hugegraph-server/hugegraph-core/src/main/java/org/apache/hugegraph/config/CoreOptions.java
+++ b/hugegraph-server/hugegraph-core/src/main/java/org/apache/hugegraph/config/CoreOptions.java
@@ -83,7 +83,8 @@ public class CoreOptions extends OptionHolder {
     public static final ConfigOption<Integer> SERIALIZER_BUFFER_MAX_CAPACITY =
             new ConfigOption<>(
                     "serializer.buffer_max_capacity",
-                    "The max capacity of one serialization buffer in bytes.",
+                    "The process-wide max capacity of one serialization " +
+                    "buffer in bytes.",
                     rangeInt(BytesBuffer.DEFAULT_CAPACITY,
                              BytesBuffer.MAX_BUFFER_CAPACITY_UPPER_BOUND),
                     BytesBuffer.MAX_BUFFER_CAPACITY

--- a/hugegraph-server/hugegraph-core/src/main/java/org/apache/hugegraph/util/LZ4Util.java
+++ b/hugegraph-server/hugegraph-core/src/main/java/org/apache/hugegraph/util/LZ4Util.java
@@ -64,7 +64,7 @@ public class LZ4Util {
         LZ4FastDecompressor decompressor = factory.fastDecompressor();
         ByteArrayInputStream bais = new ByteArrayInputStream(bytes);
         int initBufferSize = Math.min(Math.round(bytes.length * ratio),
-                                      BytesBuffer.MAX_BUFFER_CAPACITY);
+                                      BytesBuffer.maxBufferCapacity());
         BytesBuffer buf = new BytesBuffer(initBufferSize);
         LZ4BlockInputStream lzInput = new LZ4BlockInputStream(bais, decompressor);
         int count;

--- a/hugegraph-server/hugegraph-dist/src/assembly/static/conf/graphs/hstore.properties.template
+++ b/hugegraph-server/hugegraph-dist/src/assembly/static/conf/graphs/hstore.properties.template
@@ -24,6 +24,8 @@ edge.cache_type=l2
 # version before 1.7.0 of apache hugegraph for your application.
 backend=hstore
 serializer=binary
+# The max capacity of one serialization buffer in bytes
+#serializer.buffer_max_capacity=134217728
 
 store=hugegraph
 

--- a/hugegraph-server/hugegraph-dist/src/assembly/static/conf/graphs/hstore.properties.template
+++ b/hugegraph-server/hugegraph-dist/src/assembly/static/conf/graphs/hstore.properties.template
@@ -24,7 +24,7 @@ edge.cache_type=l2
 # version before 1.7.0 of apache hugegraph for your application.
 backend=hstore
 serializer=binary
-# The max capacity of one serialization buffer in bytes
+# The process-wide max capacity of one serialization buffer in bytes
 #serializer.buffer_max_capacity=134217728
 
 store=hugegraph

--- a/hugegraph-server/hugegraph-dist/src/assembly/static/conf/graphs/hugegraph.properties
+++ b/hugegraph-server/hugegraph-dist/src/assembly/static/conf/graphs/hugegraph.properties
@@ -23,7 +23,7 @@ edge.cache_type=l2
 # if you want to use Cassandra/MySql/PG... as backend, please use version < 1.7.0
 backend=rocksdb
 serializer=binary
-# The max capacity of one serialization buffer in bytes
+# The process-wide max capacity of one serialization buffer in bytes
 #serializer.buffer_max_capacity=134217728
 
 store=hugegraph

--- a/hugegraph-server/hugegraph-dist/src/assembly/static/conf/graphs/hugegraph.properties
+++ b/hugegraph-server/hugegraph-dist/src/assembly/static/conf/graphs/hugegraph.properties
@@ -23,6 +23,8 @@ edge.cache_type=l2
 # if you want to use Cassandra/MySql/PG... as backend, please use version < 1.7.0
 backend=rocksdb
 serializer=binary
+# The max capacity of one serialization buffer in bytes
+#serializer.buffer_max_capacity=134217728
 
 store=hugegraph
 

--- a/hugegraph-server/hugegraph-test/src/main/java/org/apache/hugegraph/unit/serializer/BytesBufferTest.java
+++ b/hugegraph-server/hugegraph-test/src/main/java/org/apache/hugegraph/unit/serializer/BytesBufferTest.java
@@ -216,6 +216,35 @@ public class BytesBufferTest extends BaseUnitTest {
     }
 
     @Test
+    public void testMaxBufferCapacityInheritsProcessWideValue()
+           throws Exception {
+        HugeConfig config1 = FakeObjects.newConfig();
+        config1.setProperty(CoreOptions.STORE.name(), "buffer_inherit_1");
+        config1.setProperty(CoreOptions.SERIALIZER_BUFFER_MAX_CAPACITY.name(),
+                            256);
+
+        HugeGraph graph1 = HugeFactory.open(config1);
+        try {
+            Assert.assertEquals(256, BytesBuffer.maxBufferCapacity());
+
+            // Second graph omits SERIALIZER_BUFFER_MAX_CAPACITY, so it
+            // receives the default value and should inherit the process-wide
+            // cap (256) instead of throwing a conflict error.
+            HugeConfig config2 = FakeObjects.newConfig();
+            config2.setProperty(CoreOptions.STORE.name(), "buffer_inherit_2");
+
+            HugeGraph graph2 = HugeFactory.open(config2);
+            try {
+                Assert.assertEquals(256, BytesBuffer.maxBufferCapacity());
+            } finally {
+                graph2.close();
+            }
+        } finally {
+            graph1.close();
+        }
+    }
+
+    @Test
     public void testWrap() {
         BytesBuffer buf4 = BytesBuffer.wrap(new byte[]{1, 2, 3, 4});
         Assert.assertArrayEquals(new byte[]{1, 2, 3, 4}, buf4.array());

--- a/hugegraph-server/hugegraph-test/src/main/java/org/apache/hugegraph/unit/serializer/BytesBufferTest.java
+++ b/hugegraph-server/hugegraph-test/src/main/java/org/apache/hugegraph/unit/serializer/BytesBufferTest.java
@@ -27,10 +27,14 @@ import java.util.Set;
 import java.util.TimeZone;
 import java.util.UUID;
 
+import org.apache.hugegraph.HugeFactory;
+import org.apache.hugegraph.HugeGraph;
 import org.apache.hugegraph.backend.id.Id;
 import org.apache.hugegraph.backend.id.IdGenerator;
 import org.apache.hugegraph.backend.id.IdGenerator.UuidId;
 import org.apache.hugegraph.backend.serializer.BytesBuffer;
+import org.apache.hugegraph.config.CoreOptions;
+import org.apache.hugegraph.config.HugeConfig;
 import org.apache.hugegraph.schema.PropertyKey;
 import org.apache.hugegraph.testutil.Assert;
 import org.apache.hugegraph.type.define.Cardinality;
@@ -38,12 +42,19 @@ import org.apache.hugegraph.type.define.DataType;
 import org.apache.hugegraph.unit.BaseUnitTest;
 import org.apache.hugegraph.unit.FakeObjects;
 import org.apache.hugegraph.util.Blob;
+import org.apache.hugegraph.util.LZ4Util;
+import org.junit.After;
 import org.junit.Test;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 
 public class BytesBufferTest extends BaseUnitTest {
+
+    @After
+    public void tearDown() {
+        BytesBuffer.setMaxBufferCapacity(BytesBuffer.MAX_BUFFER_CAPACITY);
+    }
 
     @Test
     public void testAllocate() {
@@ -67,6 +78,87 @@ public class BytesBufferTest extends BaseUnitTest {
         buf0.write(new byte[4]);
         Assert.assertArrayEquals(new byte[]{0, 0, 0, 0},
                                  buf0.bytes());
+    }
+
+    @Test
+    public void testAllocateWithMaxBufferCapacity() {
+        Assert.assertEquals(BytesBuffer.MAX_BUFFER_CAPACITY,
+                            BytesBuffer.maxBufferCapacity());
+
+        BytesBuffer.setMaxBufferCapacity(128);
+        Assert.assertEquals(128, BytesBuffer.maxBufferCapacity());
+        Assert.assertEquals(128, BytesBuffer.allocate(128).array().length);
+
+        Assert.assertThrows(IllegalArgumentException.class, () -> {
+            BytesBuffer.allocate(129);
+        }, e -> {
+            Assert.assertContains("Capacity 129 exceeds max buffer " +
+                                  "capacity: 128",
+                                  e.getMessage());
+        });
+    }
+
+    @Test
+    public void testResizeWithMaxBufferCapacity() {
+        BytesBuffer.setMaxBufferCapacity(128);
+        BytesBuffer buffer = BytesBuffer.allocate(64);
+        buffer.write(new byte[64]);
+
+        Assert.assertThrows(IllegalArgumentException.class, () -> {
+            buffer.write((byte) 1);
+        }, e -> {
+            Assert.assertContains("Capacity 129 exceeds max buffer " +
+                                  "capacity: 128",
+                                  e.getMessage());
+        });
+    }
+
+    @Test
+    public void testSetMaxBufferCapacityWithInvalidValue() {
+        Assert.assertThrows(IllegalArgumentException.class, () -> {
+            BytesBuffer.setMaxBufferCapacity(BytesBuffer.DEFAULT_CAPACITY - 1);
+        }, e -> {
+            Assert.assertContains("Max buffer capacity must be in range",
+                                  e.getMessage());
+        });
+
+        Assert.assertThrows(IllegalArgumentException.class, () -> {
+            BytesBuffer.setMaxBufferCapacity(
+                    BytesBuffer.MAX_BUFFER_CAPACITY_UPPER_BOUND + 1);
+        }, e -> {
+            Assert.assertContains("Max buffer capacity must be in range",
+                                  e.getMessage());
+        });
+    }
+
+    @Test
+    public void testLZ4DecompressWithMaxBufferCapacity() {
+        byte[] bytes = genBytes(256);
+        BytesBuffer compressed = LZ4Util.compress(bytes, 64);
+
+        BytesBuffer.setMaxBufferCapacity(128);
+
+        Assert.assertThrows(IllegalArgumentException.class, () -> {
+            LZ4Util.decompress(compressed.bytes(), 64);
+        }, e -> {
+            Assert.assertContains("exceeds max buffer capacity: 128",
+                                  e.getMessage());
+        });
+    }
+
+    @Test
+    public void testMaxBufferCapacityFromGraphConfig() throws Exception {
+        HugeConfig config = FakeObjects.newConfig();
+        config.setProperty(CoreOptions.STORE.name(), "buffer_capacity");
+        config.setProperty(CoreOptions.SERIALIZER_BUFFER_MAX_CAPACITY.name(),
+                           256);
+
+        HugeGraph graph = HugeFactory.open(config);
+        try {
+            Assert.assertEquals(256, BytesBuffer.maxBufferCapacity());
+        } finally {
+            graph.close();
+        }
     }
 
     @Test

--- a/hugegraph-server/hugegraph-test/src/main/java/org/apache/hugegraph/unit/serializer/BytesBufferTest.java
+++ b/hugegraph-server/hugegraph-test/src/main/java/org/apache/hugegraph/unit/serializer/BytesBufferTest.java
@@ -298,7 +298,7 @@ public class BytesBufferTest extends BaseUnitTest {
     }
 
     @Test
-    public void testMaxBufferCapacityAllowsExplicitConfigAfterDefaultGraph()
+    public void testMaxBufferCapacityRejectsExplicitConfigAfterDefaultGraph()
            throws Exception {
         HugeConfig config1 = FakeObjects.newConfig();
         config1.setProperty(CoreOptions.STORE.name(), "buffer_default_first");
@@ -314,12 +314,18 @@ public class BytesBufferTest extends BaseUnitTest {
             config2.setProperty(
                     CoreOptions.SERIALIZER_BUFFER_MAX_CAPACITY.name(), 256);
 
-            HugeGraph graph2 = HugeFactory.open(config2);
-            try {
-                Assert.assertEquals(256, BytesBuffer.maxBufferCapacity());
-            } finally {
-                graph2.close();
-            }
+            Assert.assertThrows(IllegalArgumentException.class, () -> {
+                HugeFactory.open(config2);
+            }, e -> {
+                Assert.assertContains("process-wide serializer buffer max " +
+                                      "capacity has been initialized to " +
+                                      BytesBuffer.MAX_BUFFER_CAPACITY,
+                                      e.getMessage());
+                Assert.assertContains("conflicting value 256",
+                                      e.getMessage());
+            });
+            Assert.assertEquals(BytesBuffer.MAX_BUFFER_CAPACITY,
+                                BytesBuffer.maxBufferCapacity());
         } finally {
             graph1.close();
         }

--- a/hugegraph-server/hugegraph-test/src/main/java/org/apache/hugegraph/unit/serializer/BytesBufferTest.java
+++ b/hugegraph-server/hugegraph-test/src/main/java/org/apache/hugegraph/unit/serializer/BytesBufferTest.java
@@ -192,23 +192,14 @@ public class BytesBufferTest extends BaseUnitTest {
     }
 
     @Test
-    public void testDefaultMaxBufferCapacityRejectsLateExplicitInit() {
+    public void testDefaultMaxBufferCapacityDefersExplicitInit() {
         BytesBuffer.initMaxBufferCapacity(BytesBuffer.MAX_BUFFER_CAPACITY,
                                           false);
         Assert.assertEquals(BytesBuffer.MAX_BUFFER_CAPACITY,
                             BytesBuffer.maxBufferCapacity());
 
-        Assert.assertThrows(IllegalArgumentException.class, () -> {
-            BytesBuffer.initMaxBufferCapacity(256);
-        }, e -> {
-            Assert.assertContains("process-wide serializer buffer max " +
-                                  "capacity has been initialized to " +
-                                  BytesBuffer.MAX_BUFFER_CAPACITY,
-                                  e.getMessage());
-            Assert.assertContains("conflicting value 256",
-                                  e.getMessage());
-        });
-        Assert.assertEquals(BytesBuffer.MAX_BUFFER_CAPACITY,
+        BytesBuffer.initMaxBufferCapacity(256);
+        Assert.assertEquals(256,
                             BytesBuffer.maxBufferCapacity());
     }
 
@@ -319,7 +310,7 @@ public class BytesBufferTest extends BaseUnitTest {
     }
 
     @Test
-    public void testMaxBufferCapacityRejectsExplicitConfigAfterDefaultGraph()
+    public void testMaxBufferCapacityDefersToExplicitConfigAfterDefaultGraph()
            throws Exception {
         HugeConfig config1 = FakeObjects.newConfig();
         config1.setProperty(CoreOptions.STORE.name(), "buffer_default_first");
@@ -335,18 +326,12 @@ public class BytesBufferTest extends BaseUnitTest {
             config2.setProperty(
                     CoreOptions.SERIALIZER_BUFFER_MAX_CAPACITY.name(), 256);
 
-            Assert.assertThrows(IllegalArgumentException.class, () -> {
-                HugeFactory.open(config2);
-            }, e -> {
-                Assert.assertContains("process-wide serializer buffer max " +
-                                      "capacity has been initialized to " +
-                                      BytesBuffer.MAX_BUFFER_CAPACITY,
-                                      e.getMessage());
-                Assert.assertContains("conflicting value 256",
-                                      e.getMessage());
-            });
-            Assert.assertEquals(BytesBuffer.MAX_BUFFER_CAPACITY,
-                                BytesBuffer.maxBufferCapacity());
+            HugeGraph graph2 = HugeFactory.open(config2);
+            try {
+                Assert.assertEquals(256, BytesBuffer.maxBufferCapacity());
+            } finally {
+                graph2.close();
+            }
         } finally {
             graph1.close();
         }

--- a/hugegraph-server/hugegraph-test/src/main/java/org/apache/hugegraph/unit/serializer/BytesBufferTest.java
+++ b/hugegraph-server/hugegraph-test/src/main/java/org/apache/hugegraph/unit/serializer/BytesBufferTest.java
@@ -144,17 +144,17 @@ public class BytesBufferTest extends BaseUnitTest {
         // Writing 2 more bytes triggers resize:
         //   requiredCapacity = 64 + 2 = 66
         //   naive newCapacity = 66 + DEFAULT_CAPACITY(64) = 130
-        //   Math.min(130, maxCapacity=128) = 128  ← capped
+        //   Math.min(130, maxCapacity=128) = 128, capped
         buffer.write(new byte[2]);
         Assert.assertEquals(128, buffer.array().length);
         Assert.assertEquals(66, buffer.bytes().length);
 
         // Buffer now at capacity 128, position 66, remaining 62.
-        // Fill remaining space — should succeed without resize.
+        // Fill remaining space, should succeed without resize.
         buffer.write(new byte[62]);
         Assert.assertEquals(128, buffer.bytes().length);
 
-        // One more byte exceeds the max — should throw.
+        // One more byte exceeds the max, should throw.
         Assert.assertThrows(IllegalArgumentException.class, () -> {
             buffer.write((byte) 1);
         }, e -> {
@@ -188,6 +188,27 @@ public class BytesBufferTest extends BaseUnitTest {
         BytesBuffer.initMaxBufferCapacity(
                 BytesBuffer.MAX_BUFFER_CAPACITY_UPPER_BOUND);
         Assert.assertEquals(BytesBuffer.MAX_BUFFER_CAPACITY_UPPER_BOUND,
+                            BytesBuffer.maxBufferCapacity());
+    }
+
+    @Test
+    public void testDefaultMaxBufferCapacityRejectsLateExplicitInit() {
+        BytesBuffer.initMaxBufferCapacity(BytesBuffer.MAX_BUFFER_CAPACITY,
+                                          false);
+        Assert.assertEquals(BytesBuffer.MAX_BUFFER_CAPACITY,
+                            BytesBuffer.maxBufferCapacity());
+
+        Assert.assertThrows(IllegalArgumentException.class, () -> {
+            BytesBuffer.initMaxBufferCapacity(256);
+        }, e -> {
+            Assert.assertContains("process-wide serializer buffer max " +
+                                  "capacity has been initialized to " +
+                                  BytesBuffer.MAX_BUFFER_CAPACITY,
+                                  e.getMessage());
+            Assert.assertContains("conflicting value 256",
+                                  e.getMessage());
+        });
+        Assert.assertEquals(BytesBuffer.MAX_BUFFER_CAPACITY,
                             BytesBuffer.maxBufferCapacity());
     }
 

--- a/hugegraph-server/hugegraph-test/src/main/java/org/apache/hugegraph/unit/serializer/BytesBufferTest.java
+++ b/hugegraph-server/hugegraph-test/src/main/java/org/apache/hugegraph/unit/serializer/BytesBufferTest.java
@@ -18,6 +18,7 @@
 package org.apache.hugegraph.unit.serializer;
 
 import java.awt.Point;
+import java.lang.reflect.Field;
 import java.util.Arrays;
 import java.util.Calendar;
 import java.util.Iterator;
@@ -44,6 +45,7 @@ import org.apache.hugegraph.unit.FakeObjects;
 import org.apache.hugegraph.util.Blob;
 import org.apache.hugegraph.util.LZ4Util;
 import org.junit.After;
+import org.junit.Before;
 import org.junit.Test;
 
 import com.google.common.collect.ImmutableList;
@@ -51,9 +53,20 @@ import com.google.common.collect.ImmutableSet;
 
 public class BytesBufferTest extends BaseUnitTest {
 
+    @Before
+    public void setUp() throws Exception {
+        resetMaxBufferCapacity();
+    }
+
     @After
-    public void tearDown() {
-        BytesBuffer.setMaxBufferCapacity(BytesBuffer.MAX_BUFFER_CAPACITY);
+    public void tearDown() throws Exception {
+        resetMaxBufferCapacity();
+    }
+
+    private static void resetMaxBufferCapacity() throws Exception {
+        Field field = BytesBuffer.class.getDeclaredField("maxBufferCapacity");
+        field.setAccessible(true);
+        field.set(null, null);
     }
 
     @Test
@@ -85,7 +98,9 @@ public class BytesBufferTest extends BaseUnitTest {
         Assert.assertEquals(BytesBuffer.MAX_BUFFER_CAPACITY,
                             BytesBuffer.maxBufferCapacity());
 
-        BytesBuffer.setMaxBufferCapacity(128);
+        BytesBuffer.initMaxBufferCapacity(128);
+        Assert.assertEquals(128, BytesBuffer.maxBufferCapacity());
+        BytesBuffer.initMaxBufferCapacity(128);
         Assert.assertEquals(128, BytesBuffer.maxBufferCapacity());
         Assert.assertEquals(128, BytesBuffer.allocate(128).array().length);
 
@@ -100,9 +115,14 @@ public class BytesBufferTest extends BaseUnitTest {
 
     @Test
     public void testResizeWithMaxBufferCapacity() {
-        BytesBuffer.setMaxBufferCapacity(128);
+        BytesBuffer.initMaxBufferCapacity(128);
         BytesBuffer buffer = BytesBuffer.allocate(64);
         buffer.write(new byte[64]);
+        buffer.write((byte) 1);
+        Assert.assertEquals(65, buffer.bytes().length);
+        Assert.assertEquals(128, buffer.array().length);
+
+        buffer.write(new byte[63]);
 
         Assert.assertThrows(IllegalArgumentException.class, () -> {
             buffer.write((byte) 1);
@@ -116,14 +136,15 @@ public class BytesBufferTest extends BaseUnitTest {
     @Test
     public void testSetMaxBufferCapacityWithInvalidValue() {
         Assert.assertThrows(IllegalArgumentException.class, () -> {
-            BytesBuffer.setMaxBufferCapacity(BytesBuffer.DEFAULT_CAPACITY - 1);
+            BytesBuffer.initMaxBufferCapacity(
+                    BytesBuffer.DEFAULT_CAPACITY - 1);
         }, e -> {
             Assert.assertContains("Max buffer capacity must be in range",
                                   e.getMessage());
         });
 
         Assert.assertThrows(IllegalArgumentException.class, () -> {
-            BytesBuffer.setMaxBufferCapacity(
+            BytesBuffer.initMaxBufferCapacity(
                     BytesBuffer.MAX_BUFFER_CAPACITY_UPPER_BOUND + 1);
         }, e -> {
             Assert.assertContains("Max buffer capacity must be in range",
@@ -136,7 +157,7 @@ public class BytesBufferTest extends BaseUnitTest {
         byte[] bytes = genBytes(256);
         BytesBuffer compressed = LZ4Util.compress(bytes, 64);
 
-        BytesBuffer.setMaxBufferCapacity(128);
+        BytesBuffer.initMaxBufferCapacity(128);
 
         Assert.assertThrows(IllegalArgumentException.class, () -> {
             LZ4Util.decompress(compressed.bytes(), 64);
@@ -158,6 +179,39 @@ public class BytesBufferTest extends BaseUnitTest {
             Assert.assertEquals(256, BytesBuffer.maxBufferCapacity());
         } finally {
             graph.close();
+        }
+    }
+
+    @Test
+    public void testMaxBufferCapacityRejectsConflictingGraphConfig()
+           throws Exception {
+        HugeConfig config1 = FakeObjects.newConfig();
+        config1.setProperty(CoreOptions.STORE.name(), "buffer_capacity_1");
+        config1.setProperty(CoreOptions.SERIALIZER_BUFFER_MAX_CAPACITY.name(),
+                            256);
+
+        HugeGraph graph1 = HugeFactory.open(config1);
+        try {
+            Assert.assertEquals(256, BytesBuffer.maxBufferCapacity());
+
+            HugeConfig config2 = FakeObjects.newConfig();
+            config2.setProperty(CoreOptions.STORE.name(),
+                                "buffer_capacity_2");
+            config2.setProperty(
+                    CoreOptions.SERIALIZER_BUFFER_MAX_CAPACITY.name(), 512);
+
+            Assert.assertThrows(IllegalArgumentException.class, () -> {
+                HugeFactory.open(config2);
+            }, e -> {
+                Assert.assertContains("process-wide serializer buffer max " +
+                                      "capacity has been initialized to 256",
+                                      e.getMessage());
+                Assert.assertContains("conflicting value 512",
+                                      e.getMessage());
+            });
+            Assert.assertEquals(256, BytesBuffer.maxBufferCapacity());
+        } finally {
+            graph1.close();
         }
     }
 

--- a/hugegraph-server/hugegraph-test/src/main/java/org/apache/hugegraph/unit/serializer/BytesBufferTest.java
+++ b/hugegraph-server/hugegraph-test/src/main/java/org/apache/hugegraph/unit/serializer/BytesBufferTest.java
@@ -134,6 +134,37 @@ public class BytesBufferTest extends BaseUnitTest {
     }
 
     @Test
+    public void testResizeCappedAtMaxBufferCapacity() {
+        BytesBuffer.initMaxBufferCapacity(128);
+
+        // Allocate small buffer and fill it completely
+        BytesBuffer buffer = BytesBuffer.allocate(64);
+        buffer.write(new byte[64]);
+
+        // Writing 2 more bytes triggers resize:
+        //   requiredCapacity = 64 + 2 = 66
+        //   naive newCapacity = 66 + DEFAULT_CAPACITY(64) = 130
+        //   Math.min(130, maxCapacity=128) = 128  ← capped
+        buffer.write(new byte[2]);
+        Assert.assertEquals(128, buffer.array().length);
+        Assert.assertEquals(66, buffer.bytes().length);
+
+        // Buffer now at capacity 128, position 66, remaining 62.
+        // Fill remaining space — should succeed without resize.
+        buffer.write(new byte[62]);
+        Assert.assertEquals(128, buffer.bytes().length);
+
+        // One more byte exceeds the max — should throw.
+        Assert.assertThrows(IllegalArgumentException.class, () -> {
+            buffer.write((byte) 1);
+        }, e -> {
+            Assert.assertContains("Capacity 129 exceeds max buffer " +
+                                  "capacity: 128",
+                                  e.getMessage());
+        });
+    }
+
+    @Test
     public void testSetMaxBufferCapacityWithInvalidValue() {
         Assert.assertThrows(IllegalArgumentException.class, () -> {
             BytesBuffer.initMaxBufferCapacity(
@@ -153,6 +184,14 @@ public class BytesBufferTest extends BaseUnitTest {
     }
 
     @Test
+    public void testSetMaxBufferCapacityAtUpperBound() {
+        BytesBuffer.initMaxBufferCapacity(
+                BytesBuffer.MAX_BUFFER_CAPACITY_UPPER_BOUND);
+        Assert.assertEquals(BytesBuffer.MAX_BUFFER_CAPACITY_UPPER_BOUND,
+                            BytesBuffer.maxBufferCapacity());
+    }
+
+    @Test
     public void testLZ4DecompressWithMaxBufferCapacity() {
         byte[] bytes = genBytes(256);
         BytesBuffer compressed = LZ4Util.compress(bytes, 64);
@@ -165,6 +204,20 @@ public class BytesBufferTest extends BaseUnitTest {
             Assert.assertContains("exceeds max buffer capacity: 128",
                                   e.getMessage());
         });
+    }
+
+    @Test
+    public void testLZ4DecompressSucceedsWithCustomMaxBufferCapacity() {
+        byte[] bytes = genBytes(64);
+        BytesBuffer compressed = LZ4Util.compress(bytes, 64);
+
+        // Set a custom max that is large enough for the decompressed data
+        BytesBuffer.initMaxBufferCapacity(256);
+
+        BytesBuffer decompressed = LZ4Util.decompress(compressed.bytes(), 64);
+        // Verify the custom cap is active and decompression succeeded
+        Assert.assertEquals(256, BytesBuffer.maxBufferCapacity());
+        Assert.assertArrayEquals(bytes, decompressed.bytes());
     }
 
     @Test

--- a/hugegraph-server/hugegraph-test/src/main/java/org/apache/hugegraph/unit/serializer/BytesBufferTest.java
+++ b/hugegraph-server/hugegraph-test/src/main/java/org/apache/hugegraph/unit/serializer/BytesBufferTest.java
@@ -298,6 +298,34 @@ public class BytesBufferTest extends BaseUnitTest {
     }
 
     @Test
+    public void testMaxBufferCapacityAllowsExplicitConfigAfterDefaultGraph()
+           throws Exception {
+        HugeConfig config1 = FakeObjects.newConfig();
+        config1.setProperty(CoreOptions.STORE.name(), "buffer_default_first");
+
+        HugeGraph graph1 = HugeFactory.open(config1);
+        try {
+            Assert.assertEquals(BytesBuffer.MAX_BUFFER_CAPACITY,
+                                BytesBuffer.maxBufferCapacity());
+
+            HugeConfig config2 = FakeObjects.newConfig();
+            config2.setProperty(CoreOptions.STORE.name(),
+                                "buffer_custom_second");
+            config2.setProperty(
+                    CoreOptions.SERIALIZER_BUFFER_MAX_CAPACITY.name(), 256);
+
+            HugeGraph graph2 = HugeFactory.open(config2);
+            try {
+                Assert.assertEquals(256, BytesBuffer.maxBufferCapacity());
+            } finally {
+                graph2.close();
+            }
+        } finally {
+            graph1.close();
+        }
+    }
+
+    @Test
     public void testWrap() {
         BytesBuffer buf4 = BytesBuffer.wrap(new byte[]{1, 2, 3, 4});
         Assert.assertArrayEquals(new byte[]{1, 2, 3, 4}, buf4.array());


### PR DESCRIPTION
<!-- 
  Thank you very much for contributing to Apache HugeGraph, we are happy that you want to help us improve it!

  Here are some tips for you:
    1. If this is your first time, please read the [contributing guidelines](https://github.com/apache/hugegraph/blob/master/CONTRIBUTING.md)

    2. If a PR fix/close an issue, type the message "close xxx" (xxx is the link of related 
issue) in the content, GitHub will auto link it (Required)

    3. Name the PR title in "Google Commit Format", start with "feat | fix | perf | refactor | doc | chore", 
      such like: "feat(core): support the PageRank algorithm" or "fix: wrong break in the compute loop" (module is optional)
      skip it if you are unsure about which is the best component.

    4. One PR address one issue, better not to mix up multiple issues.

    5. Put an `x` in the `[ ]` to mark the item as CHECKED. `[x]` (or click it directly after 
published)
-->

## Purpose of the PR

- close #3046

<!--
Please explain more context in this section, clarify why the changes are needed. 
e.g:
- If you propose a new API, clarify the use case for a new API.
- If you fix a bug, you can clarify why it is a bug, and should be associated with an issue.
-->
This PR makes the max capacity of one serializer buffer configurable instead of always using the hardcoded default 128MB limit.

The default behavior remains unchanged, while users who need to serialize larger objects can tune the buffer limit through configuration. The new option is still bounded to avoid unbounded memory allocation.

## Main Changes

<!-- Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. These change logs are helpful for better and faster reviews.)
- Add a new core config option: `serializer.buffer_max_capacity`
  - Default value: `134217728` bytes, same as the previous hardcoded 128MB limit
  - Upper bound: 1GB
- Make `BytesBuffer` use the configured max capacity when:
  - creating a buffer
  - expanding buffer capacity
  - reporting capacity-limit errors
- Make `LZ4Util` respect the configured serializer buffer max capacity during decompression.
- Initialize the serializer buffer max capacity from graph config in `StandardHugeGraph`.
- Add sample config entries in:
  - `hugegraph.properties`
  - `hstore.properties.template`
- Add focused unit tests for:
  - buffer allocation with configured max capacity
  - buffer resize limit checks
  - invalid max capacity values
  - LZ4 decompression limit checks
  - loading the max capacity from graph config


## Verifying these changes

<!-- Please pick the proper options below -->

- [ ] Trivial rework / code cleanup without any test coverage. (No Need)
- [ ] Already covered by existing tests, such as *(please modify tests here)*.
- [x] Need tests and can be verified as follows:
    - xxx

## Does this PR potentially affect the following parts?

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ]  Dependencies ([add/update license](https://hugegraph.apache.org/docs/contribution-guidelines/contribute/#321-check-licenses) info & [regenerate_known_dependencies.sh](../install-dist/scripts/dependency/regenerate_known_dependencies.sh)) <!-- Don't forget to add/update the info in "LICENSE" & "NOTICE" files (both in root & dist module) -->
- [x]  Modify configurations
- [ ]  The public API
- [ ]  Other affects (typed here)
- [ ]  Nope


## Documentation Status

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ]  `Doc - TODO` <!-- Your PR changes impact docs and you will update later -->
- [x]  `Doc - Done` <!-- Related docs have been already added or updated -->
- [ ]  `Doc - No Need` <!-- Your PR changes don't impact/need docs -->
