### PR TITLE
perf(docker): build Java artifacts natively

### DIFF
--- a/hugegraph-pd/Dockerfile
+++ b/hugegraph-pd/Dockerfile
@@ -18,7 +18,7 @@
 
 # Dockerfile for HugeGraph PD
 # 1st stage: build source code
-FROM maven:3.9.0-eclipse-temurin-11 AS build
+FROM --platform=$BUILDPLATFORM maven:3.9.0-eclipse-temurin-11 AS build
 
 WORKDIR /pkg
 

--- a/hugegraph-server/Dockerfile
+++ b/hugegraph-server/Dockerfile
@@ -18,7 +18,7 @@
 
 # Dockerfile for HugeGraph Server
 # 1st stage: build source code
-FROM maven:3.9.0-eclipse-temurin-11 AS build
+FROM --platform=$BUILDPLATFORM maven:3.9.0-eclipse-temurin-11 AS build
 
 WORKDIR /pkg
 

--- a/hugegraph-server/Dockerfile-hstore
+++ b/hugegraph-server/Dockerfile-hstore
@@ -18,7 +18,7 @@
 
 # Dockerfile for HugeGraph Server (hstore backend)
 # 1st stage: build source code
-FROM maven:3.9.0-eclipse-temurin-11 AS build
+FROM --platform=$BUILDPLATFORM maven:3.9.0-eclipse-temurin-11 AS build
 
 WORKDIR /pkg
 

--- a/hugegraph-store/Dockerfile
+++ b/hugegraph-store/Dockerfile
@@ -18,7 +18,7 @@
 
 # Dockerfile for HugeGraph Store
 # 1st stage: build source code
-FROM maven:3.9.0-eclipse-temurin-11 AS build
+FROM --platform=$BUILDPLATFORM maven:3.9.0-eclipse-temurin-11 AS build
 
 WORKDIR /pkg
 


### PR DESCRIPTION
## Summary

- build PD, Store, standalone Server, and HStore Java artifacts on the native BuildKit platform
- keep runtime stages target-platform specific
- avoid running the full Maven reactor under QEMU for arm64 images

## Why

Recent arm64 publish jobs spend roughly 40–90 minutes in QEMU while equivalent amd64 jobs complete in under 1–8 minutes. These Docker build stages produce Java distributions that can be shared by the target-specific runtime stages.

Companion workflow and durable registry cache changes are included in hugegraph/actions#21.

## Verification

- exact JDK 11 Maven package command passed all 43 modules in 2:05
- RocksDB JNI, Jansi, JFFI, Zstd, LZ4, Snappy, and Server tcnative packages were inspected for Linux arm64 support
- protoc/grpc platform tools are build-time Java generators only
- git diff --check passed
- independent cross-repository review passed

## Remaining CI validation

The local Docker daemon was unavailable. The publish workflow should build and start the arm64 PD, Store, standalone Server, and HStore images, verify their health endpoints, and check for native-library load failures. The existing PD/Store tcnative 2.0.25 dependency is x86_64-only regardless of builder architecture, so that pre-existing runtime behavior remains part of the ARM smoke scope.