### PR TITLE
feat: Add task result chunking support (issue #3071)

### DIFF
--- a/hugegraph-server/hugegraph-core/src/main/java/org/apache/hugegraph/config/CoreOptions.java
+++ b/hugegraph-server/hugegraph-core/src/main/java/org/apache/hugegraph/config/CoreOptions.java
@@ -306,6 +306,19 @@ public class CoreOptions extends OptionHolder {
                     rangeInt(0L, Bytes.GB),
                     16 * Bytes.MB
             );
+    /**
+     * The chunk size for task results in bytes.
+     * When the compressed result exceeds this size, it will be split into
+     * multiple properties (task_result_0, task_result_1, ...).
+     * Set to 0 to disable chunking.
+     */
+    public static final ConfigOption<Integer> TASK_RESULT_CHUNK_SIZE =
+            new ConfigOption<>(
+                    "task.result_chunk_size",
+                    "The chunk size for task results in bytes. Set 0 to disable chunking.",
+                    rangeInt(0, BytesBuffer.BYTES_LEN_MAX),
+                    1048576
+            );
     public static final ConfigOption<Integer> TASK_TTL_DELETE_BATCH =
             new ConfigOption<>(
                     "task.ttl_delete_batch",

--- a/hugegraph-server/hugegraph-core/src/main/java/org/apache/hugegraph/task/HugeTask.java
+++ b/hugegraph-server/hugegraph-core/src/main/java/org/apache/hugegraph/task/HugeTask.java
@@ -575,9 +575,29 @@ public class HugeTask<V> extends FutureTask<V> {
 
         if (this.result != null) {
             byte[] bytes = StringEncoding.compress(this.result);
-            checkPropertySize(bytes.length, P.RESULT);
-            list.add(P.RESULT);
-            list.add(bytes);
+            int chunkSize = CoreOptions.instance().get(CoreOptions.TASK_RESULT_CHUNK_SIZE);
+
+            if (chunkSize > 0 && bytes.length > chunkSize) {
+                // Split into chunks
+                int numChunks = (int) Math.ceil((double) bytes.length / chunkSize);
+                for (int i = 0; i < numChunks; i++) {
+                    int start = i * chunkSize;
+                    int end = Math.min(start + chunkSize, bytes.length);
+                    byte[] chunk = new byte[end - start];
+                    System.arraycopy(bytes, start, chunk, 0, end - start);
+                    checkPropertySize(chunk.length, P.chunkKey(i));
+                    list.add(P.chunkKey(i));
+                    list.add(chunk);
+                }
+                // Write chunk count
+                list.add(P.RESULT_CHUNK_COUNT);
+                list.add(String.valueOf(numChunks));
+            } else {
+                // Single property (original behavior)
+                checkPropertySize(bytes.length, P.RESULT);
+                list.add(P.RESULT);
+                list.add(bytes);
+            }
         }
 
         if (this.server != null) {
@@ -859,8 +879,31 @@ public class HugeTask<V> extends FutureTask<V> {
         public static final String RETRIES = "~task_retries";
         public static final String INPUT = "~task_input";
         public static final String RESULT = "~task_result";
+        public static final String RESULT_CHUNK_COUNT = "~task_result_chunk_count";
         public static final String DEPENDENCIES = "~task_dependencies";
         public static final String SERVER = "~task_server";
+
+        /**
+         * Get the chunk key for a given chunk index.
+         * @param index the chunk index, or -1 for the non-chunked result key
+         * @return the property key for the chunk
+         */
+        public static String chunkKey(int index) {
+            if (index < 0) {
+                return RESULT;
+            }
+            return RESULT + "_" + index;
+        }
+
+        /**
+         * Check if a property key is a chunked result property.
+         * @param key the property key to check
+         * @return true if the key matches the chunk pattern
+         */
+        public static boolean isChunkedProperty(String key) {
+            return key.startsWith(RESULT + "_") && key.length() > RESULT.length() + 1 &&
+                   key.substring(RESULT.length() + 1).matches("\\d+");
+        }
 
         private static final String[] METADATA_PROPERTIES = new String[]{
                 TYPE, NAME, CALLABLE, DESCRIPTION, CONTEXT, STATUS, PROGRESS,


### PR DESCRIPTION
## Summary

This PR adds support for chunking large task results to avoid memory overflow.

## Changes

- Added `TASK_RESULT_CHUNK_SIZE` config option to `CoreOptions.java` (default 1MB)
- Added `chunkKey()` and `isChunkedProperty()` helper methods to `P` class
- Implemented chunked write in `asArray()` method
- Added `RESULT_CHUNK_COUNT` constant

## Usage

When the compressed result exceeds `task.result_chunk_size`, it will be split into
multiple properties (`~task_result_0`, `~task_result_1`, ...).

Set `task.result_chunk_size=0` to disable chunking (preserves original behavior).

## Related

Part of issue #3071 (Chunk 1-4)

🤖 Generated with [Claude Code](https://claude.com/claude-code)