### PR TITLE
  fix(core): self-heal etcd meta watch on transport reconnect

### DIFF
--- a/hugegraph-server/hugegraph-core/src/main/java/org/apache/hugegraph/backend/cache/CachedSchemaTransactionV2.java
+++ b/hugegraph-server/hugegraph-core/src/main/java/org/apache/hugegraph/backend/cache/CachedSchemaTransactionV2.java
@@ -52,10 +52,10 @@ public class CachedSchemaTransactionV2 extends SchemaTransactionV2 {
 
     // MetaDriver doesn't expose unlisten, register the meta listener once.
     // Lifecycle: this JVM-global flag is intentionally never reset by
-    // unlistenChanges() (the underlying gRPC watch is process-wide). If that
-    // watch is silently dropped after a transport reconnect, recovery is not
-    // automatic; resetMetaListenerForReconnect() is only a manual hook to let
-    // the next schema operation install a fresh watch.
+    // unlistenChanges() (the underlying gRPC watch is process-wide). The driver
+    // watch self-heals across transport reconnects (PdMetaDriver via KvClient,
+    // EtcdMetaDriver via Watch.Listener re-subscribe), so the subscription stays
+    // live and the flag staying true is correct.
     private static final AtomicBoolean metaEventListenerRegistered =
             new AtomicBoolean(false);
 
@@ -248,27 +248,6 @@ public class CachedSchemaTransactionV2 extends SchemaTransactionV2 {
             String graphName = event.graph();
             LOG.debug("Graph {} clear schema cache on meta event", graphName);
             clearSchemaCache(graphName);
-        }
-    }
-
-    /**
-     * Manually reset the JVM-global meta listener flag after detecting that
-     * the MetaManager transport reconnected and dropped the underlying gRPC
-     * watch. This method is not wired to a MetaManager/MetaDriver reconnect
-     * callback today; callers must invoke it explicitly after detecting that
-     * condition. Without such a manual reset {@link #metaEventListenerRegistered}
-     * would stay {@code true} forever and this JVM would stop receiving
-     * cross-node schema cache clear events with no error or warning.
-     *
-     * <p>TODO: wire this into MetaManager once it exposes a transport
-     * reconnect callback (e.g. {@code listenReconnect} /
-     * {@code onTransportReconnect}). Until then it must be invoked
-     * explicitly by code that detects the reconnect.
-     */
-    public static void resetMetaListenerForReconnect() {
-        if (metaEventListenerRegistered.compareAndSet(true, false)) {
-            LOG.warn("Schema cache clear meta listener lost on reconnect - " +
-                     "will re-register on next schema operation.");
         }
     }
 

--- a/hugegraph-server/hugegraph-core/src/main/java/org/apache/hugegraph/meta/EtcdMetaDriver.java
+++ b/hugegraph-server/hugegraph-core/src/main/java/org/apache/hugegraph/meta/EtcdMetaDriver.java
@@ -25,6 +25,9 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
 
 import org.apache.commons.io.FileUtils;
@@ -33,7 +36,9 @@ import org.apache.hugegraph.meta.lock.EtcdDistributedLock;
 import org.apache.hugegraph.meta.lock.LockResult;
 import org.apache.hugegraph.type.define.CollectionType;
 import org.apache.hugegraph.util.E;
+import org.apache.hugegraph.util.Log;
 import org.apache.hugegraph.util.collection.CollectionFactory;
+import org.slf4j.Logger;
 
 import com.google.common.base.Strings;
 
@@ -42,6 +47,7 @@ import io.etcd.jetcd.Client;
 import io.etcd.jetcd.ClientBuilder;
 import io.etcd.jetcd.KV;
 import io.etcd.jetcd.KeyValue;
+import io.etcd.jetcd.Watch;
 import io.etcd.jetcd.kv.GetResponse;
 import io.etcd.jetcd.lease.LeaseKeepAliveResponse;
 import io.etcd.jetcd.options.DeleteOption;
@@ -57,8 +63,23 @@ import io.netty.handler.ssl.SslProvider;
 
 public class EtcdMetaDriver implements MetaDriver {
 
+    private static final Logger LOG = Log.logger(EtcdMetaDriver.class);
+
     private final Client client;
     private final EtcdDistributedLock lock;
+
+    // Re-subscribes a dropped watch off the jetcd callback thread; single
+    // daemon thread, process-lifetime (no close()), so JVM shutdown reclaims it.
+    private final ScheduledExecutorService reWatchExecutor =
+            Executors.newSingleThreadScheduledExecutor(r -> {
+                Thread thread = new Thread(r, "etcd-meta-rewatch");
+                thread.setDaemon(true);
+                return thread;
+            });
+
+    // Backoff before re-subscribing a dropped watch. Package-private and
+    // mutable only so tests can set it to 0; never reassigned in production.
+    long reWatchDelayMs = 1000L;
 
     public EtcdMetaDriver(String trustFile, String clientCertFile,
                           String clientKeyFile, Object... endpoints) {
@@ -74,6 +95,13 @@ public class EtcdMetaDriver implements MetaDriver {
         ClientBuilder builder = this.etcdMetaDriverBuilder(endpoints);
         this.client = builder.build();
         this.lock = EtcdDistributedLock.getInstance(this.client);
+    }
+
+    // Package-private constructor for tests: inject a mock Client and skip lock
+    // setup (watch tests never touch the distributed lock).
+    EtcdMetaDriver(Client client) {
+        this.client = client;
+        this.lock = null;
     }
 
     private static ByteSequence toByteSequence(String content) {
@@ -303,9 +331,8 @@ public class EtcdMetaDriver implements MetaDriver {
     @SuppressWarnings("unchecked")
     @Override
     public <T> void listen(String key, Consumer<T> consumer) {
-
-        this.client.getWatchClient().watch(toByteSequence(key),
-                                           (Consumer<WatchResponse>) consumer);
+        this.watchKey(toByteSequence(key), WatchOption.DEFAULT,
+                      (Consumer<WatchResponse>) consumer);
     }
 
     /**
@@ -314,9 +341,35 @@ public class EtcdMetaDriver implements MetaDriver {
     @SuppressWarnings("unchecked")
     @Override
     public <T> void listenPrefix(String prefix, Consumer<T> consumer) {
-        ByteSequence sequence = toByteSequence(prefix);
         WatchOption option = WatchOption.newBuilder().isPrefix(true).build();
-        this.client.getWatchClient().watch(sequence, option, (Consumer<WatchResponse>) consumer);
+        this.watchKey(toByteSequence(prefix), option,
+                      (Consumer<WatchResponse>) consumer);
+    }
 
+    /**
+     * Subscribe a self-healing watch. Unlike the bare {@code Consumer} overload,
+     * this surfaces {@code onError}/{@code onCompleted}: when the underlying
+     * watch terminates (e.g. a transport reconnect drops the gRPC stream) it
+     * re-subscribes after a short backoff, so the listener is not silently lost.
+     * Mirrors the re-subscribe behaviour PdMetaDriver already gets from KvClient.
+     */
+    private void watchKey(ByteSequence key, WatchOption option,
+                          Consumer<WatchResponse> consumer) {
+        Watch.Listener listener = Watch.listener(
+                consumer,
+                throwable -> this.scheduleReWatch(key, option, consumer, throwable),
+                () -> this.scheduleReWatch(key, option, consumer, null));
+        // Watcher intentionally not closed: process-lifetime watch, recreated
+        // on self-heal; the prior watcher's stream has already terminated.
+        this.client.getWatchClient().watch(key, option, listener);
+    }
+
+    private void scheduleReWatch(ByteSequence key, WatchOption option,
+                                 Consumer<WatchResponse> consumer,
+                                 Throwable cause) {
+        LOG.warn("etcd meta watch dropped, re-subscribing", cause);
+        this.reWatchExecutor.schedule(
+                () -> this.watchKey(key, option, consumer),
+                this.reWatchDelayMs, TimeUnit.MILLISECONDS);
     }
 }

--- a/hugegraph-server/hugegraph-core/src/main/java/org/apache/hugegraph/meta/EtcdMetaDriver.java
+++ b/hugegraph-server/hugegraph-core/src/main/java/org/apache/hugegraph/meta/EtcdMetaDriver.java
@@ -347,29 +347,57 @@ public class EtcdMetaDriver implements MetaDriver {
     }
 
     /**
-     * Subscribe a self-healing watch. Unlike the bare {@code Consumer} overload,
-     * this surfaces {@code onError}/{@code onCompleted}: when the underlying
-     * watch terminates (e.g. a transport reconnect drops the gRPC stream) it
-     * re-subscribes after a short backoff, so the listener is not silently lost.
-     * Mirrors the re-subscribe behaviour PdMetaDriver already gets from KvClient.
+     * Subscribe a watch that survives the terminal close jetcd cannot recover
+     * from. The bare {@code Consumer} overload discards {@code onError} and
+     * {@code onCompleted}, so a non-retryable failure silently drops the
+     * listener (issue #3036).
+     * <p>
+     * jetcd 0.5.9 ({@code WatchImpl.WatcherImpl.handleError}) already retries
+     * <em>retryable</em> errors itself: it notifies {@code onError} and then
+     * reschedules {@code resume()} on the same watcher. Re-subscribing from
+     * {@code onError} would therefore open a duplicate watch on every transient
+     * reconnect, so {@code onError} only logs here. A non-retryable error (or an
+     * explicit cancel) ends in {@code close()}, which removes the watcher and
+     * invokes {@code onCompleted}; that is the only point where the watch is
+     * truly gone, so re-subscribe happens there. The old watcher is already
+     * closed and removed, so the replacement is not a duplicate.
      */
     private void watchKey(ByteSequence key, WatchOption option,
                           Consumer<WatchResponse> consumer) {
         Watch.Listener listener = Watch.listener(
                 consumer,
-                throwable -> this.scheduleReWatch(key, option, consumer, throwable),
-                () -> this.scheduleReWatch(key, option, consumer, null));
-        // Watcher intentionally not closed: process-lifetime watch, recreated
-        // on self-heal; the prior watcher's stream has already terminated.
+                throwable -> LOG.warn("etcd meta watch error for key '{}', " +
+                                      "jetcd will retry if recoverable",
+                                      key.toString(Charset.defaultCharset()),
+                                      throwable),
+                () -> this.scheduleReWatch(key, option, consumer));
         this.client.getWatchClient().watch(key, option, listener);
     }
 
     private void scheduleReWatch(ByteSequence key, WatchOption option,
-                                 Consumer<WatchResponse> consumer,
-                                 Throwable cause) {
-        LOG.warn("etcd meta watch dropped, re-subscribing", cause);
-        this.reWatchExecutor.schedule(
-                () -> this.watchKey(key, option, consumer),
-                this.reWatchDelayMs, TimeUnit.MILLISECONDS);
+                                 Consumer<WatchResponse> consumer) {
+        this.reWatchExecutor.schedule(() -> this.reWatch(key, option, consumer),
+                                      this.reWatchDelayMs, TimeUnit.MILLISECONDS);
+    }
+
+    /**
+     * Re-establish a watch dropped by a terminal close. If the re-subscribe
+     * itself fails (e.g. the endpoint is still unreachable), it is retried with
+     * the same backoff instead of giving up, otherwise a single failed attempt
+     * would lose the listener permanently.
+     */
+    private void reWatch(ByteSequence key, WatchOption option,
+                         Consumer<WatchResponse> consumer) {
+        try {
+            LOG.info("Re-establishing etcd meta watch for key '{}'",
+                     key.toString(Charset.defaultCharset()));
+            this.watchKey(key, option, consumer);
+        } catch (Exception e) {
+            LOG.warn("Failed to re-establish etcd meta watch for key '{}', " +
+                     "retrying in {} ms",
+                     key.toString(Charset.defaultCharset()),
+                     this.reWatchDelayMs, e);
+            this.scheduleReWatch(key, option, consumer);
+        }
     }
 }

--- a/hugegraph-server/hugegraph-test/src/main/java/org/apache/hugegraph/meta/EtcdMetaDriverTest.java
+++ b/hugegraph-server/hugegraph-test/src/main/java/org/apache/hugegraph/meta/EtcdMetaDriverTest.java
@@ -17,6 +17,7 @@
 
 package org.apache.hugegraph.meta;
 
+import java.nio.charset.Charset;
 import java.util.concurrent.atomic.AtomicReference;
 
 import org.apache.hugegraph.testutil.Assert;
@@ -31,35 +32,22 @@ import io.etcd.jetcd.options.WatchOption;
 import io.etcd.jetcd.watch.WatchResponse;
 
 /**
- * Unit tests for {@link EtcdMetaDriver}'s self-healing watch: a dropped watch
- * (onError / onCompleted) must be re-subscribed so the listener is not silently
- * lost after a transport reconnect (issue #3036). Uses a mock jetcd
- * {@link Client} via the package-private test constructor; no live etcd needed.
+ * Unit tests for {@link EtcdMetaDriver}'s watch recovery (issue #3036). jetcd
+ * retries recoverable errors itself, so the driver must re-subscribe only on the
+ * terminal {@code onCompleted} close, not on every {@code onError}. A mock jetcd
+ * {@link Client} drives these paths through the package-private test
+ * constructor; no live etcd is needed.
  */
 public class EtcdMetaDriverTest {
 
     @Test
-    public void testListenReSubscribesOnError() {
+    public void testListenReWatchesOnCompleted() {
         Watch watch = Mockito.mock(Watch.class);
         EtcdMetaDriver driver = newDriver(watch);
 
         driver.listen("k", response -> { });
-        captureListener(watch).onError(new RuntimeException("watch dropped"));
-
-        // The watch terminated, so the driver must re-subscribe: a second
-        // watch() call lands once the (0ms) backoff task runs.
-        Mockito.verify(watch, Mockito.timeout(2000).times(2))
-               .watch(Mockito.any(ByteSequence.class),
-                      Mockito.any(WatchOption.class),
-                      Mockito.any(Watch.Listener.class));
-    }
-
-    @Test
-    public void testListenReSubscribesOnCompleted() {
-        Watch watch = Mockito.mock(Watch.class);
-        EtcdMetaDriver driver = newDriver(watch);
-
-        driver.listen("k", response -> { });
+        // onCompleted is jetcd's terminal-close signal: the watcher is gone, so
+        // the driver must re-subscribe (a second watch() call).
         captureListener(watch).onCompleted();
 
         Mockito.verify(watch, Mockito.timeout(2000).times(2))
@@ -69,14 +57,63 @@ public class EtcdMetaDriverTest {
     }
 
     @Test
-    public void testListenPrefixReSubscribesOnError() {
+    public void testListenDoesNotReWatchOnError() {
+        Watch watch = Mockito.mock(Watch.class);
+        EtcdMetaDriver driver = newDriver(watch);
+
+        driver.listen("k", response -> { });
+        // jetcd already reschedules the same watcher for recoverable errors;
+        // re-subscribing here would create a duplicate watch. Assert it does not.
+        captureListener(watch).onError(new RuntimeException("recoverable"));
+
+        Mockito.verify(watch, Mockito.after(500).times(1))
+               .watch(Mockito.any(ByteSequence.class),
+                      Mockito.any(WatchOption.class),
+                      Mockito.any(Watch.Listener.class));
+    }
+
+    @Test
+    public void testListenPrefixReWatchPreservesKeyAndPrefix() {
         Watch watch = Mockito.mock(Watch.class);
         EtcdMetaDriver driver = newDriver(watch);
 
         driver.listenPrefix("prefix", response -> { });
-        captureListener(watch).onError(new RuntimeException("watch dropped"));
+        captureListener(watch).onCompleted();
 
+        ArgumentCaptor<ByteSequence> keyCaptor =
+                ArgumentCaptor.forClass(ByteSequence.class);
+        ArgumentCaptor<WatchOption> optionCaptor =
+                ArgumentCaptor.forClass(WatchOption.class);
         Mockito.verify(watch, Mockito.timeout(2000).times(2))
+               .watch(keyCaptor.capture(), optionCaptor.capture(),
+                      Mockito.any(Watch.Listener.class));
+
+        // The re-created watch must still target "prefix" with prefix semantics,
+        // not silently downgrade to an exact-key watch.
+        ByteSequence reWatchKey = keyCaptor.getAllValues().get(1);
+        WatchOption reWatchOption = optionCaptor.getAllValues().get(1);
+        Assert.assertEquals("prefix",
+                            reWatchKey.toString(Charset.defaultCharset()));
+        Assert.assertTrue(reWatchOption.isPrefix());
+    }
+
+    @Test
+    public void testReWatchRetriesWhenFirstAttemptThrows() {
+        Watch watch = Mockito.mock(Watch.class);
+        // Initial watch() succeeds, the first re-watch throws, the retry succeeds.
+        // A single failed re-watch must not abandon recovery permanently.
+        Mockito.when(watch.watch(Mockito.any(ByteSequence.class),
+                                 Mockito.any(WatchOption.class),
+                                 Mockito.any(Watch.Listener.class)))
+               .thenReturn(null)
+               .thenThrow(new RuntimeException("etcd still unreachable"))
+               .thenReturn(null);
+        EtcdMetaDriver driver = newDriver(watch);
+
+        driver.listen("k", response -> { });
+        captureListener(watch).onCompleted();
+
+        Mockito.verify(watch, Mockito.timeout(2000).times(3))
                .watch(Mockito.any(ByteSequence.class),
                       Mockito.any(WatchOption.class),
                       Mockito.any(Watch.Listener.class));

--- a/hugegraph-server/hugegraph-test/src/main/java/org/apache/hugegraph/meta/EtcdMetaDriverTest.java
+++ b/hugegraph-server/hugegraph-test/src/main/java/org/apache/hugegraph/meta/EtcdMetaDriverTest.java
@@ -1,0 +1,115 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with this
+ * work for additional information regarding copyright ownership. The ASF
+ * licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.hugegraph.meta;
+
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.apache.hugegraph.testutil.Assert;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
+
+import io.etcd.jetcd.ByteSequence;
+import io.etcd.jetcd.Client;
+import io.etcd.jetcd.Watch;
+import io.etcd.jetcd.options.WatchOption;
+import io.etcd.jetcd.watch.WatchResponse;
+
+/**
+ * Unit tests for {@link EtcdMetaDriver}'s self-healing watch: a dropped watch
+ * (onError / onCompleted) must be re-subscribed so the listener is not silently
+ * lost after a transport reconnect (issue #3036). Uses a mock jetcd
+ * {@link Client} via the package-private test constructor; no live etcd needed.
+ */
+public class EtcdMetaDriverTest {
+
+    @Test
+    public void testListenReSubscribesOnError() {
+        Watch watch = Mockito.mock(Watch.class);
+        EtcdMetaDriver driver = newDriver(watch);
+
+        driver.listen("k", response -> { });
+        captureListener(watch).onError(new RuntimeException("watch dropped"));
+
+        // The watch terminated, so the driver must re-subscribe: a second
+        // watch() call lands once the (0ms) backoff task runs.
+        Mockito.verify(watch, Mockito.timeout(2000).times(2))
+               .watch(Mockito.any(ByteSequence.class),
+                      Mockito.any(WatchOption.class),
+                      Mockito.any(Watch.Listener.class));
+    }
+
+    @Test
+    public void testListenReSubscribesOnCompleted() {
+        Watch watch = Mockito.mock(Watch.class);
+        EtcdMetaDriver driver = newDriver(watch);
+
+        driver.listen("k", response -> { });
+        captureListener(watch).onCompleted();
+
+        Mockito.verify(watch, Mockito.timeout(2000).times(2))
+               .watch(Mockito.any(ByteSequence.class),
+                      Mockito.any(WatchOption.class),
+                      Mockito.any(Watch.Listener.class));
+    }
+
+    @Test
+    public void testListenPrefixReSubscribesOnError() {
+        Watch watch = Mockito.mock(Watch.class);
+        EtcdMetaDriver driver = newDriver(watch);
+
+        driver.listenPrefix("prefix", response -> { });
+        captureListener(watch).onError(new RuntimeException("watch dropped"));
+
+        Mockito.verify(watch, Mockito.timeout(2000).times(2))
+               .watch(Mockito.any(ByteSequence.class),
+                      Mockito.any(WatchOption.class),
+                      Mockito.any(Watch.Listener.class));
+    }
+
+    @Test
+    public void testListenDeliversEventsToConsumer() {
+        Watch watch = Mockito.mock(Watch.class);
+        AtomicReference<WatchResponse> received = new AtomicReference<>();
+        EtcdMetaDriver driver = newDriver(watch);
+
+        driver.listen("k", received::set);
+        WatchResponse response = Mockito.mock(WatchResponse.class);
+        captureListener(watch).onNext(response);
+
+        Assert.assertSame(response, received.get());
+    }
+
+    private static EtcdMetaDriver newDriver(Watch watch) {
+        Client client = Mockito.mock(Client.class);
+        Mockito.when(client.getWatchClient()).thenReturn(watch);
+        EtcdMetaDriver driver = new EtcdMetaDriver(client);
+        // No backoff in tests so the re-subscribe runs promptly.
+        driver.reWatchDelayMs = 0L;
+        return driver;
+    }
+
+    private static Watch.Listener captureListener(Watch watch) {
+        ArgumentCaptor<Watch.Listener> captor =
+                ArgumentCaptor.forClass(Watch.Listener.class);
+        Mockito.verify(watch).watch(Mockito.any(ByteSequence.class),
+                                    Mockito.any(WatchOption.class),
+                                    captor.capture());
+        return captor.getValue();
+    }
+}

--- a/hugegraph-server/hugegraph-test/src/main/java/org/apache/hugegraph/unit/UnitTestSuite.java
+++ b/hugegraph-server/hugegraph-test/src/main/java/org/apache/hugegraph/unit/UnitTestSuite.java
@@ -18,6 +18,7 @@
 package org.apache.hugegraph.unit;
 
 import org.apache.hugegraph.core.RoleElectionStateMachineTest;
+import org.apache.hugegraph.meta.EtcdMetaDriverTest;
 import org.apache.hugegraph.meta.MetaManagerSchemaCacheClearEventTest;
 import org.apache.hugegraph.traversal.optimize.TraversalUtilOptimizeTest;
 import org.apache.hugegraph.unit.api.filter.LoadDetectFilterTest;
@@ -99,6 +100,7 @@ import org.junit.runners.Suite;
         CacheTest.LevelCacheTest.class,
         CachedSchemaTransactionTest.class,
         MetaManagerSchemaCacheClearEventTest.class,
+        EtcdMetaDriverTest.class,
         CachedGraphTransactionTest.class,
         CacheManagerTest.class,
         RamTableTest.class,


### PR DESCRIPTION

## Purpose of the PR

- close #3036

`CachedSchemaTransactionV2` registers a JVM-global watch on the meta store so that a schema change on one node clears the schema cache on the other nodes. That watch goes through `EtcdMetaDriver.listen` / `listenPrefix`, which handed jetcd the bare `Consumer<WatchResponse>` overload. That overload discards `onError` and `onCompleted`, so when jetcd ends a watch (e.g. after a transport reconnect tears down the gRPC stream) the listener stopped receiving events with no log line and no exception. The node kept serving stale schema and nothing reported it. `PdMetaDriver` does not have this problem because its `KvClient` already re-subscribes on error.

## Main Changes

- **`EtcdMetaDriver.listen` / `listenPrefix`** now register a `Watch.Listener` instead of the bare `Consumer` overload, surfacing both `onError` and `onCompleted`.
  - `onError` **only logs** at WARN level. jetcd 0.5.9 (`WatchImpl.WatcherImpl.handleError`) already retries recoverable errors internally by notifying `onError` and rescheduling `resume()` on the same watcher; re-subscribing from `onError` would therefore open a duplicate watch on every transient reconnect.
  - `onCompleted` **schedules a re-subscribe** after a 1 s backoff on a daemon thread. `onCompleted` is jetcd's terminal-close signal: the old watcher is already removed and will not recover, so a replacement watch is safe and necessary. This mirrors the self-heal `PdMetaDriver` already gets from `KvClient`.
  - If the re-subscribe itself throws (e.g. the endpoint is still unreachable), it is retried with the same backoff instead of abandoning recovery after a single failure.
- **Removed `CachedSchemaTransactionV2.resetMetaListenerForReconnect()`**. It was a manual stopgap added in #3011 with no callers, and it never shipped in a tagged release. Now that the driver self-heals, the JVM-global register-once flag is correct to stay set; the manual reset has nothing left to do. The lifecycle comment on `metaEventListenerRegistered` is updated to describe the self-heal behaviour.
- The `MetaDriver` interface is unchanged, so neither implementor needs edits beyond `EtcdMetaDriver`.

Known limitation: the re-subscribe opens a fresh watch without a stored revision, so any cache-clear events emitted during the short reconnect window are not replayed. This is the same behaviour as `PdMetaDriver` / `KvClient`. The change removes the permanent silent failure; it does not add gap replay.

## Verifying these changes

- [x] Need tests and can be verified as follows:
  - New `EtcdMetaDriverTest` (JUnit + Mockito) mocks the jetcd `Client`/`Watch` via the package-private test constructor (no live etcd needed) and asserts:
    1. `onCompleted` triggers a re-subscribe (a second `watch(...)` call).
    2. `onError` does **not** trigger a re-subscribe (only logs), so no duplicate watch is opened.
    3. The re-created prefix watch preserves the original key and `isPrefix` `WatchOption`.
    4. `onNext` still delivers events to the consumer.
    5. A re-watch that throws once is retried and eventually succeeds (no permanent loss).
  - Local run: `EtcdMetaDriverTest` 5/5, `CachedSchemaTransactionTest` 18/18, `MetaManagerSchemaCacheClearEventTest` 6/6 after the stopgap removal.
  - Red-green: commenting out the re-subscribe in `onCompleted` makes the recovery tests fail; restoring it makes them pass.

## Does this PR potentially affect the following parts?

- [ ] Dependencies
- [ ] Modify configurations
- [ ] The public API
- [ ] Other affects (typed here)
- [x] Nope

## Documentation Status

- [ ] `Doc - TODO`
- [ ] `Doc - Done`
- [x] `Doc - No Need`