### PR TITLE
fix(api): update GroupAPI @Path to include graphspace for consistency

### DIFF
--- a/hugegraph-server/hugegraph-api/src/main/java/org/apache/hugegraph/api/auth/GroupAPI.java
+++ b/hugegraph-server/hugegraph-api/src/main/java/org/apache/hugegraph/api/auth/GroupAPI.java
@@ -51,7 +51,7 @@ import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.QueryParam;
 import jakarta.ws.rs.core.Context;
 
-@Path("/auth/groups")
+@Path("graphspaces/{graphspace}/auth/groups")
 @Singleton
 @Tag(name = "GroupAPI")
 public class GroupAPI extends API {


### PR DESCRIPTION
## Summary
This PR fixes issue #3019 by aligning GroupAPI with all other auth API classes.

## Problem
All other auth API classes (UserAPI, TargetAPI, BelongAPI, AccessAPI, ProjectAPI, ManagerAPI) use the pattern:
```java
@Path("graphspaces/{graphspace}/auth/...")
```

But GroupAPI was the outlier:
```java
@Path("/auth/groups")   // WRONG — absolute path, bypasses graphspace
```

This inconsistency causes:
1. The AuthenticationFilter cannot extract the graph space for permission checks
2. Documentation confusion — docs say POST to `/graphspaces/DEFAULT/auth/groups` returns 404

## Fix
Changed GroupAPI.java line 54:
```diff
-@Path("/auth/groups")
+@Path("graphspaces/{graphspace}/auth/groups")
```

## Verification
- All 6 other auth APIs confirmed using `graphspaces/{graphspace}/auth/...` pattern
- One-line change, no other modifications needed
- Git diff confirmed minimal and targeted

Fixes #3019