### PR TITLE
fix: gremlin-console.sh fails on Mac M/ARM CPU #3050

### DIFF
--- a/hugegraph-server/hugegraph-dist/pom.xml
+++ b/hugegraph-server/hugegraph-dist/pom.xml
@@ -33,6 +33,7 @@
         <assembly.dir>${project.basedir}/src/assembly</assembly.dir>
         <assembly.descriptor.dir>${assembly.dir}/descriptor</assembly.descriptor.dir>
         <assembly.static.dir>${assembly.dir}/static</assembly.static.dir>
+        <jansi.version>2.4.0</jansi.version>
     </properties>
 
     <dependencies>
@@ -122,6 +123,15 @@
             <groupId>io.grpc</groupId>
             <artifactId>grpc-stub</artifactId>
             <version>${grpc.version}</version>
+        </dependency>
+
+        <!-- Added updated jar to avoid java.lang.NoClassDefFoundError: org/fusesource/jansi/AnsiConsole when launching
+             gremlin console on arm64 -->
+        <dependency>
+            <groupId>org.fusesource.jansi</groupId>
+            <artifactId>jansi</artifactId>
+            <version>${jansi.version}</version>
+            <scope>runtime</scope>
         </dependency>
     </dependencies>
 

--- a/install-dist/release-docs/LICENSE
+++ b/install-dist/release-docs/LICENSE
@@ -929,3 +929,9 @@ The text of each license is also included in licenses/LICENSE-[project].txt.
 
     https://central.sonatype.com/artifact/xmlpull/xmlpull/1.1.3.1 -> Public Domain
     https://central.sonatype.com/artifact/xpp3/xpp3_min/1.1.4c -> Public Domain
+
+#
+# jansi 2.4.0 (https://github.com/fusesource/jansi)
+#
+# This product includes software developed by the Jansi project (http://fusesource.github.io/jansi/).
+# See licenses/LICENSE-jansi-2.4.0.txt for license details (Apache License 2.0 or LGPL 3.0+).

--- a/install-dist/release-docs/NOTICE
+++ b/install-dist/release-docs/NOTICE
@@ -1887,3 +1887,12 @@ swagger-ui NOTICE
 
 swagger-ui
 Copyright 2020-2021 SmartBear Software Inc.
+
+========================================================================
+
+#
+# jansi 2.4.0 (https://github.com/fusesource/jansi)
+#
+# This product includes software developed by the Jansi project (http://fusesource.github.io/jansi/).
+# See licenses/LICENSE-jansi-2.4.0.txt for license details (Apache License 2.0 or LGPL 3.0+).
+

--- a/install-dist/release-docs/licenses/LICENSE-jansi-2.4.0.txt
+++ b/install-dist/release-docs/licenses/LICENSE-jansi-2.4.0.txt
@@ -1,0 +1,16 @@
+Copyright (c) 2007-2021, the original author(s)
+All rights reserved.
+
+This software is dual-licensed under the Apache License, Version 2.0 and the GNU Lesser General Public License, version 3 or later (LGPL-3.0-or-later).
+
+You may obtain a copy of the Apache License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+You may obtain a copy of the GNU Lesser General Public License at
+
+    http://www.gnu.org/licenses/lgpl-3.0.html
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+
+This product includes software developed by the Jansi project (http://fusesource.github.io/jansi/).

--- a/install-dist/scripts/dependency/known-dependencies.txt
+++ b/install-dist/scripts/dependency/known-dependencies.txt
@@ -241,6 +241,7 @@ jakarta.ws.rs-api-3.0.0.jar
 jakarta.xml.bind-api-2.3.3.jar
 jakarta.xml.bind-api-3.0.0.jar
 jamm-0.3.2.jar
+jansi-2.4.0.jar
 java-cup-runtime-11b-20160615.jar
 javapoet-1.8.0.jar
 javassist-3.21.0-GA.jar


### PR DESCRIPTION
### What I changed
- Added runtime dependency `org.fusesource.jansi:jansi:2.4.0` in `hugegraph-server/hugegraph-dist/pom.xml`.
- Updated release docs:
  - `install-dist/release-docs/LICENSE`
  - `install-dist/release-docs/NOTICE`
  - `install-dist/release-docs/licenses/LICENSE-jansi-2.4.0.txt`

### Validation performed
```bash
 ✘ vjoshi@DNWW7WJ4LJ  ~/SourceCode/HUGEGRAPH/hugegraph   3031-AppleSiliconFix  export RUNNER_TEMP="$(mktemp -d)"     
VERSION=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)
SERVER_DIR="hugegraph-server/apache-hugegraph-server-${VERSION}"
printf "println \"gremlin-console-smoke-ok\"\n" > "$RUNNER_TEMP/gremlin-console-smoke.groovy"
"${SERVER_DIR}/bin/gremlin-console.sh" -- -e "$RUNNER_TEMP/gremlin-console-smoke.groovy"

WARNING: An illegal reflective access operation has occurred
WARNING: Illegal reflective access by org.codehaus.groovy.reflection.CachedClass (file:/Users/vjoshi/SourceCode/HUGEGRAPH/hugegraph/hugegraph-server/apache-hugegraph-server-1.7.0/lib/groovy-2.5.14-indy.jar) to method java.lang.Object.finalize()
WARNING: Please consider reporting this to the maintainers of org.codehaus.groovy.reflection.CachedClass
WARNING: Use --illegal-access=warn to enable warnings of further illegal reflective access operations
WARNING: All illegal access operations will be denied in a future release
gremlin-console-smoke-ok

Manually checked if we can launch gremlin console.