### PR TITLE
chore(ci): exit 77 when tools missing to distinguish skip from pass

### DIFF
--- a/.github/workflows/pd-store-ci.yml
+++ b/.github/workflows/pd-store-ci.yml
@@ -111,7 +111,15 @@ jobs:
         run: |
           VERSION=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)
           PD_DIR=hugegraph-pd/apache-hugegraph-pd-$VERSION/
+          set +e
           $TRAVIS_DIR/test-start-hugegraph-pd.sh $PD_DIR
+          EXIT=$?
+          set -e
+          if [ $EXIT -eq 77 ]; then
+            echo "::notice::PD startup tests skipped — required tools not available"
+            exit 0
+          fi
+          exit $EXIT
 
       - name: Prepare env and service
         run: |
@@ -173,7 +181,15 @@ jobs:
         run: |
           VERSION=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)
           STORE_DIR=hugegraph-store/apache-hugegraph-store-$VERSION/
+          set +e
           $TRAVIS_DIR/test-start-hugegraph-store.sh $STORE_DIR
+          EXIT=$?
+          set -e
+          if [ $EXIT -eq 77 ]; then
+            echo "::notice::Store startup tests skipped — required tools not available"
+            exit 0
+          fi
+          exit $EXIT
 
       - name: Prepare env and service
         run: |

--- a/.github/workflows/pd-store-ci.yml
+++ b/.github/workflows/pd-store-ci.yml
@@ -107,19 +107,29 @@ jobs:
         run: |
           mvn clean package -U -Dmaven.javadoc.skip=true -Dmaven.test.skip=true -ntp --fail-at-end
 
+      - name: Check startup test prerequisites (PD)
+        id: pd-preflight
+        run: |
+          for tool in lsof curl java; do
+            if ! command -v "$tool" >/dev/null 2>&1; then
+              echo "can_run=false" >> "$GITHUB_OUTPUT"
+              echo "skip_reason=missing tool: $tool" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
+          done
+          echo "can_run=true" >> "$GITHUB_OUTPUT"
+
       - name: Run start-hugegraph-pd.sh foreground mode tests
+        if: steps.pd-preflight.outputs.can_run == 'true'
         run: |
           VERSION=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)
           PD_DIR=hugegraph-pd/apache-hugegraph-pd-$VERSION/
-          set +e
           $TRAVIS_DIR/test-start-hugegraph-pd.sh $PD_DIR
-          EXIT=$?
-          set -e
-          if [ $EXIT -eq 77 ]; then
-            echo "::notice::PD startup tests skipped — required tools not available"
-            exit 0
-          fi
-          exit $EXIT
+
+      - name: Startup tests skipped (missing prerequisites)
+        if: steps.pd-preflight.outputs.can_run == 'false'
+        run: |
+          echo "::notice::PD startup tests skipped — ${{ steps.pd-preflight.outputs.skip_reason }}"
 
       - name: Prepare env and service
         run: |
@@ -177,19 +187,35 @@ jobs:
         run: |
           mvn clean package -U -Dmaven.javadoc.skip=true -Dmaven.test.skip=true -ntp --fail-at-end
 
+      - name: Check startup test prerequisites (Store)
+        id: store-preflight
+        run: |
+          for tool in lsof curl java; do
+            if ! command -v "$tool" >/dev/null 2>&1; then
+              echo "can_run=false" >> "$GITHUB_OUTPUT"
+              echo "skip_reason=missing tool: $tool" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
+          done
+          LIMIT_N=$(ulimit -n)
+          if [[ "$LIMIT_N" != "unlimited" ]] && (( LIMIT_N < 1024 )); then
+            echo "can_run=false" >> "$GITHUB_OUTPUT"
+            echo "skip_reason=ulimit -n is $LIMIT_N (store requires >= 1024)" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          echo "can_run=true" >> "$GITHUB_OUTPUT"
+
       - name: Run start-hugegraph-store.sh foreground mode tests
+        if: steps.store-preflight.outputs.can_run == 'true'
         run: |
           VERSION=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)
           STORE_DIR=hugegraph-store/apache-hugegraph-store-$VERSION/
-          set +e
           $TRAVIS_DIR/test-start-hugegraph-store.sh $STORE_DIR
-          EXIT=$?
-          set -e
-          if [ $EXIT -eq 77 ]; then
-            echo "::notice::Store startup tests skipped — required tools not available"
-            exit 0
-          fi
-          exit $EXIT
+
+      - name: Startup tests skipped (missing prerequisites)
+        if: steps.store-preflight.outputs.can_run == 'false'
+        run: |
+          echo "::notice::Store startup tests skipped — ${{ steps.store-preflight.outputs.skip_reason }}"
 
       - name: Prepare env and service
         run: |

--- a/.github/workflows/server-ci.yml
+++ b/.github/workflows/server-ci.yml
@@ -70,21 +70,31 @@ jobs:
         run: |
           mvn clean compile -U -Dmaven.javadoc.skip=true -ntp
 
-      - name: Run start-hugegraph.sh foreground mode tests
+      - name: Check startup test prerequisites
+        id: server-preflight
         if: ${{ env.BACKEND == 'rocksdb' }}
+        run: |
+          for tool in lsof crontab curl java; do
+            if ! command -v "$tool" >/dev/null 2>&1; then
+              echo "can_run=false" >> "$GITHUB_OUTPUT"
+              echo "skip_reason=missing tool: $tool" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
+          done
+          echo "can_run=true" >> "$GITHUB_OUTPUT"
+
+      - name: Run start-hugegraph.sh foreground mode tests
+        if: ${{ env.BACKEND == 'rocksdb' && steps.server-preflight.outputs.can_run == 'true' }}
         run: |
           mvn package -Dmaven.test.skip=true -pl hugegraph-server/hugegraph-dist -am -ntp
           VERSION=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)
           SERVER_DIR=hugegraph-server/apache-hugegraph-server-$VERSION/
-          set +e
           $TRAVIS_DIR/test-start-hugegraph.sh $SERVER_DIR
-          EXIT=$?
-          set -e
-          if [ $EXIT -eq 77 ]; then
-            echo "::notice::Startup tests skipped — required tools not available"
-            exit 0
-          fi
-          exit $EXIT
+
+      - name: Startup tests skipped (missing prerequisites)
+        if: ${{ env.BACKEND == 'rocksdb' && steps.server-preflight.outputs.can_run == 'false' }}
+        run: |
+          echo "::notice::Server startup tests skipped — ${{ steps.server-preflight.outputs.skip_reason }}"
 
       - name: Run unit test
         run: |

--- a/.github/workflows/server-ci.yml
+++ b/.github/workflows/server-ci.yml
@@ -76,7 +76,15 @@ jobs:
           mvn package -Dmaven.test.skip=true -pl hugegraph-server/hugegraph-dist -am -ntp
           VERSION=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)
           SERVER_DIR=hugegraph-server/apache-hugegraph-server-$VERSION/
+          set +e
           $TRAVIS_DIR/test-start-hugegraph.sh $SERVER_DIR
+          EXIT=$?
+          set -e
+          if [ $EXIT -eq 77 ]; then
+            echo "::notice::Startup tests skipped — required tools not available"
+            exit 0
+          fi
+          exit $EXIT
 
       - name: Run unit test
         run: |

--- a/hugegraph-server/hugegraph-dist/src/assembly/travis/test-start-hugegraph-pd.sh
+++ b/hugegraph-server/hugegraph-dist/src/assembly/travis/test-start-hugegraph-pd.sh
@@ -132,7 +132,7 @@ fi
 for tool in lsof curl java; do
     if ! command -v "$tool" >/dev/null 2>&1; then
         echo "SKIP: required tool '$tool' not found — skipping test suite"
-        exit 0
+        exit 77
     fi
 done
 

--- a/hugegraph-server/hugegraph-dist/src/assembly/travis/test-start-hugegraph-store.sh
+++ b/hugegraph-server/hugegraph-dist/src/assembly/travis/test-start-hugegraph-store.sh
@@ -113,7 +113,7 @@ fi
 for tool in lsof curl java; do
     if ! command -v "$tool" >/dev/null 2>&1; then
         echo "SKIP: required tool '$tool' not found — skipping test suite"
-        exit 0
+        exit 77
     fi
 done
 
@@ -122,7 +122,7 @@ LIMIT_N=$(ulimit -n)
 if [[ "$LIMIT_N" != "unlimited" ]]; then
     if (( LIMIT_N < 1024 )); then
         echo "SKIP: ulimit -n is $LIMIT_N — store requires >= 1024. Run: ulimit -n 1024"
-        exit 0
+        exit 77
     fi
 fi
 

--- a/hugegraph-server/hugegraph-dist/src/assembly/travis/test-start-hugegraph.sh
+++ b/hugegraph-server/hugegraph-dist/src/assembly/travis/test-start-hugegraph.sh
@@ -148,7 +148,7 @@ fi
 for tool in lsof crontab curl java; do
     if ! command -v "$tool" >/dev/null 2>&1; then
         echo "SKIP: required tool '$tool' not found — skipping test suite"
-        exit 0
+        exit 77
     fi
 done
 


### PR DESCRIPTION
## Purpose of the PR

- relates to #3043
- follow-up to #3044, #3047
- close #3054 
- close #3043
The three startup test scripts (`test-start-hugegraph.sh`, `test-start-hugegraph-pd.sh`, `test-start-hugegraph-store.sh`) exit `0` when required tools (`lsof`, `curl`, `java`) are not found. Exit code `0` is indistinguishable from a passing test run — CI shows green even though no tests ran.

## Main Changes

**Test scripts:**
- Change `exit 0` → `exit 77` in all tool-missing skip paths
- Change `exit 0` → `exit 77` in the Store `ulimit -n` skip path

**CI workflows (`server-ci.yml`, `pd-store-ci.yml`):**
- Wrap each test step with `set +e` / exit code capture
- Treat exit `77` as a visible `::notice::` annotation (not a failure)
- All other non-zero exits still fail the step

## Verifying these changes

- [x] Need tests and can be verified as follows:
  - Remove `lsof` from the runner path → CI step shows `::notice::... skipped` instead of silently passing
  - Normal run (all tools present) → exit `0`, step passes as before
  - Test failure → exit `1`, step fails as before

## Does this PR potentially affect the following parts?

- [ ] Dependencies
- [ ] Modify configurations
- [ ] The public API
- [ ] Other affects
- [x] Nope

## Documentation Status

- [x] `Doc - No Need`