### PR TITLE
chore(commons): remove redundant version property

### DIFF
--- a/hugegraph-commons/hugegraph-common/src/main/resources/version.properties
+++ b/hugegraph-commons/hugegraph-common/src/main/resources/version.properties
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 # When updating the version, Version can be read from the pom file. 
-# When hugegraph-common is updated, hugegraph-commons.version in the pom file needs to be updated, 
+# hugegraph-common follows the project version defined by ${revision} in the root pom.xml,
 # and VersionInBash needs to be updated in this file.
 Version=${revision}
 ApiVersion=0.71

--- a/hugegraph-pd/hg-pd-service/pom.xml
+++ b/hugegraph-pd/hg-pd-service/pom.xml
@@ -142,7 +142,7 @@
         <dependency>
             <groupId>org.apache.hugegraph</groupId>
             <artifactId>hugegraph-common</artifactId>
-            <version>${hugegraph-commons.version}</version>
+            <version>${project.version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.logging.log4j</groupId>

--- a/hugegraph-server/pom.xml
+++ b/hugegraph-server/pom.xml
@@ -80,12 +80,12 @@
             <dependency>
                 <groupId>org.apache.hugegraph</groupId>
                 <artifactId>hugegraph-rpc</artifactId>
-                <version>${hugegraph-commons.version}</version>
+                <version>${project.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.hugegraph</groupId>
                 <artifactId>hugegraph-common</artifactId>
-                <version>${hugegraph-commons.version}</version>
+                <version>${project.version}</version>
             </dependency>
 
             <!-- logging -->

--- a/hugegraph-store/hg-store-rocksdb/pom.xml
+++ b/hugegraph-store/hg-store-rocksdb/pom.xml
@@ -34,7 +34,7 @@
         <dependency>
             <groupId>org.apache.hugegraph</groupId>
             <artifactId>hugegraph-common</artifactId>
-            <version>${hugegraph-commons.version}</version>
+            <version>${project.version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.glassfish.jersey.inject</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -88,7 +88,6 @@
     <properties>
         <fabric8.version>5.6.0</fabric8.version>
         <revision>1.7.0</revision>
-        <hugegraph-commons.version>1.7.0</hugegraph-commons.version>
         <lombok.version>1.18.30</lombok.version>
         <release.name>hugegraph</release.name>
         <maven.compiler.source>11</maven.compiler.source>


### PR DESCRIPTION
## Purpose of the PR

- close #3088 

The `hugegraph-commons` module is already versioned by `${revision}`.
At the same time, the root POM defines a separate property `hugegraph-commons.version` that tracks the same value.

This creates a duplicated version source for the same module family.

## Main Changes

- Remove `hugegraph-commons.version` from root `pom.xml`
- Replace `${hugegraph-commons.version}` with `${project.version}` in:
  - `hugegraph-server/pom.xml`
  - `hugegraph-store/hg-store-rocksdb/pom.xml`
  - `hugegraph-pd/hg-pd-service/pom.xml`
- Keep version management consistent with existing project-level versioning

## Verifying these changes

- [x] Trivial rework / code cleanup without any test coverage. (No Need)
- [ ] Already covered by existing tests, such as *(please modify tests here)*.
- [ ] Need tests and can be verified as follows:
    - N/A

## Does this PR potentially affect the following parts?

- [ ]  Dependencies ([add/update license](https://hugegraph.apache.org/docs/contribution-guidelines/contribute/#321-check-licenses) info & [regenerate_known_dependencies.sh](../install-dist/scripts/dependency/regenerate_known_dependencies.sh))
- [ ]  Modify configurations
- [ ]  The public API
- [ ]  Other affects (typed here)
- [x]  Nope

## Documentation Status

- [ ]  `Doc - TODO`
- [ ]  `Doc - Done`
- [x]  `Doc - No Need`