### PR TITLE
fix(docker): supervise Java process in entrypoints instead of tail -f /dev/null

### DIFF
--- a/hugegraph-pd/hg-pd-dist/docker/docker-entrypoint.sh
+++ b/hugegraph-pd/hg-pd-dist/docker/docker-entrypoint.sh
@@ -82,5 +82,4 @@ log "  pd.initial-store-list=${HG_PD_INITIAL_STORE_LIST}"
 log "  pd.initial-store-count=${HG_PD_INITIAL_STORE_COUNT}"
 log "  pd.data-path=${HG_PD_DATA_PATH}"
 
-./bin/start-hugegraph-pd.sh -j "${JAVA_OPTS:-}"
-tail -f /dev/null
+./bin/start-hugegraph-pd.sh -d false -j "${JAVA_OPTS:-}"

--- a/hugegraph-server/hugegraph-dist/docker/docker-entrypoint.sh
+++ b/hugegraph-server/hugegraph-dist/docker/docker-entrypoint.sh
@@ -91,4 +91,8 @@ if [[ "${ACTUAL_BACKEND}" == "hstore" ]]; then
     ./bin/wait-partition.sh || log "WARN: partitions not assigned yet"
 fi
 
-tail -f /dev/null
+PID=$(cat ./bin/pid 2>/dev/null || true)
+if [[ -n "$PID" ]]; then
+    tail --pid="$PID" -f /dev/null
+    exit 1
+fi

--- a/hugegraph-server/hugegraph-dist/docker/docker-entrypoint.sh
+++ b/hugegraph-server/hugegraph-dist/docker/docker-entrypoint.sh
@@ -93,6 +93,7 @@ fi
 
 PID=$(cat ./bin/pid 2>/dev/null || true)
 if [[ -n "$PID" ]]; then
+    trap 'kill -TERM "$PID" 2>/dev/null; while kill -0 "$PID" 2>/dev/null; do sleep 1; done; exit 0' TERM INT
     tail --pid="$PID" -f /dev/null
     exit 1
 fi

--- a/hugegraph-store/hg-store-dist/docker/docker-entrypoint.sh
+++ b/hugegraph-store/hg-store-dist/docker/docker-entrypoint.sh
@@ -77,5 +77,4 @@ log "  raft.address=${HG_STORE_RAFT_ADDRESS}"
 log "  server.port=${HG_STORE_REST_PORT}"
 log "  app.data-path=${HG_STORE_DATA_PATH}"
 
-./bin/start-hugegraph-store.sh -j "${JAVA_OPTS:-}"
-tail -f /dev/null
+./bin/start-hugegraph-store.sh -d false -j "${JAVA_OPTS:-}"


### PR DESCRIPTION
## Purpose of the PR

- relates to #3043
- close #3043

All three `docker-entrypoint.sh` files used `tail -f /dev/null` to keep the container alive. When Java crashed, `tail` kept running and the container stayed up with no Java inside — Docker restart policy never fired.

## Main Changes

**PD and Store:** replace daemon start + `tail -f /dev/null` with `-d false`, which triggers the foreground branch added in #3047. `exec java` replaces the shell with Java directly, so the entrypoint blocks and exits with Java's real exit code when Java exits.

**Server:** keep daemon start (`wait-partition.sh` must run after Java is already up in the background). Replace `tail -f /dev/null` with `tail --pid=$(cat ./bin/pid) -f /dev/null`. When Java exits, `tail --pid` returns, entrypoint exits 1, restart policy fires.

Note: server entrypoint always exits 1 — `start-hugegraph.sh` calls `disown` before returning so Java is not a child of the entrypoint shell and its real exit code is not available. This is sufficient for `--restart=on-failure`.

| Component | Before | After |
|---|---|---|
| PD | daemon start + `tail -f /dev/null` | `-d false` → `exec java` blocks |
| Store | daemon start + `tail -f /dev/null` | `-d false` → `exec java` blocks |
| Server | daemon start + `tail -f /dev/null` | daemon start + `tail --pid` supervision |

## Verifying these changes

- [x] Need tests and can be verified as follows:
  - `docker run --restart=on-failure` → `kill -9` Java inside container → container exits and Docker restarts it automatically
  - Verified locally: 3 kill-9 tests on server container, PD restart loop confirmed

## Does this PR potentially affect the following parts?

- [ ] Dependencies
- [ ] Modify configurations
- [ ] The public API
- [ ] Other affects
- [x] Nope

## Documentation Status

- [x] `Doc - TODO` — README/docs update for Docker deployment lifecycle will follow in a separate PR