### PR TITLE
docs: document -d flag and Docker process supervision model 

### DIFF
--- a/hugegraph-pd/README.md
+++ b/hugegraph-pd/README.md
@@ -78,12 +78,13 @@ bin/stop-hugegraph-pd.sh
 #### Startup Options
 
 ```bash
-bin/start-hugegraph-pd.sh [-g GC_TYPE] [-j "JVM_OPTIONS"] [-y ENABLE_OTEL]
+bin/start-hugegraph-pd.sh [-g GC_TYPE] [-j "JVM_OPTIONS"] [-y ENABLE_OTEL] [-d DAEMON]
 ```
 
 - `-g`: GC type (`g1` or `ZGC`, default: `g1`)
 - `-j`: Custom JVM options (e.g., `-j "-Xmx4g -Xms4g"`)
 - `-y`: Enable OpenTelemetry tracing (`true` or `false`, default: `false`)
+- `-d`: Daemon mode (`true` = daemon, `false` = foreground; default: `true`). Set to `false` when running under Docker or a process supervisor so the container exits if Java dies.
 
 ### Configuration
 

--- a/hugegraph-server/hugegraph-dist/docker/README.md
+++ b/hugegraph-server/hugegraph-dist/docker/README.md
@@ -143,7 +143,4 @@ native `HEALTHCHECK` instructions. `docker ps` shows real health status:
 | `hugegraph/hugegraph-pd` | `GET /v1/health` on port 8620 |
 | `hugegraph/hugegraph-store` | `GET /v1/health` on port 8520 |
 
-The entrypoints supervise the Java process directly — when Java exits, the
-container exits and Docker's `restart: unless-stopped` policy brings it back
-automatically. The old cron-based monitor (`-m true`) is for VM/bare-metal
-deployments only and is not used in Docker images.
+The entrypoints supervise the Java process directly — when Java exits, the container exits. If started with a restart policy (the provided compose files use `restart: unless-stopped`), Docker will bring it back automatically. The old cron-based monitor (`-m true`) is for VM/bare-metal deployments only and is not used in Docker images.

--- a/hugegraph-server/hugegraph-dist/docker/README.md
+++ b/hugegraph-server/hugegraph-dist/docker/README.md
@@ -130,3 +130,20 @@ HUGEGRAPH_VERSION=1.7.0 docker compose -f docker-compose-3pd-3store-3server.yml 
 
 See [docker/README.md](../../../docker/README.md) for the full setup guide,
 environment variable reference, and troubleshooting.
+
+## 6. Process Supervision & Health Checks
+
+All four HugeGraph Docker images (PD, Store, Server, Server-hstore) include
+native `HEALTHCHECK` instructions. `docker ps` shows real health status:
+
+| Image | Health endpoint |
+|---|---|
+| `hugegraph/hugegraph` | `GET /versions` on port 8080 |
+| `hugegraph/hugegraph-hstore` | `GET /versions` on port 8080 |
+| `hugegraph/hugegraph-pd` | `GET /v1/health` on port 8620 |
+| `hugegraph/hugegraph-store` | `GET /v1/health` on port 8520 |
+
+The entrypoints supervise the Java process directly — when Java exits, the
+container exits and Docker's `restart: unless-stopped` policy brings it back
+automatically. The old cron-based monitor (`-m true`) is for VM/bare-metal
+deployments only and is not used in Docker images.

--- a/hugegraph-store/README.md
+++ b/hugegraph-store/README.md
@@ -231,11 +231,12 @@ bin/restart-hugegraph-store.sh
 #### Startup Options
 
 ```bash
-bin/start-hugegraph-store.sh [-g GC_TYPE] [-j "JVM_OPTIONS"]
+bin/start-hugegraph-store.sh [-g GC_TYPE] [-j "JVM_OPTIONS"] [-d DAEMON]
 ```
 
 - `-g`: GC type (`g1` or `ZGC`, default: `g1`)
 - `-j`: Custom JVM options (e.g., `-j "-Xmx16g -Xms8g"`)
+- `-d`: Daemon mode (`true` = daemon, `false` = foreground; default: `true`). Set to `false` when running under Docker or a process supervisor so the container exits if Java dies.
 
 Default JVM memory settings (defined in `start-hugegraph-store.sh`):
 - Max heap: 32GB


### PR DESCRIPTION
## Purpose of the PR

- Part of #3043 (Chunk 10) 
- close #3043
- Follow-up to #3047 (added `-d` flag to PD/Store startup scripts) and #3051/#3052 (Docker entrypoint supervision + HEALTHCHECK)

Documents the new `-d true|false` daemon flag and the Docker-native process supervision model introduced in the preceding PRs.

## Main Changes

**`hugegraph-pd/README.md`:**
- Add `-d DAEMON` to the startup options signature
- Document: daemon mode (`true` = daemon, `false` = foreground; default: `true`); set to `false` under Docker or a process supervisor

**`hugegraph-store/README.md`:**
- Same additions as PD

**`hugegraph-server/hugegraph-dist/docker/README.md`:**
- Add section explaining HEALTHCHECK endpoints (`:8080/versions`, `:8620/v1/health`, `:8520/v1/health`) and the Java process supervision model
- Note that the cron-based monitor (`-m true`) is for VM/bare-metal only, not Docker

## Verifying these changes

- [x] Need tests and can be verified as follows:
  - `docker inspect <image> | grep -A5 Healthcheck` — confirms HEALTHCHECK is present
  - `docker stop <container>` — container exits cleanly (SIGTERM forwarded to Java)
  - `kill -9 <java-pid>` inside container — container exits, restart policy fires

## Does this PR potentially affect the following parts?

- [ ] Dependencies
- [ ] Modify configurations
- [ ] The public API
- [ ] Other affects
- [x] Nope

## Documentation Status

- [x] `Doc - Updated` (in-repo README files only; `hugegraph-doc` follow-up is tracked separately)