### PR TITLE
feat: support secure Hubble monitoring targets

### DIFF
--- a/hugegraph-pd/hg-pd-core/src/main/java/org/apache/hugegraph/pd/config/PDConfig.java
+++ b/hugegraph-pd/hg-pd-core/src/main/java/org/apache/hugegraph/pd/config/PDConfig.java
@@ -31,6 +31,7 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.stereotype.Component;
 
 import lombok.Data;
+import lombok.ToString;
 
 /**
  * PD profile
@@ -69,6 +70,7 @@ public class PDConfig {
     private ThreadPoolGrpc threadPoolGrpc;
 
     @Value("${auth.secret-key: 'FXQXbJtbCLxODc6tGci732pkH1cyf8Qg'}")
+    @ToString.Exclude
     private String secretKey;
 
     @Autowired

--- a/hugegraph-pd/hg-pd-service/src/main/java/org/apache/hugegraph/pd/rest/StoreAPI.java
+++ b/hugegraph-pd/hg-pd-service/src/main/java/org/apache/hugegraph/pd/rest/StoreAPI.java
@@ -33,6 +33,7 @@ import org.apache.hugegraph.pd.model.StoreRestRequest;
 import org.apache.hugegraph.pd.model.TimeRangeRequest;
 import org.apache.hugegraph.pd.service.PDRestService;
 import org.apache.hugegraph.pd.util.DateUtil;
+import org.apache.hugegraph.pd.util.StoreRestAddressUtil;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -278,6 +279,7 @@ public class StoreAPI extends API {
         // store statistics
         String storeId;
         String address;
+        String restAddress;
         String raftAddress;
         String version;
         String state;
@@ -302,6 +304,7 @@ public class StoreAPI extends API {
             if (store != null) {
                 storeId = String.valueOf(store.getId());
                 address = store.getAddress();
+                restAddress = StoreRestAddressUtil.getRestAddress(store);
                 raftAddress = store.getRaftAddress();
                 state = String.valueOf(store.getState());
                 version = store.getVersion();

--- a/hugegraph-pd/hg-pd-service/src/main/java/org/apache/hugegraph/pd/service/SDConfigService.java
+++ b/hugegraph-pd/hg-pd-service/src/main/java/org/apache/hugegraph/pd/service/SDConfigService.java
@@ -22,7 +22,6 @@ import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.Set;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
@@ -33,6 +32,7 @@ import org.apache.hugegraph.pd.common.HgAssert;
 import org.apache.hugegraph.pd.common.PDException;
 import org.apache.hugegraph.pd.config.PDConfig;
 import org.apache.hugegraph.pd.grpc.Metapb;
+import org.apache.hugegraph.pd.util.StoreRestAddressUtil;
 import org.apache.hugegraph.pd.grpc.Pdpb;
 import org.apache.hugegraph.pd.grpc.discovery.NodeInfo;
 import org.apache.hugegraph.pd.grpc.discovery.NodeInfos;
@@ -215,34 +215,14 @@ public class SDConfigService {
         return res;
     }
 
-    // TODO: optimized store registry data, to add host:port of REST server.
+    // Keep the legacy gRPC fallback when no valid REST port is registered.
     private String getRestAddress(Metapb.Store store) {
         String address = store.getAddress();
         if (address == null || address.isEmpty()) {
             return null;
         }
-        try {
-            Optional<String> port = store.getLabelsList().stream().map(
-                    e -> {
-                        if ("rest.port".equals(e.getKey())) {
-                            return e.getValue();
-                        }
-                        return null;
-                    }).filter(e -> e != null).findFirst();
-
-            if (port.isPresent()) {
-                java.net.URI uri = address.contains("://")
-                                   ? java.net.URI.create(address)
-                                   : java.net.URI.create("http://" + address);
-                String host = uri.getHost() != null ? uri.getHost() : address;
-                String hostPart =
-                        host.contains(":") && !host.startsWith("[") ? "[" + host + "]" : host;
-                address = hostPart + ":" + port.get().trim();
-            }
-        } catch (Throwable t) {
-            log.error("Failed to extract the REST address of store, cause by:", t);
-        }
-        return address;
+        String restAddress = StoreRestAddressUtil.getRestAddress(store);
+        return restAddress != null ? restAddress : address;
 
     }
 

--- a/hugegraph-pd/hg-pd-service/src/main/java/org/apache/hugegraph/pd/util/StoreRestAddressUtil.java
+++ b/hugegraph-pd/hg-pd-service/src/main/java/org/apache/hugegraph/pd/util/StoreRestAddressUtil.java
@@ -1,0 +1,71 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hugegraph.pd.util;
+
+import java.net.URI;
+import java.util.Optional;
+
+import org.apache.hugegraph.pd.grpc.Metapb;
+
+public final class StoreRestAddressUtil {
+
+    private static final String REST_PORT_LABEL = "rest.port";
+
+    private StoreRestAddressUtil() {
+    }
+
+    public static String getRestAddress(Metapb.Store store) {
+        if (store == null || store.getAddress().isEmpty()) {
+            return null;
+        }
+
+        Optional<String> label = store.getLabelsList().stream()
+                                      .filter(item -> REST_PORT_LABEL.equals(
+                                              item.getKey()))
+                                      .map(Metapb.StoreLabel::getValue)
+                                      .findFirst();
+        if (!label.isPresent()) {
+            return null;
+        }
+
+        int port;
+        try {
+            port = Integer.parseInt(label.get().trim());
+        } catch (NumberFormatException ignored) {
+            return null;
+        }
+        if (port < 1 || port > 65535) {
+            return null;
+        }
+
+        try {
+            String address = store.getAddress().trim();
+            URI uri = address.contains("://") ? URI.create(address) :
+                      URI.create("http://" + address);
+            String host = uri.getHost();
+            if (host == null || host.isEmpty()) {
+                return null;
+            }
+            String hostPart = host.contains(":") && !host.startsWith("[") ?
+                              "[" + host + "]" : host;
+            return hostPart + ":" + port;
+        } catch (IllegalArgumentException ignored) {
+            return null;
+        }
+    }
+}

--- a/hugegraph-pd/hg-pd-test/src/main/java/org/apache/hugegraph/pd/core/PDConfigTest.java
+++ b/hugegraph-pd/hg-pd-test/src/main/java/org/apache/hugegraph/pd/core/PDConfigTest.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hugegraph.pd.core;
+
+import org.apache.hugegraph.pd.config.PDConfig;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class PDConfigTest {
+
+    @Test
+    public void testToStringDoesNotExposeSecretKey() {
+        PDConfig config = new PDConfig();
+        config.setClusterId(123L);
+        config.setDataPath("pd-test-data");
+        config.setInitialStoreList("");
+        config.setSecretKey("secret-value-that-must-not-appear");
+
+        String text = config.toString();
+
+        Assert.assertEquals("secret-value-that-must-not-appear",
+                            config.getSecretKey());
+        Assert.assertFalse(text.contains("secret-value-that-must-not-appear"));
+        Assert.assertFalse(text.contains("secretKey"));
+        Assert.assertTrue(text.contains("clusterId=123"));
+        Assert.assertTrue(text.contains("dataPath=pd-test-data"));
+    }
+}

--- a/hugegraph-pd/hg-pd-test/src/main/java/org/apache/hugegraph/pd/core/PDCoreSuiteTest.java
+++ b/hugegraph-pd/hg-pd-test/src/main/java/org/apache/hugegraph/pd/core/PDCoreSuiteTest.java
@@ -31,6 +31,7 @@ import lombok.extern.slf4j.Slf4j;
 @Suite.SuiteClasses({
         MetadataKeyHelperTest.class,
         HgKVStoreImplTest.class,
+        PDConfigTest.class,
         ConfigServiceTest.class,
         IdServiceTest.class,
         KvServiceTest.class,

--- a/hugegraph-pd/hg-pd-test/src/main/java/org/apache/hugegraph/pd/rest/PDRestSuiteTest.java
+++ b/hugegraph-pd/hg-pd-test/src/main/java/org/apache/hugegraph/pd/rest/PDRestSuiteTest.java
@@ -17,6 +17,7 @@
 
 package org.apache.hugegraph.pd.rest;
 
+import org.apache.hugegraph.pd.util.StoreRestAddressUtilTest;
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
 
@@ -25,6 +26,8 @@ import lombok.extern.slf4j.Slf4j;
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
         RestApiTest.class,
+        StoreAPIStoreStatisticsTest.class,
+        StoreRestAddressUtilTest.class,
 })
 @Slf4j
 public class PDRestSuiteTest {

--- a/hugegraph-pd/hg-pd-test/src/main/java/org/apache/hugegraph/pd/rest/StoreAPIStoreStatisticsTest.java
+++ b/hugegraph-pd/hg-pd-test/src/main/java/org/apache/hugegraph/pd/rest/StoreAPIStoreStatisticsTest.java
@@ -1,0 +1,68 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hugegraph.pd.rest;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import org.apache.hugegraph.pd.common.PDException;
+import org.apache.hugegraph.pd.grpc.Metapb;
+import org.apache.hugegraph.pd.service.PDRestService;
+import org.junit.Test;
+
+public class StoreAPIStoreStatisticsTest {
+
+    @Test
+    public void testExposeStoreRestAddress() throws PDException {
+        StoreAPI api = new StoreAPI();
+        api.pdRestService = mock(PDRestService.class);
+        Metapb.Store store = store("127.0.0.1:8500", "8520");
+        when(api.pdRestService.getStore(store.getId())).thenReturn(store);
+
+        StoreAPI.StoreStatistics statistics = api.new StoreStatistics(store);
+
+        assertEquals("127.0.0.1:8500", statistics.getAddress());
+        assertEquals("127.0.0.1:8520", statistics.getRestAddress());
+    }
+
+    @Test
+    public void testKeepRestAddressNullWithoutPortLabel() throws PDException {
+        StoreAPI api = new StoreAPI();
+        api.pdRestService = mock(PDRestService.class);
+        Metapb.Store store = store("127.0.0.1:8500", null);
+        when(api.pdRestService.getStore(store.getId())).thenReturn(store);
+
+        StoreAPI.StoreStatistics statistics = api.new StoreStatistics(store);
+
+        assertNull(statistics.getRestAddress());
+    }
+
+    private static Metapb.Store store(String address, String restPort) {
+        Metapb.Store.Builder builder = Metapb.Store.newBuilder()
+                                                   .setId(1L)
+                                                   .setAddress(address);
+        if (restPort != null) {
+            builder.addLabels(Metapb.StoreLabel.newBuilder()
+                                               .setKey("rest.port")
+                                               .setValue(restPort));
+        }
+        return builder.build();
+    }
+}

--- a/hugegraph-pd/hg-pd-test/src/main/java/org/apache/hugegraph/pd/util/StoreRestAddressUtilTest.java
+++ b/hugegraph-pd/hg-pd-test/src/main/java/org/apache/hugegraph/pd/util/StoreRestAddressUtilTest.java
@@ -1,0 +1,81 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hugegraph.pd.util;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+import org.apache.hugegraph.pd.grpc.Metapb;
+import org.junit.Test;
+
+public class StoreRestAddressUtilTest {
+
+    @Test
+    public void testBuildIPv4RestAddress() {
+        Metapb.Store store = store("127.0.0.1:8500", "8520");
+
+        assertEquals("127.0.0.1:8520",
+                     StoreRestAddressUtil.getRestAddress(store));
+    }
+
+    @Test
+    public void testBuildIPv6RestAddress() {
+        Metapb.Store store = store("[2001:db8::1]:8500", "8520");
+
+        assertEquals("[2001:db8::1]:8520",
+                     StoreRestAddressUtil.getRestAddress(store));
+    }
+
+    @Test
+    public void testBuildRestAddressFromUri() {
+        Metapb.Store store = store("http://store.example:8500", "8520");
+
+        assertEquals("store.example:8520",
+                     StoreRestAddressUtil.getRestAddress(store));
+    }
+
+    @Test
+    public void testRejectMissingOrInvalidRestPort() {
+        assertNull(StoreRestAddressUtil.getRestAddress(
+                store("127.0.0.1:8500", null)));
+        assertNull(StoreRestAddressUtil.getRestAddress(
+                store("127.0.0.1:8500", "0")));
+        assertNull(StoreRestAddressUtil.getRestAddress(
+                store("127.0.0.1:8500", "65536")));
+        assertNull(StoreRestAddressUtil.getRestAddress(
+                store("127.0.0.1:8500", "8520/path")));
+    }
+
+    @Test
+    public void testRejectMissingOrMalformedStoreAddress() {
+        assertNull(StoreRestAddressUtil.getRestAddress(store("", "8520")));
+        assertNull(StoreRestAddressUtil.getRestAddress(
+                store("2001:db8::1:8500", "8520")));
+    }
+
+    private static Metapb.Store store(String address, String restPort) {
+        Metapb.Store.Builder builder = Metapb.Store.newBuilder()
+                                                   .setAddress(address);
+        if (restPort != null) {
+            builder.addLabels(Metapb.StoreLabel.newBuilder()
+                                               .setKey("rest.port")
+                                               .setValue(restPort));
+        }
+        return builder.build();
+    }
+}

--- a/hugegraph-server/hugegraph-api/src/main/java/org/apache/hugegraph/core/GraphManager.java
+++ b/hugegraph-server/hugegraph-api/src/main/java/org/apache/hugegraph/core/GraphManager.java
@@ -1864,6 +1864,17 @@ public final class GraphManager {
         if (StringUtils.isNotEmpty((String) configs.get(CoreOptions.ALIAS_NAME.name()))) {
             return attachedConfigs;
         }
+        if (this.config.containsKey(CoreOptions.SCHEMA_CACHE_CAPACITY.name())) {
+            attachedConfigs.putIfAbsent(
+                    CoreOptions.SCHEMA_CACHE_CAPACITY.name(),
+                    this.config.get(CoreOptions.SCHEMA_CACHE_CAPACITY));
+        }
+        if (this.config.containsKey(
+                CoreOptions.SERIALIZER_BUFFER_MAX_CAPACITY.name())) {
+            attachedConfigs.putIfAbsent(
+                    CoreOptions.SERIALIZER_BUFFER_MAX_CAPACITY.name(),
+                    this.config.get(CoreOptions.SERIALIZER_BUFFER_MAX_CAPACITY));
+        }
         Object value = this.config.get(CoreOptions.VERTEX_CACHE_EXPIRE);
         if (Objects.nonNull(value)) {
             attachedConfigs.putIfAbsent(CoreOptions.VERTEX_CACHE_EXPIRE.name(),

--- a/hugegraph-server/hugegraph-test/src/main/java/org/apache/hugegraph/unit/UnitTestSuite.java
+++ b/hugegraph-server/hugegraph-test/src/main/java/org/apache/hugegraph/unit/UnitTestSuite.java
@@ -40,6 +40,7 @@ import org.apache.hugegraph.unit.core.ConditionTest;
 import org.apache.hugegraph.unit.core.DataTypeTest;
 import org.apache.hugegraph.unit.core.DirectionsTest;
 import org.apache.hugegraph.unit.core.ExceptionTest;
+import org.apache.hugegraph.unit.core.GraphManagerConfigTest;
 import org.apache.hugegraph.unit.core.LocksTableTest;
 import org.apache.hugegraph.unit.core.PageStateTest;
 import org.apache.hugegraph.unit.core.QueryTest;
@@ -133,6 +134,7 @@ import org.junit.runners.Suite;
         SecurityManagerTest.class,
         RolePermissionTest.class,
         ExceptionTest.class,
+        GraphManagerConfigTest.class,
         BackendStoreInfoTest.class,
         TraversalUtilTest.class,
         TraversalUtilOptimizeTest.class,

--- a/hugegraph-server/hugegraph-test/src/main/java/org/apache/hugegraph/unit/core/GraphManagerConfigTest.java
+++ b/hugegraph-server/hugegraph-test/src/main/java/org/apache/hugegraph/unit/core/GraphManagerConfigTest.java
@@ -1,0 +1,154 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hugegraph.unit.core;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.apache.commons.configuration2.PropertiesConfiguration;
+import org.apache.hugegraph.config.CoreOptions;
+import org.apache.hugegraph.config.HugeConfig;
+import org.apache.hugegraph.config.ServerOptions;
+import org.apache.hugegraph.core.GraphManager;
+import org.apache.hugegraph.event.EventHub;
+import org.apache.hugegraph.testutil.Assert;
+import org.apache.hugegraph.testutil.Whitebox;
+import org.junit.Test;
+
+public class GraphManagerConfigTest {
+
+    @Test
+    public void testAttachExplicitLocalResourceLimits() {
+        PropertiesConfiguration properties = new PropertiesConfiguration();
+        properties.setProperty(CoreOptions.SCHEMA_CACHE_CAPACITY.name(), 1000L);
+        properties.setProperty(
+                CoreOptions.SERIALIZER_BUFFER_MAX_CAPACITY.name(), 8388608);
+        GraphManager manager = newManager(properties);
+
+        try {
+            Map<String, Object> attached = attach(manager, new HashMap<>());
+
+            Assert.assertEquals(1000L, attached.get(
+                    CoreOptions.SCHEMA_CACHE_CAPACITY.name()));
+            Assert.assertEquals(8388608, attached.get(
+                    CoreOptions.SERIALIZER_BUFFER_MAX_CAPACITY.name()));
+        } finally {
+            manager.close();
+        }
+    }
+
+    @Test
+    public void testKeepIncomingResourceLimits() {
+        PropertiesConfiguration properties = new PropertiesConfiguration();
+        properties.setProperty(CoreOptions.SCHEMA_CACHE_CAPACITY.name(), 1000L);
+        properties.setProperty(
+                CoreOptions.SERIALIZER_BUFFER_MAX_CAPACITY.name(), 8388608);
+        GraphManager manager = newManager(properties);
+        Map<String, Object> configs = new HashMap<>();
+        configs.put(CoreOptions.SCHEMA_CACHE_CAPACITY.name(), 2000L);
+        configs.put(CoreOptions.SERIALIZER_BUFFER_MAX_CAPACITY.name(),
+                    16777216);
+
+        try {
+            Map<String, Object> attached = attach(manager, configs);
+
+            Assert.assertEquals(2000L, attached.get(
+                    CoreOptions.SCHEMA_CACHE_CAPACITY.name()));
+            Assert.assertEquals(16777216, attached.get(
+                    CoreOptions.SERIALIZER_BUFFER_MAX_CAPACITY.name()));
+        } finally {
+            manager.close();
+        }
+    }
+
+    @Test
+    public void testAttachDoesNotMutateSourceOrCopySensitiveOptions() {
+        PropertiesConfiguration properties = new PropertiesConfiguration();
+        properties.setProperty(CoreOptions.SCHEMA_CACHE_CAPACITY.name(), 1000L);
+        properties.setProperty(
+                CoreOptions.SERIALIZER_BUFFER_MAX_CAPACITY.name(), 8388608);
+        properties.setProperty(CoreOptions.BACKEND.name(), "memory");
+        properties.setProperty(CoreOptions.STORE.name(), "local_store");
+        properties.setProperty(ServerOptions.ADMIN_PA.name(), "local_secret");
+        GraphManager manager = newManager(properties);
+        Map<String, Object> configs = new HashMap<>();
+        configs.put("marker", "source");
+        Map<String, Object> source = new HashMap<>(configs);
+
+        try {
+            Map<String, Object> attached = attach(manager, configs);
+
+            Assert.assertEquals(source, configs);
+            Assert.assertEquals("source", attached.get("marker"));
+            Assert.assertFalse(attached.containsKey(CoreOptions.BACKEND.name()));
+            Assert.assertFalse(attached.containsKey(CoreOptions.STORE.name()));
+            Assert.assertFalse(attached.containsKey(ServerOptions.ADMIN_PA.name()));
+        } finally {
+            manager.close();
+        }
+    }
+
+    @Test
+    public void testDoNotAttachImplicitLocalDefaults() {
+        GraphManager manager = newManager(new PropertiesConfiguration());
+
+        try {
+            Map<String, Object> attached = attach(manager, new HashMap<>());
+
+            Assert.assertFalse(attached.containsKey(
+                    CoreOptions.SCHEMA_CACHE_CAPACITY.name()));
+            Assert.assertFalse(attached.containsKey(
+                    CoreOptions.SERIALIZER_BUFFER_MAX_CAPACITY.name()));
+        } finally {
+            manager.close();
+        }
+    }
+
+    @Test
+    public void testDoNotAttachResourceLimitsToAliasGraph() {
+        PropertiesConfiguration properties = new PropertiesConfiguration();
+        properties.setProperty(CoreOptions.SCHEMA_CACHE_CAPACITY.name(), 1000L);
+        properties.setProperty(
+                CoreOptions.SERIALIZER_BUFFER_MAX_CAPACITY.name(), 8388608);
+        GraphManager manager = newManager(properties);
+        Map<String, Object> configs = new HashMap<>();
+        configs.put(CoreOptions.ALIAS_NAME.name(), "source_graph");
+        Map<String, Object> source = new HashMap<>(configs);
+
+        try {
+            Map<String, Object> attached = attach(manager, configs);
+
+            Assert.assertEquals(source, attached);
+            Assert.assertEquals(source, configs);
+        } finally {
+            manager.close();
+        }
+    }
+
+    private static GraphManager newManager(PropertiesConfiguration properties) {
+        return new GraphManager(new HugeConfig(properties),
+                                new EventHub("config-test"));
+    }
+
+    @SuppressWarnings("unchecked")
+    private static Map<String, Object> attach(GraphManager manager,
+                                               Map<String, Object> configs) {
+        return Whitebox.invoke(manager.getClass(), new Class<?>[]{Map.class},
+                               "attachLocalCacheConfig", manager, configs);
+    }
+}


### PR DESCRIPTION
## Purpose

Provide the small HugeGraph Server and PD compatibility boundaries required by Hubble native monitoring while keeping existing authentication and discovery behavior intact.

## Changes

- exclude `PDConfig.secretKey` from generated log output without changing authentication access
- add `StoreStatistics.restAddress`, derived from the registered Store host and validated `rest.port`, with IPv4/hostname/IPv6 handling
- share REST-address construction with service discovery while preserving its legacy fallback
- propagate only explicitly configured `schema.cache_capacity` and `serializer.buffer_max_capacity` into PD graph configs, preserving caller/PD values

## Verification

- PD targeted tests: 7/7; PD REST suite: 15/15
- Server unit suite: 583 tests, 0 failures, 0 errors, 1 skipped
- checkstyle, RAT, package/distribution, and `git diff --check` passed
- real 1.7.0 PD/Store/Server stack: PD formed a Leader, Store re-registered, `/v1/stores` returned the validated REST authority, Prometheus target discovery remained available, and four Server graphs started with the explicit cache limits
- independent read-only review found no unresolved high- or medium-severity issue

This is intentionally limited to compatibility, secret redaction, and bounded local test configuration support; it does not add an alerting engine or production sizing policy.