### PR TITLE
fix(server): wait for GRAPH_CREATE event when creating graph on PD path

### DIFF
--- a/hugegraph-commons/hugegraph-common/src/main/java/org/apache/hugegraph/event/EventHub.java
+++ b/hugegraph-commons/hugegraph-common/src/main/java/org/apache/hugegraph/event/EventHub.java
@@ -39,6 +39,29 @@ import com.google.common.collect.ImmutableList;
 
 public class EventHub {
 
+    public static final class NotifyResult {
+
+        private final int attempted;
+        private final int succeeded;
+
+        private NotifyResult(int attempted, int succeeded) {
+            this.attempted = attempted;
+            this.succeeded = succeeded;
+        }
+
+        public int attempted() {
+            return this.attempted;
+        }
+
+        public int succeeded() {
+            return this.succeeded;
+        }
+
+        public boolean success() {
+            return this.attempted == this.succeeded;
+        }
+    }
+
     private static final Logger LOG = Log.logger(EventHub.class);
 
     public static final String EVENT_WORKER = "event-worker-%d";
@@ -170,7 +193,7 @@ public class EventHub {
     /**
      * Notify all registered listeners in the current thread.
      */
-    public int notifySync(String event, @Nullable Object... args) {
+    public NotifyResult notifySync(String event, @Nullable Object... args) {
         ExtendableIterator<EventListener> all = this.eventListeners(event);
         return this.notifyListeners(all, null, new Event(this, event, args));
     }
@@ -184,7 +207,7 @@ public class EventHub {
         }
         Event ev = new Event(this, event, args);
         return executor().submit(() -> {
-            return this.notifyListeners(all, ignoredListener, ev);
+            return this.notifyListeners(all, ignoredListener, ev).succeeded();
         });
     }
 
@@ -203,27 +226,30 @@ public class EventHub {
         return all;
     }
 
-    private int notifyListeners(ExtendableIterator<EventListener> all,
-                                EventListener ignoredListener, Event event) {
+    private NotifyResult notifyListeners(ExtendableIterator<EventListener> all,
+                                         EventListener ignoredListener,
+                                         Event event) {
         if (!all.hasNext()) {
-            return 0;
+            return new NotifyResult(0, 0);
         }
 
-        int count = 0;
+        int attempted = 0;
+        int succeeded = 0;
         // Notify all listeners, and ignore the results
         while (all.hasNext()) {
             EventListener listener = all.next();
             if (listener == ignoredListener) {
                 continue;
             }
+            attempted++;
             try {
                 listener.event(event);
-                count++;
+                succeeded++;
             } catch (Throwable e) {
                 LOG.warn("Failed to handle event: {}", event, e);
             }
         }
-        return count;
+        return new NotifyResult(attempted, succeeded);
     }
 
     public Object call(String event, @Nullable Object... args) {

--- a/hugegraph-commons/hugegraph-common/src/main/java/org/apache/hugegraph/event/EventHub.java
+++ b/hugegraph-commons/hugegraph-common/src/main/java/org/apache/hugegraph/event/EventHub.java
@@ -167,10 +167,29 @@ public class EventHub {
         return this.notify(event, null, args);
     }
 
+    /**
+     * Notify all registered listeners in the current thread.
+     */
+    public int notifySync(String event, @Nullable Object... args) {
+        ExtendableIterator<EventListener> all = this.eventListeners(event);
+        return this.notifyListeners(all, null, new Event(this, event, args));
+    }
+
     private Future<Integer> notify(String event,
                                    EventListener ignoredListener,
                                    @Nullable Object... args) {
-        @SuppressWarnings("resource")
+        ExtendableIterator<EventListener> all = this.eventListeners(event);
+        if (!all.hasNext()) {
+            return CompletableFuture.completedFuture(0);
+        }
+        Event ev = new Event(this, event, args);
+        return executor().submit(() -> {
+            return this.notifyListeners(all, ignoredListener, ev);
+        });
+    }
+
+    @SuppressWarnings("resource")
+    private ExtendableIterator<EventListener> eventListeners(String event) {
         ExtendableIterator<EventListener> all = new ExtendableIterator<>();
 
         List<EventListener> ls = this.listeners.get(event);
@@ -181,31 +200,30 @@ public class EventHub {
         if (lsAny != null && !lsAny.isEmpty()) {
             all.extend(lsAny.iterator());
         }
+        return all;
+    }
 
+    private int notifyListeners(ExtendableIterator<EventListener> all,
+                                EventListener ignoredListener, Event event) {
         if (!all.hasNext()) {
-            return CompletableFuture.completedFuture(0);
+            return 0;
         }
 
-        Event ev = new Event(this, event, args);
-
-        // The submit will catch params: `all`(Listeners) and `ev`(Event)
-        return executor().submit(() -> {
-            int count = 0;
-            // Notify all listeners, and ignore the results
-            while (all.hasNext()) {
-                EventListener listener = all.next();
-                if (listener == ignoredListener) {
-                    continue;
-                }
-                try {
-                    listener.event(ev);
-                    count++;
-                } catch (Throwable e) {
-                    LOG.warn("Failed to handle event: {}", ev, e);
-                }
+        int count = 0;
+        // Notify all listeners, and ignore the results
+        while (all.hasNext()) {
+            EventListener listener = all.next();
+            if (listener == ignoredListener) {
+                continue;
             }
-            return count;
-        });
+            try {
+                listener.event(event);
+                count++;
+            } catch (Throwable e) {
+                LOG.warn("Failed to handle event: {}", event, e);
+            }
+        }
+        return count;
     }
 
     public Object call(String event, @Nullable Object... args) {

--- a/hugegraph-commons/hugegraph-common/src/test/java/org/apache/hugegraph/unit/event/EventHubTest.java
+++ b/hugegraph-commons/hugegraph-common/src/test/java/org/apache/hugegraph/unit/event/EventHubTest.java
@@ -389,6 +389,27 @@ public class EventHubTest extends BaseUnitTest {
     }
 
     @Test
+    public void testEventNotifySync() {
+        final String notify = "event-notify-sync";
+        AtomicInteger count = new AtomicInteger();
+
+        this.eventHub.listen(notify, event -> {
+            count.incrementAndGet();
+            return null;
+        });
+        this.eventHub.listen(notify, event -> {
+            throw new RuntimeException("fake exception");
+        });
+        this.eventHub.listen(EventHub.ANY_EVENT, event -> {
+            count.incrementAndGet();
+            return null;
+        });
+
+        Assert.assertEquals(2, this.eventHub.notifySync(notify));
+        Assert.assertEquals(2, count.get());
+    }
+
+    @Test
     public void testNotifyExcept() throws Exception {
         final String notify = "event-notify";
         AtomicInteger listenerACount = new AtomicInteger();

--- a/hugegraph-commons/hugegraph-common/src/test/java/org/apache/hugegraph/unit/event/EventHubTest.java
+++ b/hugegraph-commons/hugegraph-common/src/test/java/org/apache/hugegraph/unit/event/EventHubTest.java
@@ -31,6 +31,7 @@ import org.apache.hugegraph.testutil.Assert;
 import org.apache.hugegraph.unit.BaseUnitTest;
 import org.apache.hugegraph.event.Event;
 import org.apache.hugegraph.event.EventHub;
+import org.apache.hugegraph.event.EventHub.NotifyResult;
 import org.apache.hugegraph.event.EventListener;
 
 public class EventHubTest extends BaseUnitTest {
@@ -405,8 +406,26 @@ public class EventHubTest extends BaseUnitTest {
             return null;
         });
 
-        Assert.assertEquals(2, this.eventHub.notifySync(notify));
+        NotifyResult result = this.eventHub.notifySync(notify);
+        Assert.assertEquals(3, result.attempted());
+        Assert.assertEquals(2, result.succeeded());
+        Assert.assertFalse(result.success());
         Assert.assertEquals(2, count.get());
+    }
+
+    @Test
+    public void testEventNotifySyncUsesSingleListenerSnapshot() {
+        final String notify = "event-notify-sync-snapshot";
+        this.eventHub.listen(notify, event -> {
+            this.eventHub.listen(notify, ignored -> null);
+            return null;
+        });
+
+        NotifyResult result = this.eventHub.notifySync(notify);
+
+        Assert.assertEquals(1, result.attempted());
+        Assert.assertEquals(1, result.succeeded());
+        Assert.assertTrue(result.success());
     }
 
     @Test

--- a/hugegraph-server/hugegraph-api/src/main/java/org/apache/hugegraph/auth/ContextGremlinServer.java
+++ b/hugegraph-server/hugegraph-api/src/main/java/org/apache/hugegraph/auth/ContextGremlinServer.java
@@ -146,8 +146,12 @@ public class ContextGremlinServer extends GremlinServer {
         GremlinExecutor executor = this.getServerGremlinExecutor()
                                        .getGremlinExecutor();
         try {
-            manager.removeGraph(name);
-            manager.removeTraversalSource(G_PREFIX + name);
+            if (manager.getGraph(name) != null) {
+                manager.removeGraph(name);
+            }
+            if (manager.getTraversalSource(G_PREFIX + name) != null) {
+                manager.removeTraversalSource(G_PREFIX + name);
+            }
             Whitebox.invoke(executor, "globalBindings",
                             new Class<?>[]{Object.class},
                             "remove", name);

--- a/hugegraph-server/hugegraph-api/src/main/java/org/apache/hugegraph/auth/ContextGremlinServer.java
+++ b/hugegraph-server/hugegraph-api/src/main/java/org/apache/hugegraph/auth/ContextGremlinServer.java
@@ -75,7 +75,7 @@ public class ContextGremlinServer extends GremlinServer {
             LOG.debug("GremlinServer accepts event '{}'", event.name());
             event.checkArgs(HugeGraph.class);
             HugeGraph graph = (HugeGraph) event.args()[0];
-            this.removeGraph(graph.spaceGraphName());
+            this.removeGraph(graph);
             return null;
         });
     }
@@ -123,7 +123,7 @@ public class ContextGremlinServer extends GremlinServer {
         }
     }
 
-    private void injectGraph(HugeGraph graph) {
+    private synchronized void injectGraph(HugeGraph graph) {
         String name = graph.spaceGraphName();
         GraphManager manager = this.getServerGremlinExecutor()
                                    .getGraphManager();
@@ -140,14 +140,15 @@ public class ContextGremlinServer extends GremlinServer {
                         "put", name, graph);
     }
 
-    private void removeGraph(String name) {
+    private synchronized void removeGraph(HugeGraph graph) {
+        String name = graph.spaceGraphName();
         GraphManager manager = this.getServerGremlinExecutor()
                                    .getGraphManager();
         GremlinExecutor executor = this.getServerGremlinExecutor()
                                        .getGremlinExecutor();
         try {
-            if (manager.getGraph(name) != null) {
-                manager.removeGraph(name);
+            if (manager.getGraph(name) != graph) {
+                return;
             }
             if (manager.getTraversalSource(G_PREFIX + name) != null) {
                 manager.removeTraversalSource(G_PREFIX + name);
@@ -155,6 +156,9 @@ public class ContextGremlinServer extends GremlinServer {
             Whitebox.invoke(executor, "globalBindings",
                             new Class<?>[]{Object.class},
                             "remove", name);
+            if (manager.getGraph(name) != null) {
+                manager.removeGraph(name);
+            }
         } catch (Exception e) {
             throw new HugeException("Failed to remove graph '%s' from " +
                                     "gremlin server context", e, name);

--- a/hugegraph-server/hugegraph-api/src/main/java/org/apache/hugegraph/core/GraphManager.java
+++ b/hugegraph-server/hugegraph-api/src/main/java/org/apache/hugegraph/core/GraphManager.java
@@ -1353,7 +1353,7 @@ public final class GraphManager {
         }
 
         // Let gremlin server and rest server context add graph
-        this.eventHub.notify(Events.GRAPH_CREATE, graph);
+        this.notifyAndWaitEvent(Events.GRAPH_CREATE, graph);
 
         if (init) {
             String schema = propConfig.getString(

--- a/hugegraph-server/hugegraph-api/src/main/java/org/apache/hugegraph/core/GraphManager.java
+++ b/hugegraph-server/hugegraph-api/src/main/java/org/apache/hugegraph/core/GraphManager.java
@@ -34,8 +34,10 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
@@ -151,6 +153,13 @@ public final class GraphManager {
     public static final String DELIMITER = "-";
     public static final String NAMESPACE_CREATE = "namespace_create";
     private static final Logger LOG = Log.logger(GraphManager.class);
+    /*
+     * The graph create/drop listeners only do in-memory registrations (put the
+     * graph into the rest server context and into the gremlin server bindings),
+     * so they finish in microseconds on a healthy server. The bound is only a
+     * guard against a stuck or starved event worker.
+     */
+    private static final long EVENT_WAIT_TIMEOUT = 30L;
     private KvStore kvStore;
 
     private final String cluster;
@@ -1193,17 +1202,19 @@ public final class GraphManager {
 
             // Init graph and start it
             graph.create(this.graphsDir, this.globalNodeRoleInfo);
+
+            // Let gremlin server and rest server add graph to context
+            this.notifyAndWaitEvent(Events.GRAPH_CREATE, graph);
         } catch (Throwable e) {
             LOG.error("Failed to create graph '{}' due to: {}",
                       name, e.getMessage(), e);
             if (graph != null) {
+                // The create event may have added the graph to the context
+                this.graphs.remove(graph.spaceGraphName());
                 this.dropGraphLocal(graph);
             }
             throw e;
         }
-
-        // Let gremlin server and rest server add graph to context
-        this.notifyAndWaitEvent(Events.GRAPH_CREATE, graph);
 
         return graph;
     }
@@ -1342,18 +1353,36 @@ public final class GraphManager {
         graph.updateTime(timeStamp);
 
         String graphName = spaceGraphName(graphSpace, name);
+        this.graphs.put(graphName, graph);
+
+        /*
+         * Let gremlin server and rest server context add graph before the
+         * graph is published, so that a failed local binding can't leave the
+         * graph behind in meta for the other servers to converge on
+         */
+        try {
+            this.notifyAndWaitEvent(Events.GRAPH_CREATE, graph);
+        } catch (Throwable e) {
+            this.graphs.remove(graphName);
+            try {
+                graph.close();
+            } catch (Exception e1) {
+                if (graph instanceof StandardHugeGraph) {
+                    ((StandardHugeGraph) graph).clearSchedulerAndLock();
+                }
+            }
+            HugeFactory.remove(graph);
+            throw e;
+        }
+
         if (init) {
             this.creatingGraphs.add(graphName);
             this.metaManager.addGraphConfig(graphSpace, name, configs);
             this.metaManager.notifyGraphAdd(graphSpace, name);
         }
-        this.graphs.put(graphName, graph);
         if (!grpcThread) {
             this.metaManager.updateGraphSpaceConfig(graphSpace, gs);
         }
-
-        // Let gremlin server and rest server context add graph
-        this.notifyAndWaitEvent(Events.GRAPH_CREATE, graph);
 
         if (init) {
             String schema = propConfig.getString(
@@ -1771,10 +1800,60 @@ public final class GraphManager {
         this.metaManager.listenGraphClear(ConsumerWrapper.wrap(this::graphClearHandler));
     }
 
+    /**
+     * Notify the listeners of `event` and wait for them to finish, failing if
+     * any listener did not complete successfully.
+     * <p>
+     * EventHub swallows every throwable raised by a listener and resolves the
+     * future with the number of listeners that returned normally, so waiting
+     * alone doesn't prove that the graph was registered. Comparing the
+     * notified count with the registered listener count detects the swallowed
+     * failure and lets the caller fail instead of returning a graph that is
+     * missing from the rest/gremlin server context.
+     */
     private void notifyAndWaitEvent(String event, HugeGraph graph) {
-        Future<?> future = this.eventHub.notify(event, graph);
+        String graphName = graph.spaceGraphName();
+        // Listeners of ANY_EVENT are notified too, so they count as expected
+        int expected = this.eventHub.listeners(event).size() +
+                       this.eventHub.listeners(EventHub.ANY_EVENT).size();
+        int notified;
         try {
-            future.get();
+            Future<Integer> future = this.eventHub.notify(event, graph);
+            notified = future.get(EVENT_WAIT_TIMEOUT, TimeUnit.SECONDS);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new HugeException("Interrupted while waiting for event " +
+                                    "'%s' of graph '%s'", e, event, graphName);
+        } catch (TimeoutException e) {
+            throw new HugeException("Timeout(%ss) while waiting for event " +
+                                    "'%s' of graph '%s'", e,
+                                    EVENT_WAIT_TIMEOUT, event, graphName);
+        } catch (ExecutionException e) {
+            throw new HugeException("Failed to wait for event '%s' of " +
+                                    "graph '%s'", e, event, graphName);
+        }
+
+        if (notified < expected) {
+            throw new HugeException("Only %s of %s listeners handled event " +
+                                    "'%s' of graph '%s' successfully",
+                                    notified, expected, event, graphName);
+        }
+    }
+
+    /**
+     * Same bounded wait as notifyAndWaitEvent(), but a failed listener is only
+     * logged. Used by the drop path: the graph data is already deleted when
+     * the event is sent, so failing the request can't undo anything, and the
+     * listener state may legitimately be absent already.
+     */
+    private void notifyAndWaitEventLenient(String event, HugeGraph graph) {
+        try {
+            Future<Integer> future = this.eventHub.notify(event, graph);
+            future.get(EVENT_WAIT_TIMEOUT, TimeUnit.SECONDS);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            LOG.warn("Interrupted when waiting for event execution: {}",
+                     event, e);
         } catch (Throwable e) {
             LOG.warn("Error when waiting for event execution: {}", event, e);
         }
@@ -1999,7 +2078,7 @@ public final class GraphManager {
         this.dropGraphLocal(graph);
 
         // Let gremlin server and rest server context remove graph
-        this.notifyAndWaitEvent(Events.GRAPH_DROP, graph);
+        this.notifyAndWaitEventLenient(Events.GRAPH_DROP, graph);
     }
 
     public void dropGraph(String graphSpace, String name, boolean clear) {

--- a/hugegraph-server/hugegraph-api/src/main/java/org/apache/hugegraph/core/GraphManager.java
+++ b/hugegraph-server/hugegraph-api/src/main/java/org/apache/hugegraph/core/GraphManager.java
@@ -34,10 +34,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
@@ -153,13 +150,6 @@ public final class GraphManager {
     public static final String DELIMITER = "-";
     public static final String NAMESPACE_CREATE = "namespace_create";
     private static final Logger LOG = Log.logger(GraphManager.class);
-    /*
-     * The graph create/drop listeners only do in-memory registrations (put the
-     * graph into the rest server context and into the gremlin server bindings),
-     * so they finish in microseconds on a healthy server. The bound is only a
-     * guard against a stuck or starved event worker.
-     */
-    private static final long EVENT_WAIT_TIMEOUT = 30L;
     private KvStore kvStore;
 
     private final String cluster;
@@ -1204,13 +1194,13 @@ public final class GraphManager {
             graph.create(this.graphsDir, this.globalNodeRoleInfo);
 
             // Let gremlin server and rest server add graph to context
-            this.notifyAndWaitEvent(Events.GRAPH_CREATE, graph);
+            this.notifyEvent(Events.GRAPH_CREATE, graph);
         } catch (Throwable e) {
             LOG.error("Failed to create graph '{}' due to: {}",
                       name, e.getMessage(), e);
             if (graph != null) {
                 // The create event may have added the graph to the context
-                this.graphs.remove(graph.spaceGraphName());
+                this.graphs.remove(graph.spaceGraphName(), graph);
                 this.dropGraphLocal(graph);
             }
             throw e;
@@ -1361,9 +1351,10 @@ public final class GraphManager {
          * graph behind in meta for the other servers to converge on
          */
         try {
-            this.notifyAndWaitEvent(Events.GRAPH_CREATE, graph);
+            this.notifyEvent(Events.GRAPH_CREATE, graph);
         } catch (Throwable e) {
-            this.graphs.remove(graphName);
+            this.notifyEventLenient(Events.GRAPH_DROP, graph);
+            this.graphs.remove(graphName, graph);
             try {
                 graph.close();
             } catch (Exception e1) {
@@ -1783,7 +1774,7 @@ public final class GraphManager {
             LOG.debug("RestServer accepts event '{}'", event.name());
             event.checkArgs(HugeGraph.class);
             HugeGraph graph = (HugeGraph) event.args()[0];
-            this.graphs.remove(graph.spaceGraphName());
+            this.graphs.remove(graph.spaceGraphName(), graph);
             return null;
         });
     }
@@ -1801,37 +1792,19 @@ public final class GraphManager {
     }
 
     /**
-     * Notify the listeners of `event` and wait for them to finish, failing if
-     * any listener did not complete successfully.
+     * Notify the listeners of `event` synchronously, failing if any listener
+     * did not complete successfully.
      * <p>
-     * EventHub swallows every throwable raised by a listener and resolves the
-     * future with the number of listeners that returned normally, so waiting
-     * alone doesn't prove that the graph was registered. Comparing the
-     * notified count with the registered listener count detects the swallowed
-     * failure and lets the caller fail instead of returning a graph that is
-     * missing from the rest/gremlin server context.
+     * EventHub swallows every throwable raised by a listener and returns the
+     * number of listeners that completed normally. Comparing it with the
+     * registered listener count detects the swallowed failure.
      */
-    private void notifyAndWaitEvent(String event, HugeGraph graph) {
+    private void notifyEvent(String event, HugeGraph graph) {
         String graphName = graph.spaceGraphName();
         // Listeners of ANY_EVENT are notified too, so they count as expected
         int expected = this.eventHub.listeners(event).size() +
                        this.eventHub.listeners(EventHub.ANY_EVENT).size();
-        int notified;
-        try {
-            Future<Integer> future = this.eventHub.notify(event, graph);
-            notified = future.get(EVENT_WAIT_TIMEOUT, TimeUnit.SECONDS);
-        } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
-            throw new HugeException("Interrupted while waiting for event " +
-                                    "'%s' of graph '%s'", e, event, graphName);
-        } catch (TimeoutException e) {
-            throw new HugeException("Timeout(%ss) while waiting for event " +
-                                    "'%s' of graph '%s'", e,
-                                    EVENT_WAIT_TIMEOUT, event, graphName);
-        } catch (ExecutionException e) {
-            throw new HugeException("Failed to wait for event '%s' of " +
-                                    "graph '%s'", e, event, graphName);
-        }
+        int notified = this.eventHub.notifySync(event, graph);
 
         if (notified < expected) {
             throw new HugeException("Only %s of %s listeners handled event " +
@@ -1841,21 +1814,14 @@ public final class GraphManager {
     }
 
     /**
-     * Same bounded wait as notifyAndWaitEvent(), but a failed listener is only
-     * logged. Used by the drop path: the graph data is already deleted when
-     * the event is sent, so failing the request can't undo anything, and the
-     * listener state may legitimately be absent already.
+     * Notify listeners synchronously, but keep listener failures non-fatal.
+     * Used by the drop and rollback paths, where cleanup must be best-effort.
      */
-    private void notifyAndWaitEventLenient(String event, HugeGraph graph) {
+    private void notifyEventLenient(String event, HugeGraph graph) {
         try {
-            Future<Integer> future = this.eventHub.notify(event, graph);
-            future.get(EVENT_WAIT_TIMEOUT, TimeUnit.SECONDS);
-        } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
-            LOG.warn("Interrupted when waiting for event execution: {}",
-                     event, e);
+            this.eventHub.notifySync(event, graph);
         } catch (Throwable e) {
-            LOG.warn("Error when waiting for event execution: {}", event, e);
+            LOG.warn("Error when notifying event: {}", event, e);
         }
     }
 
@@ -2078,7 +2044,7 @@ public final class GraphManager {
         this.dropGraphLocal(graph);
 
         // Let gremlin server and rest server context remove graph
-        this.notifyAndWaitEventLenient(Events.GRAPH_DROP, graph);
+        this.notifyEventLenient(Events.GRAPH_DROP, graph);
     }
 
     public void dropGraph(String graphSpace, String name, boolean clear) {

--- a/hugegraph-server/hugegraph-api/src/main/java/org/apache/hugegraph/core/GraphManager.java
+++ b/hugegraph-server/hugegraph-api/src/main/java/org/apache/hugegraph/core/GraphManager.java
@@ -65,6 +65,7 @@ import org.apache.hugegraph.config.HugeConfig;
 import org.apache.hugegraph.config.ServerOptions;
 import org.apache.hugegraph.config.TypedOption;
 import org.apache.hugegraph.event.EventHub;
+import org.apache.hugegraph.event.EventHub.NotifyResult;
 import org.apache.hugegraph.exception.ExistedException;
 import org.apache.hugegraph.exception.NotFoundException;
 import org.apache.hugegraph.exception.NotSupportException;
@@ -1801,21 +1802,18 @@ public final class GraphManager {
      * Notify the listeners of `event` synchronously, failing if any listener
      * did not complete successfully.
      * <p>
-     * EventHub swallows every throwable raised by a listener and returns the
-     * number of listeners that completed normally. Comparing it with the
-     * registered listener count detects the swallowed failure.
+     * EventHub swallows every throwable raised by a listener and reports the
+     * attempted and successful listeners from the same snapshot.
      */
     private void notifyEvent(String event, HugeGraph graph) {
         String graphName = graph.spaceGraphName();
-        // Listeners of ANY_EVENT are notified too, so they count as expected
-        int expected = this.eventHub.listeners(event).size() +
-                       this.eventHub.listeners(EventHub.ANY_EVENT).size();
-        int notified = this.eventHub.notifySync(event, graph);
+        NotifyResult result = this.eventHub.notifySync(event, graph);
 
-        if (notified < expected) {
+        if (!result.success()) {
             throw new HugeException("Only %s of %s listeners handled event " +
                                     "'%s' of graph '%s' successfully",
-                                    notified, expected, event, graphName);
+                                    result.succeeded(), result.attempted(),
+                                    event, graphName);
         }
     }
 

--- a/hugegraph-server/hugegraph-api/src/main/java/org/apache/hugegraph/core/GraphManager.java
+++ b/hugegraph-server/hugegraph-api/src/main/java/org/apache/hugegraph/core/GraphManager.java
@@ -1199,9 +1199,13 @@ public final class GraphManager {
             LOG.error("Failed to create graph '{}' due to: {}",
                       name, e.getMessage(), e);
             if (graph != null) {
-                // The create event may have added the graph to the context
                 this.graphs.remove(graph.spaceGraphName(), graph);
-                this.dropGraphLocal(graph);
+                try {
+                    this.dropGraphLocal(graph);
+                } finally {
+                    // The create event may have partially registered the graph
+                    this.notifyEventLenient(Events.GRAPH_DROP, graph);
+                }
             }
             throw e;
         }
@@ -1210,14 +1214,16 @@ public final class GraphManager {
     }
 
     private void dropGraphLocal(HugeGraph graph) {
-        // Clear data and config files
-        graph.drop();
-
-        /*
-         * Will fill graph instance into HugeFactory.graphs after
-         * GraphFactory.open() succeed, remove it when the graph drops
-         */
-        HugeFactory.remove(graph);
+        try {
+            // Clear data and config files
+            graph.drop();
+        } finally {
+            /*
+             * Will fill graph instance into HugeFactory.graphs after
+             * GraphFactory.open() succeed, remove it when the graph drops
+             */
+            HugeFactory.remove(graph);
+        }
     }
 
     public HugeGraph createGraph(String graphSpace, String name, String creator,


### PR DESCRIPTION
## Purpose

This is Phase 1 of #3137. It closes the local race on the Server that handles graph creation; cluster-wide readiness remains a follow-up.

In distributed mode (PD + HStore), graph creation previously returned HTTP 200 after scheduling `GRAPH_CREATE`, but before the embedded Gremlin Server had necessarily registered the graph and its `TraversalSource`. An immediate Gremlin or Cypher request to the same Server could therefore fail with:

```text
Could not rebind [g] to [__g_<name>]
```

## Before and after

```text
Before: create graph -> schedule GRAPH_CREATE -> publish/return 200 -> bind later
After:  create graph -> bind locally and verify listeners -> publish -> return 200
```

After this PR, HTTP 200 guarantees that the **creating Server** has completed its local REST and Gremlin registrations, including the `__g_<space>-<graph>` traversal binding.

## Changes

- Add synchronous `EventHub.notifySync()` dispatch while preserving the existing asynchronous `notify()` behavior for other callers.
- Report attempted and successful listeners from the same notification snapshot, avoiding false create results if listeners change concurrently.
- Run graph-create listeners and the standalone local drop listener synchronously because they define the request's local success boundary.
- Fail graph creation when any registered `GRAPH_CREATE` listener fails.
- On local binding failure, clear the local graph and remove partial REST/Gremlin registrations; make Gremlin removal safe when only part of the binding was installed.
- Publish the graph to PD metadata only after local binding succeeds.
- Carry graph identity through REST and Gremlin cleanup, and serialize local Gremlin registration/removal so a stale rollback cannot remove a replacement binding.

## Scope: intentionally not handled here

- **Other Server replicas may still be loading the graph after 200.** Requests routed to another replica can still need retry or sticky routing. Cluster-wide `LOADING / READY / FAILED` reporting is Phase 2 of #3137.
- Graph creation ownership is not moved into PD; that architectural change remains Phase 3 of #3137.
- Failures after local binding during PD metadata publication or `prepareSchema` are not made transactional here; they belong to the Phase 3 PD creation state machine.
- The distributed graph-drop path is unchanged.
- Full serialization of concurrent create/drop operations for the same graph name is not introduced; that belongs to the broader graph lifecycle state-machine work.
- Requests racing with Server shutdown are outside this local create-readiness guarantee.
- Listener deadlines and cancellation are unchanged; lifecycle listeners are expected to remain local and non-blocking.

## Verification

- `EventHubTest`: 21 tests passed on JDK 11, including synchronous dispatch, listener-failure counting, and snapshot mutation.
- `hugegraph-api` and all required reactor modules compiled successfully on JDK 11.
- The original distributed reproduction remains: create a graph and immediately query it on the creating Server. That Server must no longer return 200 before its Gremlin binding exists.

## Does this PR potentially affect the following parts?

- [ ] Dependencies
- [ ] Modify configurations
- [ ] Public API contract
- [x] Internal graph lifecycle handling

## Documentation Status

- [x] Doc - No Need
